### PR TITLE
Add support to bypass pre-serialized jobs in client-local.

### DIFF
--- a/api/src/main/java/com/cloudera/livy/Job.java
+++ b/api/src/main/java/com/cloudera/livy/Job.java
@@ -22,7 +22,7 @@ import java.io.Serializable;
 /**
  * Interface for a Spark remote job.
  */
-public interface Job<T extends Serializable> extends Serializable {
+public interface Job<T> extends Serializable {
 
   T call(JobContext jc) throws Exception;
 

--- a/api/src/main/java/com/cloudera/livy/JobHandle.java
+++ b/api/src/main/java/com/cloudera/livy/JobHandle.java
@@ -17,14 +17,13 @@
 
 package com.cloudera.livy;
 
-import java.io.Serializable;
 import java.util.List;
 import java.util.concurrent.Future;
 
 /**
  * A handle to a submitted job. Allows for monitoring and controlling of the running remote job.
  */
-public interface JobHandle<T extends Serializable> extends Future<T> {
+public interface JobHandle<T> extends Future<T> {
 
   /**
    * The client job ID. This is unrelated to any Spark jobs that might be triggered by the
@@ -74,7 +73,7 @@ public interface JobHandle<T extends Serializable> extends Future<T> {
    * A listener for monitoring the state of the job in the remote context. Callbacks are called
    * when the corresponding state change occurs.
    */
-  static interface Listener<T extends Serializable> {
+  static interface Listener<T> {
 
     void onJobQueued(JobHandle<T> job);
 

--- a/api/src/main/java/com/cloudera/livy/LivyClient.java
+++ b/api/src/main/java/com/cloudera/livy/LivyClient.java
@@ -17,7 +17,6 @@
 
 package com.cloudera.livy;
 
-import java.io.Serializable;
 import java.net.URI;
 import java.util.concurrent.Future;
 
@@ -32,7 +31,7 @@ public interface LivyClient {
    * @param job The job to execute.
    * @return A handle that be used to monitor the job.
    */
-  <T extends Serializable> JobHandle<T> submit(Job<T> job);
+  <T> JobHandle<T> submit(Job<T> job);
 
   String clientId();
 
@@ -51,7 +50,7 @@ public interface LivyClient {
    * @param job The job to execute.
    * @return A future to monitor the result of the job.
    */
-  <T extends Serializable> Future<T> run(Job<T> job);
+  <T> Future<T> run(Job<T> job);
 
   /**
    * Stops the remote context.

--- a/api/src/main/java/com/cloudera/livy/metrics/Metrics.java
+++ b/api/src/main/java/com/cloudera/livy/metrics/Metrics.java
@@ -17,8 +17,6 @@
 
 package com.cloudera.livy.metrics;
 
-import java.io.Serializable;
-
 import org.apache.spark.executor.TaskMetrics;
 
 /**
@@ -27,7 +25,7 @@ import org.apache.spark.executor.TaskMetrics;
  * Depending on how the metrics object is obtained (by calling methods in the `MetricsCollection`
  * class), metrics will refer to one or more tasks.
  */
-public class Metrics implements Serializable {
+public class Metrics {
 
   /** Time taken on the executor to deserialize tasks. */
   public final long executorDeserializeTime;

--- a/api/src/main/java/com/cloudera/livy/metrics/ShuffleReadMetrics.java
+++ b/api/src/main/java/com/cloudera/livy/metrics/ShuffleReadMetrics.java
@@ -17,14 +17,12 @@
 
 package com.cloudera.livy.metrics;
 
-import java.io.Serializable;
-
 import org.apache.spark.executor.TaskMetrics;
 
 /**
  * Metrics pertaining to reading shuffle data.
  */
-public class ShuffleReadMetrics implements Serializable {
+public class ShuffleReadMetrics {
 
   /** Number of remote blocks fetched in shuffles by tasks. */
   public final int remoteBlocksFetched;

--- a/api/src/main/java/com/cloudera/livy/metrics/ShuffleWriteMetrics.java
+++ b/api/src/main/java/com/cloudera/livy/metrics/ShuffleWriteMetrics.java
@@ -17,14 +17,12 @@
 
 package com.cloudera.livy.metrics;
 
-import java.io.Serializable;
-
 import org.apache.spark.executor.TaskMetrics;
 
 /**
  * Metrics pertaining to writing shuffle data.
  */
-public class ShuffleWriteMetrics implements Serializable {
+public class ShuffleWriteMetrics {
 
   /** Number of bytes written for the shuffle by tasks. */
   public final long shuffleBytesWritten;

--- a/api/src/test/java/com/cloudera/livy/TestClientFactory.java
+++ b/api/src/test/java/com/cloudera/livy/TestClientFactory.java
@@ -17,7 +17,6 @@
 
 package com.cloudera.livy;
 
-import java.io.Serializable;
 import java.net.URI;
 import java.util.Properties;
 import java.util.concurrent.Future;
@@ -47,7 +46,7 @@ public class TestClientFactory implements LivyClientFactory {
     }
 
     @Override
-    public <T extends Serializable> JobHandle<T> submit(Job<T> job) {
+    public <T> JobHandle<T> submit(Job<T> job) {
       throw new UnsupportedOperationException();
     }
 
@@ -57,7 +56,7 @@ public class TestClientFactory implements LivyClientFactory {
     }
 
     @Override
-    public <T extends Serializable> Future<T> run(Job<T> job) {
+    public <T> Future<T> run(Job<T> job) {
       throw new UnsupportedOperationException();
     }
 

--- a/client-common/pom.xml
+++ b/client-common/pom.xml
@@ -25,37 +25,20 @@
   </parent>
 
   <groupId>com.cloudera.livy</groupId>
-  <artifactId>livy-api_2.10</artifactId>
+  <artifactId>livy-client-common_2.10</artifactId>
   <version>0.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_${scala.binary.version}</artifactId>
-      <scope>provided</scope>
+      <groupId>com.cloudera.livy</groupId>
+      <artifactId>livy-api_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
     </dependency>
+
     <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-hive_${scala.binary.version}</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_${scala.binary.version}</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <!-- Needed by Spark but excluded in the Livy root pom. -->
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <scope>provided</scope>
+      <groupId>com.esotericsoftware.kryo</groupId>
+      <artifactId>kryo</artifactId>
     </dependency>
   </dependencies>
-
 </project>

--- a/client-common/src/main/java/com/cloudera/livy/client/common/BufferUtils.java
+++ b/client-common/src/main/java/com/cloudera/livy/client/common/BufferUtils.java
@@ -15,33 +15,28 @@
  * limitations under the License.
  */
 
-package com.cloudera.livy.metrics;
+package com.cloudera.livy.client.common;
 
-import org.apache.spark.executor.TaskMetrics;
+import java.nio.ByteBuffer;
+
+import com.cloudera.livy.annotations.Private;
 
 /**
- * Metrics pertaining to reading input data.
+ * Utility methods for dealing with byte buffers and byte arrays.
  */
-public class InputMetrics {
+@Private
+public class BufferUtils {
 
-  public final DataReadMethod readMethod;
-  public final long bytesRead;
-
-  private InputMetrics() {
-    // For Serialization only.
-    this(null, 0L);
-  }
-
-  public InputMetrics(
-      DataReadMethod readMethod,
-      long bytesRead) {
-    this.readMethod = readMethod;
-    this.bytesRead = bytesRead;
-  }
-
-  public InputMetrics(TaskMetrics metrics) {
-    this(DataReadMethod.valueOf(metrics.inputMetrics().get().readMethod().toString()),
-      metrics.inputMetrics().get().bytesRead());
+  public static byte[] toByteArray(ByteBuffer buf) {
+    byte[] bytes;
+    if (buf.hasArray() && buf.arrayOffset() == 0 &&
+        buf.remaining() == buf.array().length) {
+      bytes = buf.array();
+    } else {
+      bytes = new byte[buf.remaining()];
+      buf.get(bytes);
+    }
+    return bytes;
   }
 
 }

--- a/client-common/src/main/java/com/cloudera/livy/client/common/Serializer.java
+++ b/client-common/src/main/java/com/cloudera/livy/client/common/Serializer.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.client.common;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.ByteBufferInputStream;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.shaded.org.objenesis.strategy.StdInstantiatorStrategy;
+
+import com.cloudera.livy.annotations.Private;
+
+/**
+ * Utility class to serialize user data using Kryo.
+ */
+@Private
+public class Serializer {
+
+  // Kryo docs say 0-8 are taken. Strange things happen if you don't set an ID when registering
+  // classes.
+  private static final int REG_ID_BASE = 16;
+
+  private final ThreadLocal<Kryo> kryos;
+
+  public Serializer(final Class<?>... klasses) {
+    this.kryos = new ThreadLocal<Kryo>() {
+      @Override
+      protected Kryo initialValue() {
+        Kryo kryo = new Kryo();
+        int count = 0;
+        for (Class<?> klass : klasses) {
+          kryo.register(klass, REG_ID_BASE + count);
+          count++;
+        }
+        kryo.setInstantiatorStrategy(new StdInstantiatorStrategy());
+        return kryo;
+      }
+    };
+  }
+
+  public Object deserialize(ByteBuffer data) {
+    Input kryoIn = new Input(new ByteBufferInputStream(data));
+    return kryos.get().readClassAndObject(kryoIn);
+  }
+
+  public ByteBuffer serialize(Object data) {
+    ByteBufferOutputStream out = new ByteBufferOutputStream();
+    Output kryoOut = new Output(out);
+    kryos.get().writeClassAndObject(kryoOut, data);
+    kryoOut.flush();
+    return out.getBuffer();
+  }
+
+  private static class ByteBufferOutputStream extends ByteArrayOutputStream {
+
+    public ByteBuffer getBuffer() {
+      ByteBuffer result = ByteBuffer.wrap(buf, 0, count);
+      buf = null;
+      reset();
+      return result;
+    }
+
+  }
+
+}

--- a/client-common/src/test/java/com/cloudera/livy/client/common/TestSerializer.java
+++ b/client-common/src/test/java/com/cloudera/livy/client/common/TestSerializer.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.client.common;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class TestSerializer {
+
+  private static final String MESSAGE = "Hello World!";
+
+  @Test
+  public void testSerializer() throws Exception {
+    Object decoded = doSerDe(MESSAGE);
+    assertEquals(MESSAGE, decoded);
+  }
+
+  @Test
+  public void testAutoRegistration() throws Exception {
+    Object decoded = doSerDe(new TestMessage(MESSAGE), TestMessage.class);
+    assertTrue(decoded instanceof TestMessage);
+    assertEquals(MESSAGE, ((TestMessage)decoded).data);
+  }
+
+  private Object doSerDe(Object data, Class<?>... klasses) {
+    Serializer s = new Serializer(klasses);
+    ByteBuffer serialized = s.serialize(data);
+    return s.deserialize(serialized);
+  }
+
+  private ByteBuffer newBuffer() {
+    return ByteBuffer.allocate(1024);
+  }
+
+  private static class TestMessage {
+    final String data;
+
+    TestMessage() {
+      this(null);
+    }
+
+    TestMessage(String data) {
+      this.data = data;
+    }
+  }
+
+}

--- a/client-local/pom.xml
+++ b/client-local/pom.xml
@@ -35,6 +35,11 @@
       <artifactId>livy-api_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.cloudera.livy</groupId>
+      <artifactId>livy-client-common_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>com.esotericsoftware.kryo</groupId>
@@ -89,15 +94,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
     </dependency>
   </dependencies>
 

--- a/client-local/src/main/java/com/cloudera/livy/client/local/BaseProtocol.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/BaseProtocol.java
@@ -17,8 +17,6 @@
 
 package com.cloudera.livy.client.local;
 
-import java.io.Serializable;
-
 import com.google.common.base.Throwables;
 
 import com.cloudera.livy.Job;
@@ -27,7 +25,7 @@ import com.cloudera.livy.client.local.rpc.RpcDispatcher;
 
 abstract class BaseProtocol extends RpcDispatcher {
 
-  protected static class CancelJob implements Serializable {
+  protected static class CancelJob {
 
     final String id;
 
@@ -41,11 +39,11 @@ abstract class BaseProtocol extends RpcDispatcher {
 
   }
 
-  protected static class EndSession implements Serializable {
+  protected static class EndSession {
 
   }
 
-  protected static class Error implements Serializable {
+  protected static class Error {
 
     final String cause;
 
@@ -63,7 +61,7 @@ abstract class BaseProtocol extends RpcDispatcher {
 
   }
 
-  protected static class JobMetrics implements Serializable {
+  protected static class JobMetrics {
 
     final String jobId;
     final int sparkJobId;
@@ -85,7 +83,23 @@ abstract class BaseProtocol extends RpcDispatcher {
 
   }
 
-  protected static class JobRequest<T extends Serializable> implements Serializable {
+  protected static class BypassJobRequest {
+
+    final String id;
+    final byte[] serializedJob;
+
+    BypassJobRequest(String id, byte[] serializedJob) {
+      this.id = id;
+      this.serializedJob = serializedJob;
+    }
+
+    BypassJobRequest() {
+      this(null, null);
+    }
+
+  }
+
+  protected static class JobRequest<T> {
 
     final String id;
     final Job<T> job;
@@ -101,7 +115,7 @@ abstract class BaseProtocol extends RpcDispatcher {
 
   }
 
-  protected static class JobResult<T extends Serializable> implements Serializable {
+  protected static class JobResult<T> {
 
     final String id;
     final T result;
@@ -119,7 +133,7 @@ abstract class BaseProtocol extends RpcDispatcher {
 
   }
 
-  protected static class JobStarted implements Serializable {
+  protected static class JobStarted {
 
     final String id;
 
@@ -136,7 +150,7 @@ abstract class BaseProtocol extends RpcDispatcher {
   /**
    * Inform the client that a new spark job has been submitted for the client job.
    */
-  protected static class JobSubmitted implements Serializable {
+  protected static class JobSubmitted {
     final String clientJobId;
     final int sparkJobId;
 
@@ -150,7 +164,7 @@ abstract class BaseProtocol extends RpcDispatcher {
     }
   }
 
-  protected static class SyncJobRequest<T extends Serializable> implements Serializable {
+  protected static class SyncJobRequest<T> {
 
     final Job<T> job;
 
@@ -159,6 +173,20 @@ abstract class BaseProtocol extends RpcDispatcher {
     }
 
     SyncJobRequest() {
+      this(null);
+    }
+
+  }
+
+  protected static class BypassSyncJob {
+
+    final byte[] serializedJob;
+
+    BypassSyncJob(byte[] serializedJob) {
+      this.serializedJob = serializedJob;
+    }
+
+    BypassSyncJob() {
       this(null);
     }
 

--- a/client-local/src/main/java/com/cloudera/livy/client/local/JobHandleImpl.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/JobHandleImpl.java
@@ -17,7 +17,6 @@
 
 package com.cloudera.livy.client.local;
 
-import java.io.Serializable;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
@@ -33,7 +32,7 @@ import com.cloudera.livy.MetricsCollection;
 /**
  * A handle to a submitted job. Allows for monitoring and controlling of the running remote job.
  */
-class JobHandleImpl<T extends Serializable> implements JobHandle<T> {
+class JobHandleImpl<T> implements JobHandle<T> {
 
   private final LocalClient client;
   private final String jobId;

--- a/client-local/src/main/java/com/cloudera/livy/client/local/rpc/README.md
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/rpc/README.md
@@ -30,4 +30,3 @@ Future work:
 
 - Random initial RPC id + id wrapping.
 - SSL / security in general.
-- Remove "Serializable" from the API. Not needed with kryo.

--- a/client-local/src/test/java/com/cloudera/livy/client/local/TestJobHandle.java
+++ b/client-local/src/test/java/com/cloudera/livy/client/local/TestJobHandle.java
@@ -17,8 +17,6 @@
 
 package com.cloudera.livy.client.local;
 
-import java.io.Serializable;
-
 import io.netty.util.concurrent.Promise;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,13 +32,13 @@ import com.cloudera.livy.JobHandle;
 public class TestJobHandle {
 
   @Mock private LocalClient client;
-  @Mock private Promise<Serializable> promise;
-  @Mock private JobHandle.Listener<Serializable> listener;
-  @Mock private JobHandle.Listener<Serializable> listener2;
+  @Mock private Promise<Object> promise;
+  @Mock private JobHandle.Listener<Object> listener;
+  @Mock private JobHandle.Listener<Object> listener2;
 
   @Test
   public void testStateChanges() throws Exception {
-    JobHandleImpl<Serializable> handle = new JobHandleImpl<Serializable>(client, promise, "job");
+    JobHandleImpl<Object> handle = new JobHandleImpl<Object>(client, promise, "job");
     handle.addListener(listener);
 
     assertTrue(handle.changeState(JobHandle.State.QUEUED));
@@ -62,7 +60,7 @@ public class TestJobHandle {
 
   @Test
   public void testFailedJob() throws Exception {
-    JobHandleImpl<Serializable> handle = new JobHandleImpl<Serializable>(client, promise, "job");
+    JobHandleImpl<Object> handle = new JobHandleImpl<Object>(client, promise, "job");
     handle.addListener(listener);
 
     Throwable cause = new Exception();
@@ -75,10 +73,10 @@ public class TestJobHandle {
 
   @Test
   public void testSucceededJob() throws Exception {
-    JobHandleImpl<Serializable> handle = new JobHandleImpl<Serializable>(client, promise, "job");
+    JobHandleImpl<Object> handle = new JobHandleImpl<Object>(client, promise, "job");
     handle.addListener(listener);
 
-    Serializable result = new Exception();
+    Object result = new Exception();
     when(promise.get()).thenReturn(result);
 
     assertTrue(handle.changeState(JobHandle.State.SUCCEEDED));
@@ -88,7 +86,7 @@ public class TestJobHandle {
 
   @Test
   public void testImmediateCallback() throws Exception {
-    JobHandleImpl<Serializable> handle = new JobHandleImpl<Serializable>(client, promise, "job");
+    JobHandleImpl<Object> handle = new JobHandleImpl<Object>(client, promise, "job");
     assertTrue(handle.changeState(JobHandle.State.QUEUED));
     handle.addListener(listener);
     verify(listener).onJobQueued(handle);

--- a/pom.xml
+++ b/pom.xml
@@ -123,9 +123,26 @@
     <module>server</module>
     <module>spark</module>
     <module>yarn</module>
+    <module>client-common</module>
     <module>client-local</module>
     <module>client-http</module>
   </modules>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
   <dependencyManagement>
     <dependencies>
@@ -200,20 +217,6 @@
         <groupId>javax.servlet</groupId>
         <artifactId>javax.servlet-api</artifactId>
         <version>${javax.servlet-api.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>${junit.version}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
-        <version>${mockito.version}</version>
-        <scope>test</scope>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
To implement the HTTP-based protocol for the Spark client API, the
Livy server needs to be able to bypass data serialized in the
client to the remote driver, without trying to deserialize it
in the process, because it doesn't have the necessary client
classes to do that.

This change adds a private api in client-local and some shared
helper code to implement this bypass; the remote driver will
deserialize these jobs as part of executing them. The code
running inside the Livy server becomes a dumb bypass for the
job and its result.

- Removed "Serializable" from API, since it only adds noise when
  using Kryo.
- Added a "client-common" package with shared serde code to implement
  bypass jobs.
- Added "private" API to client-local to send already serialized jobs
  to the remote context.