### PR TITLE
CDH-35359, CDH-35360. Fix RSC pom, skip tests that require a Spark installation.

### DIFF
--- a/livy-core/pom.xml
+++ b/livy-core/pom.xml
@@ -22,7 +22,7 @@
 
     <dependency>
       <groupId>com.cloudera.hue.livy.client</groupId>
-      <artifactId>livy-remote-spark-client</artifactId>
+      <artifactId>livy-remote-spark-client_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/livy-core/src/test/scala/com/cloudera/hue/livy/sessions/BaseInteractiveSessionSpec.scala
+++ b/livy-core/src/test/scala/com/cloudera/hue/livy/sessions/BaseInteractiveSessionSpec.scala
@@ -23,12 +23,12 @@ import java.util.concurrent.TimeUnit
 import com.cloudera.hue.livy.ExecuteRequest
 import com.cloudera.hue.livy.sessions.interactive.InteractiveSession
 import org.json4s.{DefaultFormats, Extraction}
-import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-abstract class BaseInteractiveSessionSpec extends FunSpec with Matchers with BeforeAndAfter {
+abstract class BaseInteractiveSessionSpec extends FunSpec with Matchers with BeforeAndAfterAll {
 
   implicit val formats = DefaultFormats
 
@@ -36,11 +36,12 @@ abstract class BaseInteractiveSessionSpec extends FunSpec with Matchers with Bef
 
   def createSession(): InteractiveSession
 
-  after {
+  override def afterAll(): Unit = {
     if (session != null) {
       session.stop()
       session = null
     }
+    super.afterAll()
   }
 
   describe("A spark session") {
@@ -79,7 +80,7 @@ abstract class BaseInteractiveSessionSpec extends FunSpec with Matchers with Bef
       val result = Await.result(stmt.output(), Duration.Inf)
       val expectedResult = Extraction.decompose(Map(
         "status" -> "error",
-        "execution_count" -> 0,
+        "execution_count" -> 1,
         "ename" -> "NameError",
         "evalue" -> "name 'x' is not defined",
         "traceback" -> List(

--- a/livy-remote-spark-client/pom.xml
+++ b/livy-remote-spark-client/pom.xml
@@ -25,24 +25,9 @@
   </parent>
 
   <groupId>com.cloudera.hue.livy.client</groupId>
-  <artifactId>livy-remote-spark-client</artifactId>
-  <version>${parent.version}</version>
+  <artifactId>livy-remote-spark-client_2.10</artifactId>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
-  <name>Spark Remote Client</name>
-
-  <properties>
-    <guava.version>14.0.1</guava.version>
-    <hive.path.to.root>..</hive.path.to.root>
-    <junit.version>4.11</junit.version>
-    <kryo.version>2.22</kryo.version>
-    <mockito-all.version>1.9.5</mockito-all.version>
-    <netty.version>4.0.23.Final</netty.version>
-    <scala.binary.version>2.10</scala.binary.version>
-    <spark.version>1.4.0</spark.version>
-    <test.redirectToFile>true</test.redirectToFile>
-    <maven.surefire.plugin.version>2.16</maven.surefire.plugin.version>
-    <hive-common.version>2.0.0-SNAPSHOT</hive-common.version>
-  </properties>
 
   <dependencies>
     <dependency>
@@ -52,122 +37,54 @@
     <dependency>
       <groupId>com.esotericsoftware.kryo</groupId>
       <artifactId>kryo</artifactId>
-      <version>${kryo.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
-      <version>${netty.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_2.10</artifactId>
-      <version>${spark.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-hive_2.10</artifactId>
-      <version>${spark.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
-      <version>${spark.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_2.10</artifactId>
-      <version>${spark.version}</version>
+      <artifactId>spark-hive_${scala.binary.version}</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_${scala.binary.version}</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>${mockito-all.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <!--
-              Spark depends on Guava 14, while Hive depends on Guava 11. The APIs used by
-              spark-client do not depend on Guava 14, but when running unit tests that
-              trigger Spark jobs, that will trigger the dependency. So, when running tests,
-              make sure Guava 14, and not Guava 11, is on the classpath.
-            -->
-            <id>copy-guava-14</id>
-            <phase>test-compile</phase>
-            <goals>
-              <goal>copy</goal>
-            </goals>
-            <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.google.guava</groupId>
-                  <artifactId>guava</artifactId>
-                  <version>14.0.1</version>
-                </artifactItem>
-              </artifactItems>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>${maven.surefire.plugin.version}</version>
-        <configuration>
-          <additionalClasspathElements>
-            <!-- Note: wildcards don't work. Thankfully there's just one jar we care about. -->
-            <additionalClasspathElement>${project.build.directory}/dependency/guava-14.0.1.jar</additionalClasspathElement>
-          </additionalClasspathElements>
-          <classpathDependencyExcludes>
-            <classpathDependencyExclude>com.google.guava:guava</classpathDependencyExclude>
-          </classpathDependencyExcludes>
-          <systemPropertyVariables>
-            <java.awt.headless>true</java.awt.headless>
-            <spark.home>${spark.home}</spark.home>
-          </systemPropertyVariables>
-          <redirectTestOutputToFile>${test.redirectToFile}</redirectTestOutputToFile>
-          <useFile>${test.redirectToFile}</useFile>
-          <argLine>-Xmx4096m -XX:MaxPermSize=512m</argLine>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 
 </project>

--- a/livy-remote-spark-client/src/test/java/com/cloudera/hue/livy/client/TestSparkClient.java
+++ b/livy-remote-spark-client/src/test/java/com/cloudera/hue/livy/client/TestSparkClient.java
@@ -48,6 +48,7 @@ import org.apache.spark.sql.hive.HiveContext;
 import org.apache.spark.streaming.api.java.JavaStreamingContext;
 import org.junit.Test;
 import static org.junit.Assert.*;
+import static org.junit.Assume.*;
 import static org.mockito.Mockito.*;
 
 public class TestSparkClient {
@@ -151,6 +152,8 @@ public class TestSparkClient {
 
   @Test
   public void testRemoteClient() throws Exception {
+    assumeTrue("Test requires a Spark installation in SPARK_HOME.",
+      System.getenv("SPARK_HOME") != null);
     runTest(false, new TestFunction() {
       @Override
       public void call(SparkClient client) throws Exception {

--- a/livy-repl/src/test/resources/log4j.properties
+++ b/livy-repl/src/test/resources/log4j.properties
@@ -1,0 +1,37 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set everything to be logged to the file target/unit-tests.log
+test.appender=file
+log4j.rootCategory=INFO, ${test.appender}
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.append=true
+log4j.appender.file.file=target/unit-tests.log
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n
+
+# Tests that launch java subprocesses can set the "test.appender" system property to
+# "console" to avoid having the child process's logs overwrite the unit test's
+# log file.
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%t: %m%n
+
+# Ignore messages below warning level from Jetty, because it's a bit verbose
+log4j.logger.org.spark-project.jetty=WARN
+org.spark-project.jetty.LEVEL=WARN

--- a/livy-repl/src/test/scala/com/cloudera/hue/livy/repl/PythonInterpreterSpec.scala
+++ b/livy-repl/src/test/scala/com/cloudera/hue/livy/repl/PythonInterpreterSpec.scala
@@ -27,6 +27,11 @@ class PythonInterpreterSpec extends BaseInterpreterSpec {
 
   implicit val formats = DefaultFormats
 
+  override protected def withFixture(test: NoArgTest) = {
+    assume(sys.env.get("SPARK_HOME").isDefined,
+      "Test requires a Spark installation in SPARK_HOME.")
+    test()
+  }
   override def createInterpreter() = PythonInterpreter()
 
   it should "execute `1 + 2` == 3" in withInterpreter { interpreter =>

--- a/livy-repl/src/test/scala/com/cloudera/hue/livy/repl/PythonSessionSpec.scala
+++ b/livy-repl/src/test/scala/com/cloudera/hue/livy/repl/PythonSessionSpec.scala
@@ -27,6 +27,12 @@ import _root_.scala.concurrent.duration.Duration
 
 class PythonSessionSpec extends BaseSessionSpec {
 
+  override protected def withFixture(test: NoArgTest) = {
+    assume(sys.env.get("SPARK_HOME").isDefined,
+      "Test requires a Spark installation in SPARK_HOME.")
+    test()
+  }
+
   override def createInterpreter() = PythonInterpreter()
 
   it should "execute `1 + 2` == 3" in withSession { session =>

--- a/livy-repl/src/test/scala/com/cloudera/hue/livy/repl/ScalaInterpreterSpec.scala
+++ b/livy-repl/src/test/scala/com/cloudera/hue/livy/repl/ScalaInterpreterSpec.scala
@@ -107,14 +107,14 @@ class ScalaInterpreterSpec extends BaseInterpreterSpec {
   }
 
   it should "report an error if accessing an unknown variable" in withInterpreter { interpreter =>
-    val response = interpreter.execute("x")
-    response should equal(Interpreter.ExecuteError(
-      "Error",
-      """<console>:8: error: not found: value x
-        |              x
-        |              ^""".stripMargin,
-      List()
-    ))
+    interpreter.execute("x") match {
+      case Interpreter.ExecuteError(ename, evalue, _) =>
+        ename should equal ("Error")
+        evalue should include ("error: not found: value x")
+
+      case other =>
+        fail(s"Expected error, got $other.")
+    }
   }
 
   it should "execute spark commands" in withInterpreter { interpreter =>

--- a/livy-repl/src/test/scala/com/cloudera/hue/livy/repl/SparkSessionSpec.scala
+++ b/livy-repl/src/test/scala/com/cloudera/hue/livy/repl/SparkSessionSpec.scala
@@ -110,18 +110,13 @@ class SparkSessionSpec extends BaseSessionSpec {
     statement.id should equal (0)
 
     val result = Await.result(statement.result, Duration.Inf)
-    val expectedResult = Extraction.decompose(Map(
-      "status" -> "error",
-      "execution_count" -> 0,
-      "ename" -> "Error",
-      "evalue" ->
-        """<console>:8: error: not found: value x
-          |              x
-          |              ^""".stripMargin,
-      "traceback" -> List()
-    ))
 
-    result should equal (expectedResult)
+    def extract(key: String): String = (result \ key).extract[String]
+
+    extract("status") should equal ("error")
+    extract("execution_count") should equal ("0")
+    extract("ename") should equal ("Error")
+    extract("evalue") should include ("error: not found: value x")
   }
 
   it should "report an error if exception is thrown" in withSession { session =>

--- a/livy-server/src/test/scala/com/cloudera/hue/livy/server/batch/BatchServletSpec.scala
+++ b/livy-server/src/test/scala/com/cloudera/hue/livy/server/batch/BatchServletSpec.scala
@@ -38,6 +38,11 @@ class BatchServletSpec extends ScalatraSuite with FunSpecLike with BeforeAndAfte
 
   protected implicit def jsonFormats: Formats = DefaultFormats
 
+  override protected def withFixture(test: NoArgTest) = {
+    assume(sys.env.get("SPARK_HOME").isDefined, "SPARK_HOME is not set.")
+    test()
+  }
+
   val script: Path = {
     val script = Files.createTempFile("livy-test", ".py")
     script.toFile.deleteOnExit()

--- a/livy-server/src/test/scala/com/cloudera/hue/livy/server/interactive/InteractiveSessionServletSpec.scala
+++ b/livy-server/src/test/scala/com/cloudera/hue/livy/server/interactive/InteractiveSessionServletSpec.scala
@@ -39,6 +39,11 @@ class InteractiveSessionServletSpec extends ScalatraSuite with FunSpecLike {
 
   protected implicit def jsonFormats: Formats = DefaultFormats ++ Serializers.SessionFormats
 
+  override protected def withFixture(test: NoArgTest) = {
+    assume(sys.env.get("SPARK_HOME").isDefined, "SPARK_HOME is not set.")
+    test()
+  }
+
   class MockInteractiveSession(val id: Int) extends InteractiveSession {
     var _state: SessionState = SessionState.Idle()
 

--- a/livy-spark/src/test/scala/com/cloudera/hue/livy/spark/batch/BatchProcessSpec.scala
+++ b/livy-spark/src/test/scala/com/cloudera/hue/livy/spark/batch/BatchProcessSpec.scala
@@ -34,6 +34,11 @@ class BatchProcessSpec
   with BeforeAndAfterAll
   with ShouldMatchers {
 
+  override protected def withFixture(test: NoArgTest) = {
+    assume(sys.env.get("SPARK_HOME").isDefined, "SPARK_HOME is not set.")
+    test()
+  }
+
   val script: Path = {
     val script = Files.createTempFile("livy-test", ".py")
     script.toFile.deleteOnExit()

--- a/livy-spark/src/test/scala/com/cloudera/hue/livy/spark/interactive/InteractiveSessionProcessSpec.scala
+++ b/livy-spark/src/test/scala/com/cloudera/hue/livy/spark/interactive/InteractiveSessionProcessSpec.scala
@@ -33,6 +33,7 @@ class InteractiveSessionProcessSpec
   livyConf.set("livy.repl.driverClassPath", sys.props("java.class.path"))
 
   def createSession() = {
+    assume(sys.env.get("SPARK_HOME").isDefined, "SPARK_HOME is not set.")
     val processFactory = new SparkProcessBuilderFactory(livyConf)
     val interactiveFactory = new InteractiveSessionProcessFactory(processFactory)
     interactiveFactory.create(0, CreateInteractiveRequest(kind = PySpark()))

--- a/pom.xml
+++ b/pom.xml
@@ -42,18 +42,22 @@
   </organization>
 
   <properties>
-    <hadoop.version>2.6.0-cdh5.4.8</hadoop.version>
-    <spark.version>1.5.1</spark.version>
+    <hadoop.version>2.6.0-cdh5.5.0</hadoop.version>
+    <spark.version>1.5.0-cdh5.5.0</spark.version>
     <commons-codec.version>1.9</commons-codec.version>
     <dispatch.version>0.11.2</dispatch.version>
+    <guava.version>14.0.1</guava.version>
     <httpclient.version>4.5</httpclient.version>
     <httpcore.version>4.4.1</httpcore.version>
     <jackson.version>2.4.4</jackson.version>
-    <jackson-module-scala.version>2.4.4</jackson-module-scala.version>
     <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
     <jetty.version>9.2.10.v20150310</jetty.version>
     <json4s.version>3.2.11</json4s.version>
+    <junit.version>4.11</junit.version>
+    <kryo.version>2.22</kryo.version>
     <metrics.version>3.1.0</metrics.version>
+    <mockito.version>1.9.5</mockito.version>
+    <netty.version>4.0.23.Final</netty.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <py4j.version>0.8.2.1</py4j.version>
     <scala.binary.version>2.10</scala.binary.version>
@@ -66,6 +70,7 @@
     <targetJavaVersion>1.7</targetJavaVersion>
     <minJavaVersion>1.7</minJavaVersion>
     <maxJavaVersion>1.8</maxJavaVersion>
+    <test.redirectToFile>true</test.redirectToFile>
   </properties>
   <repositories>
     <repository>
@@ -128,6 +133,18 @@
       </dependency>
 
       <dependency>
+        <groupId>com.esotericsoftware.kryo</groupId>
+        <artifactId>kryo</artifactId>
+        <version>${kryo.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
         <version>${jackson.version}</version>
@@ -142,8 +159,13 @@
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
-        <version>${jackson-module-scala.version}</version>
-        <scope>provided</scope>
+        <version>${jackson.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>${guava.version}</version>
       </dependency>
 
       <dependency>
@@ -165,15 +187,41 @@
       </dependency>
 
       <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-all</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>javax.servlet</groupId>
         <artifactId>javax.servlet-api</artifactId>
         <version>${javax.servlet-api.version}</version>
       </dependency>
 
       <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>${junit.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-all</artifactId>
+        <version>${mockito.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-common</artifactId>
         <version>${hadoop.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -216,6 +264,31 @@
         <groupId>org.apache.spark</groupId>
         <artifactId>spark-core_${scala.binary.version}</artifactId>
         <version>${spark.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.eclipse.jetty.orbit</groupId>
+            <artifactId>javax.servlet</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.spark</groupId>
+        <artifactId>spark-hive_${scala.binary.version}</artifactId>
+        <version>${spark.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.spark</groupId>
+        <artifactId>spark-sql_${scala.binary.version}</artifactId>
+        <version>${spark.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.spark</groupId>
+        <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+        <version>${spark.version}</version>
+        <scope>provided</scope>
       </dependency>
 
       <dependency>
@@ -491,9 +564,16 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.7</version>
+          <version>2.19</version>
           <configuration>
-            <skipTests>true</skipTests>
+            <systemPropertyVariables>
+              <java.awt.headless>true</java.awt.headless>
+              <spark.home>${spark.home}</spark.home>
+            </systemPropertyVariables>
+            <redirectTestOutputToFile>${test.redirectToFile}</redirectTestOutputToFile>
+            <useFile>${test.redirectToFile}</useFile>
+            <argLine>-Xmx4096m -XX:MaxPermSize=512m</argLine>
+            <failIfNoTests>false</failIfNoTests>
           </configuration>
         </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -585,6 +585,7 @@
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
             <junitxml>.</junitxml>
             <filereports>WDF TestSuite.txt</filereports>
+            <argLine>-Xmx4096m -XX:MaxPermSize=512m</argLine>
           </configuration>
           <executions>
             <execution>


### PR DESCRIPTION
Make sure the RSC pom integrates with the rest of the build and uses the
same dependencies; exclude some dependencies that were causing test
failures.

And for tests that need to fork Spark, check whether SPARK_HOME is set,
and skip them when it's not available.

Finally, SparkInterpreter was using internal APIs that were removed in 1.6;
added code to detect which method to use via reflection, although now we
have two cases of using internal APIs...