### PR TITLE
Add config for location of local client jars, don't use "jarOfClass".

### DIFF
--- a/livy-client-local/src/main/java/com/cloudera/livy/client/local/LocalConf.java
+++ b/livy-client-local/src/main/java/com/cloudera/livy/client/local/LocalConf.java
@@ -62,6 +62,8 @@ public class LocalConf extends Configuration {
     CLIENT_SECRET("client.auth.secret", null),
     CLIENT_IN_PROCESS("client.do_not_use.run_driver_in_process", null),
 
+    LIVY_JARS("jars", null),
+
     RPC_SERVER_ADDRESS("rpc.server.address", null),
     RPC_CLIENT_HANDSHAKE_TIMEOUT("server.connect.timeout", "90000ms"),
     RPC_CLIENT_CONNECT_TIMEOUT("client.connect.timeout", "10000ms"),

--- a/livy-client-local/src/test/java/com/cloudera/livy/client/local/TestSparkClient.java
+++ b/livy-client-local/src/test/java/com/cloudera/livy/client/local/TestSparkClient.java
@@ -74,6 +74,7 @@ public class TestSparkClient {
       conf.put("spark.app.name", "SparkClientSuite Remote App");
       conf.put("spark.driver.extraClassPath", classpath);
       conf.put("spark.executor.extraClassPath", classpath);
+      conf.put(LIVY_JARS.key, "");
     }
 
     return conf;


### PR DESCRIPTION
This allows Livy client jars to be cached somewhere (e.g. HDFS) instead
of always being uploaded to the cluster. It also removed the use of sketchy
API to figure out what jar to use (since it didn't include dependencies).