### PR TITLE
`logback-access.xml` can be served from outside of jar.

### DIFF
--- a/conf/livy-defaults.conf.template
+++ b/conf/livy-defaults.conf.template
@@ -9,6 +9,9 @@
 # Specify the keystore password.
 ## livy.keystore.password =
 
+# Specify the access log configuration file.
+## livy.server.logback-access.conf =
+
 # What host address to start the server on. Defaults to 0.0.0.0. If using the
 # `yarn` factory mode, this address must be accessible from the YARN nodes.
 ## livy.server.host = 0.0.0.0

--- a/conf/logback-access.xml
+++ b/conf/logback-access.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- always a good activate OnConsoleStatusListener -->
+    <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener" />
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%h %l %u %user %date "%r" %s %b</pattern>
+        </encoder>
+    </appender>
+
+    <appender-ref ref="STDOUT" />
+</configuration>

--- a/livy-core/src/main/scala/com/cloudera/hue/livy/WebServer.scala
+++ b/livy-core/src/main/scala/com/cloudera/hue/livy/WebServer.scala
@@ -33,6 +33,7 @@ import scala.concurrent.ExecutionContext
 object WebServer {
   val KeystoreKey = "livy.keystore"
   val KeystorePasswordKey = "livy.keystore.password"
+  val LivyLogbackAccessConfFile = "livy.server.logback-access.conf"
 }
 
 class WebServer(livyConf: LivyConf, var host: String, var port: Int) extends Logging {
@@ -76,7 +77,11 @@ class WebServer(livyConf: LivyConf, var host: String, var port: Int) extends Log
   // configure the access log
   val requestLogHandler = new RequestLogHandler
   val requestLog = new RequestLogImpl
-  requestLog.setResource("/logback-access.xml")
+  if (livyConf.contains(WebServer.LivyLogbackAccessConfFile)) {
+    requestLog.setFileName(livyConf.get(WebServer.LivyLogbackAccessConfFile))
+  } else {
+    requestLog.setResource("/logback-access.xml")
+  }
   requestLogHandler.setRequestLog(requestLog)
   handlers.addHandler(requestLogHandler)
 


### PR DESCRIPTION
Current state, `logback-access.xml` is contained inside of livy-assembly JAR. This commit introduces `livy.server.logback-access.conf` key for specifying `logback-access.xml` from any other locations. 