### PR TITLE
Modify bypass jobs to use polling to fetch status.

### DIFF
--- a/client-local/src/main/java/com/cloudera/livy/client/local/BaseProtocol.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/BaseProtocol.java
@@ -87,14 +87,30 @@ public abstract class BaseProtocol extends RpcDispatcher {
 
     public final String id;
     public final byte[] serializedJob;
+    public final boolean synchronous;
 
-    public BypassJobRequest(String id, byte[] serializedJob) {
+    public BypassJobRequest(String id, byte[] serializedJob, boolean synchronous) {
       this.id = id;
       this.serializedJob = serializedJob;
+      this.synchronous = synchronous;
     }
 
     public BypassJobRequest() {
-      this(null, null);
+      this(null, null, false);
+    }
+
+  }
+
+  protected static class GetBypassJobStatus {
+
+    public final String id;
+
+    public GetBypassJobStatus(String id) {
+      this.id = id;
+    }
+
+    public GetBypassJobStatus() {
+      this(null);
     }
 
   }
@@ -173,20 +189,6 @@ public abstract class BaseProtocol extends RpcDispatcher {
     }
 
     public SyncJobRequest() {
-      this(null);
-    }
-
-  }
-
-  protected static class BypassSyncJob {
-
-    public final byte[] serializedJob;
-
-    public BypassSyncJob(byte[] serializedJob) {
-      this.serializedJob = serializedJob;
-    }
-
-    public BypassSyncJob() {
       this(null);
     }
 

--- a/client-local/src/main/java/com/cloudera/livy/client/local/BypassJobStatus.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/BypassJobStatus.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.client.local;
+
+import com.google.common.base.Throwables;
+
+import com.cloudera.livy.Job;
+import com.cloudera.livy.JobHandle;
+import com.cloudera.livy.MetricsCollection;
+import com.cloudera.livy.client.local.rpc.RpcDispatcher;
+
+public class BypassJobStatus {
+
+  public final JobHandle.State state;
+  public final byte[] result;
+  public final String error;
+  public final MetricsCollection metrics;
+
+  public BypassJobStatus(JobHandle.State state, byte[] result, String error,
+      MetricsCollection metrics) {
+    this.state = state;
+    this.result = result;
+    this.error = error;
+    this.metrics = metrics;
+  }
+
+  BypassJobStatus() {
+    this(null, null, null, null);
+  }
+
+}

--- a/client-local/src/main/java/com/cloudera/livy/client/local/driver/BypassJobWrapper.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/driver/BypassJobWrapper.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.client.local.driver;
+
+import com.google.common.base.Throwables;
+import org.apache.spark.api.java.JavaFutureAction;
+
+import com.cloudera.livy.JobHandle;
+import com.cloudera.livy.MetricsCollection;
+import com.cloudera.livy.client.local.BypassJobStatus;
+import com.cloudera.livy.metrics.Metrics;
+
+class BypassJobWrapper extends JobWrapper<byte[]> {
+
+  private byte[] result;
+  private Throwable error;
+  private volatile MetricsCollection metrics;
+  private volatile JobHandle.State state;
+
+  BypassJobWrapper(RemoteDriver driver, String jobId, byte[] serializedJob) {
+    super(driver, jobId, new BypassJob(driver.serializer, serializedJob));
+    state = JobHandle.State.QUEUED;
+  }
+
+  @Override
+  public Void call() throws Exception {
+    state = JobHandle.State.STARTED;
+    return super.call();
+  }
+
+  @Override
+  protected void finished(byte[] result, Throwable error) {
+    if (error == null) {
+      this.result = result;
+      this.state = JobHandle.State.SUCCEEDED;
+    } else {
+      this.error = error;
+      this.state = JobHandle.State.FAILED;
+    }
+  }
+
+  @Override
+  void updateMetrics(int sparkJobId, int stageId, long taskId, Metrics metrics) {
+    if (this.metrics == null) {
+      synchronized (this) {
+        if (this.metrics == null) {
+          this.metrics = new MetricsCollection();
+        }
+      }
+    }
+    this.metrics.addMetrics(sparkJobId, stageId, taskId, metrics);
+  }
+
+  @Override
+  boolean cancel() {
+    if (super.cancel()) {
+      this.state = JobHandle.State.CANCELLED;
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  protected void jobSubmitted(JavaFutureAction<?> job) {
+    // Do nothing; just avoid sending data back to the driver.
+  }
+
+  @Override
+  protected void jobStarted() {
+    // Do nothing; just avoid sending data back to the driver.
+  }
+
+  BypassJobStatus getStatus() {
+    String stackTrace = error != null ? Throwables.getStackTraceAsString(error) : null;
+    return new BypassJobStatus(state, result, stackTrace, metrics);
+  }
+
+}

--- a/client-local/src/main/java/com/cloudera/livy/client/local/driver/RemoteDriver.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/driver/RemoteDriver.java
@@ -171,8 +171,12 @@ public class RemoteDriver {
 
   private void run() throws InterruptedException {
     synchronized (shutdownLock) {
-      while (running) {
-        shutdownLock.wait();
+      try {
+        while (running) {
+          shutdownLock.wait();
+        }
+      } catch (InterruptedException ie) {
+        // Nothing to do.
       }
     }
     executor.shutdownNow();


### PR DESCRIPTION
Right now, bypass jobs work like normal jobs; they return data to the
client as they make progress, and return the results at the end.

When the client in the picture is the Livy server, that's not desirable.
That means that the Livy server would have to store all data generated
by client jobs until the client decide to poll for it; meaning that jobs
could consume lots of memory on the Livy server just by returning a lot
of data.

This change modifies the local client, where the bypass API is implemented,
to store job data in the driver process until it's polled by the client.
This means no data about a job is transferred back to the client until
the client explicitly asks for it. So in Livy's case, instead of a job
consuming memory in the server process, it would do so in the driver
process, which is owned by the user, and wouldn't affect other users.

Note this change does not implement an API for the data to be retrived
through the Livy server's servlet yet; that will be added separately.