### PR TITLE
Add servlet to handle livy client sessions.

### DIFF
--- a/api/src/main/java/com/cloudera/livy/LivyClientBuilder.java
+++ b/api/src/main/java/com/cloudera/livy/LivyClientBuilder.java
@@ -57,6 +57,13 @@ public final class LivyClientBuilder {
     return this;
   }
 
+  public LivyClientBuilder setIfMissing(String key, String value) {
+    if (!config.containsKey(key)) {
+      setConf(key, value);
+    }
+    return this;
+  }
+
   public LivyClient build() {
     ClassLoader cl = Thread.currentThread().getContextClassLoader();
     if (cl == null) {

--- a/client-local/src/main/java/com/cloudera/livy/client/local/LocalClient.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/LocalClient.java
@@ -62,7 +62,7 @@ import com.cloudera.livy.client.local.rpc.Rpc;
 import com.cloudera.livy.client.local.rpc.RpcServer;
 import static com.cloudera.livy.client.local.LocalConf.Entry.*;
 
-class LocalClient implements LivyClient {
+public class LocalClient implements LivyClient {
   private static final Logger LOG = LoggerFactory.getLogger(LocalClient.class);
 
   private static final long DEFAULT_SHUTDOWN_TIMEOUT = 10000; // In milliseconds

--- a/server/src/main/scala/com/cloudera/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/SessionServlet.scala
@@ -113,7 +113,7 @@ abstract class SessionServlet[S <: Session](sessionManager: SessionManager[S])
     new AsyncResult {
       val is = Future {
         val session = sessionManager.create(parsedBody)
-        Created(session,
+        Created(serializeSession(session),
           headers = Map("Location" -> url(getSession, "id" -> session.id.toString))
         )
       }

--- a/server/src/main/scala/com/cloudera/livy/server/client/ClientSessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/client/ClientSessionServlet.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cloudera.livy.server.client
+
+import java.io.{ByteArrayInputStream, ObjectInputStream}
+
+import org.json4s.JValue
+import org.json4s.jackson.JsonMethods._
+import org.json4s.jackson.Serialization.write
+import org.scalatra._
+
+import com.cloudera.livy.Job
+import com.cloudera.livy.server.SessionServlet
+import com.cloudera.livy.sessions.{SessionManager, SessionState}
+import com.cloudera.livy.spark.client._
+
+class ClientSessionServlet(sessionManager: SessionManager[ClientSession])
+  extends SessionServlet[ClientSession](sessionManager) {
+
+  post("/:id/submit-job") {
+    sessionManager.get(params("id").toInt) match {
+      case Some(session) =>
+        val req = parsedBody.extract[SerializedJob]
+        if (req.job != null && req.job.length > 0) {
+          Created(session.submitJob(req.job))
+        } else {
+          BadRequest("No job provided.")
+        }
+      case None =>
+    }
+  }
+
+  post("/:id/run-job") {
+    sessionManager.get(params("id").toInt) match {
+      case Some(session) =>
+        val req = parsedBody.extract[SerializedJob]
+        if (req.job != null && req.job.length > 0) {
+          val jobId = session.runJob(req.job)
+          Created(JobSubmitted(jobId))
+        } else {
+          BadRequest("No job provided.")
+        }
+      case None =>
+    }
+  }
+
+  post("/:id/add-jar") {
+    sessionManager.get(params("id").toInt) match {
+      case Some(session) =>
+        session.addJar(parsedBody.extract[AddJar].uri)
+      case None =>
+    }
+  }
+
+  post("/:id/add-file") {
+    sessionManager.get(params("id").toInt) match {
+      case Some(session) =>
+        session.addFile(parsedBody.extract[AddFile].uri)
+      case None =>
+    }
+  }
+
+  post("/:id/job-status") {
+    sessionManager.get(params("id").toInt) match {
+      case Some(session) =>
+      case None =>
+    }
+  }
+
+  override protected def serializeSession(session: ClientSession): JValue = {
+    val view = ClientSessionView(session.id, session.state)
+    parse(write(view))
+  }
+
+  case class ClientSessionView(id: Int, state: SessionState)
+
+}

--- a/server/src/test/scala/com/cloudera/livy/server/BaseSessionServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/BaseSessionServletSpec.scala
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.server
+
+import org.json4s.{DefaultFormats, Formats, JValue}
+import org.json4s.jackson.JsonMethods._
+import org.json4s.jackson.Serialization.write
+import org.scalatest.{BeforeAndAfterAll, FunSpecLike}
+import org.scalatra.test.scalatest.ScalatraSuite
+
+import com.cloudera.livy.LivyConf
+import com.cloudera.livy.sessions.{Session, SessionFactory, SessionManager}
+
+abstract class BaseSessionServletSpec[S <: Session] extends ScalatraSuite
+  with FunSpecLike with BeforeAndAfterAll {
+
+  protected implicit def jsonFormats: Formats = DefaultFormats
+
+  override protected def withFixture(test: NoArgTest) = {
+    assume(sys.env.get("SPARK_HOME").isDefined, "SPARK_HOME is not set.")
+    test()
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    sessionManager.shutdown()
+  }
+
+
+  def sessionFactory: SessionFactory[S]
+  def servlet: SessionServlet[S]
+
+  val livyConf = new LivyConf()
+  val sessionManager = new SessionManager(livyConf, sessionFactory)
+
+  addServlet(servlet, "/*")
+
+  protected def toJson(msg: AnyRef): String = write(msg)
+
+  protected def headers: Map[String, String] = Map("Content-Type" -> "application/json")
+
+  protected def getJson(uri: String, expectedStatus: Int = 200)(fn: (JValue) => Unit): Unit = {
+    get(uri)(doTest(expectedStatus, fn))
+  }
+
+  protected def postJson(uri: String, body: AnyRef, expectedStatus: Int = 201)
+      (fn: (JValue) => Unit): Unit = {
+    post(uri, body = toJson(body), headers = headers)(doTest(expectedStatus, fn))
+  }
+
+  protected def deleteJson(uri: String, expectedStatus: Int = 200)(fn: (JValue) => Unit): Unit = {
+    delete(uri)(doTest(expectedStatus, fn))
+  }
+
+  private def doTest(expectedStatus: Int, fn: (JValue) => Unit): Unit = {
+    status should be (expectedStatus)
+    header("Content-Type") should include("application/json")
+    fn(parse(body))
+  }
+
+}

--- a/server/src/test/scala/com/cloudera/livy/server/client/ClientServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/client/ClientServletSpec.scala
@@ -1,0 +1,105 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.server.client
+
+import org.json4s.JsonAST._
+
+import com.cloudera.livy.{Job, JobContext}
+import com.cloudera.livy.client.common.{BufferUtils, Serializer}
+import com.cloudera.livy.server.BaseSessionServletSpec
+import com.cloudera.livy.spark.client._
+
+class ClientServletSpec extends BaseSessionServletSpec[ClientSession] {
+
+  override def sessionFactory = new ClientSessionFactory()
+  override def servlet = new ClientSessionServlet(sessionManager)
+
+  private var sessionId: Int = -1
+
+  def withSessionId(desc: String)(fn: (Int) => Unit): Unit = {
+    it(desc) {
+      assume(sessionId != -1, "No active session.")
+      fn(sessionId)
+    }
+  }
+
+  describe("Client Servlet") {
+
+    it("should create client sessions") {
+      val classpath = sys.props("java.class.path")
+      val conf = Map(
+        "master" -> "local",
+        "livy.local.jars" -> "",
+        "spark.driver.extraClassPath" -> classpath,
+        "spark.executor.extraClassPath" -> classpath
+        )
+
+      postJson("/", CreateClientRequest(10000L, conf)) { data =>
+        header("Location") should equal("/0")
+        data \ "id" should equal (JInt(0))
+        sessionId = (data \ "id").extract[Int]
+      }
+    }
+
+    it("should list existing sessions") {
+      getJson("/") { data =>
+        (data \ "sessions") match {
+          case JArray(contents) => contents.size should equal (1)
+          case _ => fail("Response is not an array.")
+        }
+      }
+    }
+
+    withSessionId("should handle asynchronous jobs") { id =>
+      val ser = new Serializer()
+      val job = BufferUtils.toByteArray(ser.serialize(new TestJob()))
+      postJson(s"/$id/submit-job", SerializedJob(job)) { data =>
+        // TODO: more checks; API for result.
+      }
+    }
+
+    withSessionId("should handle synchronous jobs") { id =>
+      val ser = new Serializer()
+      val job = BufferUtils.toByteArray(ser.serialize(new TestJob()))
+      postJson(s"/$id/run-job", SerializedJob(job)) { data =>
+        // TODO: more checks; API for result.
+      }
+    }
+
+    withSessionId("should tear down sessions") { id =>
+      deleteJson(s"/$id") { data =>
+        // TODO: check data when it exists.
+      }
+      getJson("/") { data =>
+        (data \ "sessions") match {
+          case JArray(contents) => contents.size should equal (0)
+          case _ => fail("Response is not an array.")
+        }
+      }
+    }
+
+  }
+
+}
+
+class TestJob extends Job[Int] {
+
+  override def call(jc: JobContext): Int = 42
+
+}

--- a/spark/src/main/scala/com/cloudera/livy/spark/client/ClientMessage.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/client/ClientMessage.scala
@@ -16,6 +16,31 @@
  */
 package com.cloudera.livy.spark.client
 
-case class CreateClientRequest (
+import java.net.URI
+
+sealed trait ClientMessage
+
+case class JobMessage(job: String) extends ClientMessage
+
+case class CreateClientRequest(
   timeout: Long,
-  conf: Map[String, String] = Map())
+  sparkConf: Map[String, String] = Map()
+) extends ClientMessage
+
+case class SerializedJob(job: Array[Byte]) extends ClientMessage
+
+case object Stop extends ClientMessage
+
+case class AddJar(uri: URI) extends ClientMessage
+
+case class AddFile(uri: URI) extends ClientMessage
+
+case class JobSubmitted(id: Long) extends ClientMessage
+
+case class JobStatus(id: Long) extends ClientMessage
+
+case class JobCompleted(id: Long) extends ClientMessage
+
+case class JobFailed(id: Long) extends ClientMessage
+
+case class JobResult(id: Long, result: Any) extends ClientMessage

--- a/spark/src/main/scala/com/cloudera/livy/spark/client/SessionClientTracker.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/client/SessionClientTracker.scala
@@ -52,7 +52,7 @@ object SessionClientTracker extends Logging {
     builder
       .setAll(conf)
       .setConf("livy.client.sessionId", sessionId.toString)
-      .setConf("spark.master", "yarn-cluster")
+      .setIfMissing("spark.master", "yarn-cluster")
     val client = builder.build()
     sessions.put(sessionId, timeout, client)
     info("Started LivyClient for sessionId: " + sessionId)


### PR DESCRIPTION
This is not complete; it allows creating / tearing down sessions and
submitting synchronous / asynchronous jobs, but there's currently no
way to retrieve a job's results (or even monitoring it's state, since
the backend code for that is not implemented).

Also includes a new base test class for the servlets that does away
with a lot of copy & paste.