### PR TITLE
Add helper class for config data, clean up unused public API.

### DIFF
--- a/api/src/main/java/com/cloudera/livy/LivyClient.java
+++ b/api/src/main/java/com/cloudera/livy/LivyClient.java
@@ -33,8 +33,6 @@ public interface LivyClient {
    */
   <T> JobHandle<T> submit(Job<T> job);
 
-  String clientId();
-
   /**
    * Asks the remote context to run a job immediately.
    * <p/>

--- a/api/src/test/java/com/cloudera/livy/TestClientFactory.java
+++ b/api/src/test/java/com/cloudera/livy/TestClientFactory.java
@@ -51,11 +51,6 @@ public class TestClientFactory implements LivyClientFactory {
     }
 
     @Override
-    public String clientId() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
     public <T> Future<T> run(Job<T> job) {
       throw new UnsupportedOperationException();
     }

--- a/client-common/src/main/java/com/cloudera/livy/client/common/ClientConf.java
+++ b/client-common/src/main/java/com/cloudera/livy/client/common/ClientConf.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.client.common;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.cloudera.livy.annotations.Private;
+
+/**
+ * Base class with common functionality for type-safe configuration objects.
+ */
+@Private
+public abstract class ClientConf<T extends ClientConf>
+  implements Iterable<Map.Entry<String, String>> {
+
+  public static interface ConfEntry {
+
+    /** The key in the configuration file. */
+    String key();
+
+    /**
+     * The default value, which also defines the type of the config. Supported types:
+     * Boolean, Integer, Long, String. <code>null</code> maps to String.
+     */
+    Object dflt();
+
+  }
+
+  private static final Map<String, TimeUnit> TIME_SUFFIXES;
+
+  static {
+    TIME_SUFFIXES = new HashMap<>();
+    TIME_SUFFIXES.put("us", TimeUnit.MICROSECONDS);
+    TIME_SUFFIXES.put("ms", TimeUnit.MILLISECONDS);
+    TIME_SUFFIXES.put("s", TimeUnit.SECONDS);
+    TIME_SUFFIXES.put("m", TimeUnit.MINUTES);
+    TIME_SUFFIXES.put("min", TimeUnit.MINUTES);
+    TIME_SUFFIXES.put("h", TimeUnit.HOURS);
+    TIME_SUFFIXES.put("d", TimeUnit.DAYS);
+  }
+
+  protected final Map<String, String> config;
+
+  protected ClientConf(Properties config) {
+    this.config = new HashMap<>();
+    if (config != null) {
+      for (String key : config.stringPropertyNames()) {
+        this.config.put(key, config.getProperty(key));
+      }
+    }
+  }
+
+  public String get(String key) {
+    return config.get(key);
+  }
+
+  @SuppressWarnings("unchecked")
+  public T set(String key, String value) {
+    config.put(key, value);
+    return (T) this;
+  }
+
+  @SuppressWarnings("unchecked")
+  public T setAll(ClientConf<?> other) {
+    for (Map.Entry<String, String> e : other) {
+      set(e.getKey(), e.getValue());
+    }
+    return (T) this;
+  }
+
+  public String get(ConfEntry e) {
+    Object value = get(e, String.class);
+    return (String) (value != null ? value : e.dflt());
+  }
+
+  public boolean getBoolean(ConfEntry e) {
+    String val = get(e, Boolean.class);
+    if (val != null) {
+      return Boolean.parseBoolean(val);
+    } else {
+      return (Boolean) e.dflt();
+    }
+  }
+
+  public int getInt(ConfEntry e) {
+    String val = get(e, Integer.class);
+    if (val != null) {
+      return Integer.parseInt(val);
+    } else {
+      return (Integer) e.dflt();
+    }
+  }
+
+  public long getLong(ConfEntry e) {
+    String val = get(e, Long.class);
+    if (val != null) {
+      return Long.parseLong(val);
+    } else {
+      return (Long) e.dflt();
+    }
+  }
+
+  public long getTimeAsMs(ConfEntry e) {
+    String time = get(e, String.class);
+    if (time == null) {
+      check(e.dflt() != null,
+        "ConfEntry %s doesn't have a default value, cannot convert to time value.", e.key());
+      time = (String) e.dflt();
+    }
+
+    Matcher m = Pattern.compile("(-?[0-9]+)([a-z]+)?").matcher(time.toLowerCase());
+    if (!m.matches()) {
+      throw new NumberFormatException("Invalid time string: " + time);
+    }
+
+    long val = Long.parseLong(m.group(1));
+    String suffix = m.group(2);
+
+    if (suffix != null && !TIME_SUFFIXES.containsKey(suffix)) {
+      throw new NumberFormatException("Invalid suffix: \"" + suffix + "\"");
+    }
+
+    return TimeUnit.MILLISECONDS.convert(val,
+      suffix != null ? TIME_SUFFIXES.get(suffix) : TimeUnit.MILLISECONDS);
+  }
+
+  @SuppressWarnings("unchecked")
+  public T set(ConfEntry e, Object value) {
+    check(typesMatch(value, e.dflt()), "Value doesn't match configuration entry type for %s.",
+      e.key());
+    if (value == null) {
+      config.remove(e.key());
+    } else {
+      config.put(e.key(), value.toString());
+    }
+    return (T) this;
+  }
+
+  @Override
+  public Iterator<Map.Entry<String, String>> iterator() {
+    return config.entrySet().iterator();
+  }
+
+  private String get(ConfEntry e, Class<?> requestedType) {
+    check(getType(e.dflt()).equals(requestedType), "Invalid type conversion requested for %s.",
+      e.key());
+    return config.get(e.key());
+  }
+
+  private boolean typesMatch(Object test, Object expected) {
+    return getType(test).equals(getType(expected));
+  }
+
+  private Class<?> getType(Object o) {
+    return (o != null) ? o.getClass() : String.class;
+  }
+
+  private void check(boolean test, String message, Object... args) {
+    if (!test) {
+      throw new IllegalArgumentException(String.format(message, args));
+    }
+  }
+
+}

--- a/client-common/src/test/java/com/cloudera/livy/client/common/TestClientConf.java
+++ b/client-common/src/test/java/com/cloudera/livy/client/common/TestClientConf.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.client.common;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class TestClientConf {
+
+  @Test
+  public void testClientConf() {
+    TestConf conf = new TestConf();
+
+    assertEquals("default", conf.get(TestConf.Entry.STRING));
+    assertEquals(false, conf.getBoolean(TestConf.Entry.BOOLEAN));
+    assertEquals(42, conf.getInt(TestConf.Entry.INT));
+    assertEquals(84L, conf.getLong(TestConf.Entry.LONG));
+    assertEquals(168L, conf.getTimeAsMs(TestConf.Entry.TIME));
+
+    try {
+      conf.get(TestConf.Entry.INT);
+      fail("Should have failed to retrieve int as string.");
+    } catch (IllegalArgumentException ie) {
+      // Expected.
+    }
+
+    conf.set(TestConf.Entry.INT, 336);
+    assertEquals(336, conf.getInt(TestConf.Entry.INT));
+
+    try {
+      conf.set(TestConf.Entry.INT, "abcde");
+      fail("Should have failed to set int as string.");
+    } catch (IllegalArgumentException ie) {
+      // Expected.
+    }
+
+    conf.set(TestConf.Entry.BOOLEAN, true);
+    assertEquals(true, conf.getBoolean(TestConf.Entry.BOOLEAN));
+  }
+
+  private static class TestConf extends ClientConf<TestConf> {
+
+    static enum Entry implements ConfEntry {
+      STRING("string", "default"),
+      BOOLEAN("bool", false),
+      INT("int", 42),
+      LONG("long", 84L),
+      TIME("time", "168ms");
+
+      private final String key;
+      private final Object dflt;
+
+      private Entry(String key, Object dflt) {
+        this.key = key;
+        this.dflt = dflt;
+      }
+
+      @Override
+      public String key() { return key; }
+
+      @Override
+      public Object dflt() { return dflt; }
+
+    }
+
+    TestConf() {
+      super(null);
+    }
+
+  }
+
+}

--- a/client-local/src/main/java/com/cloudera/livy/client/local/LocalClient.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/LocalClient.java
@@ -82,7 +82,6 @@ public class LocalClient implements LivyClient {
   private final Rpc driverRpc;
   private final ClientProtocol protocol;
   private volatile boolean isAlive;
-  private final String clientId;
 
   LocalClient(LocalClientFactory factory, LocalConf conf) throws IOException, SparkException {
     this.factory = factory;
@@ -90,7 +89,7 @@ public class LocalClient implements LivyClient {
     this.childIdGenerator = new AtomicInteger();
     this.jobs = Maps.newConcurrentMap();
 
-    clientId = UUID.randomUUID().toString();
+    String clientId = UUID.randomUUID().toString();
     String secret = factory.getServer().createSecret();
     this.driverThread = startDriver(factory.getServer(), clientId, secret);
     this.protocol = new ClientProtocol();
@@ -120,11 +119,6 @@ public class LocalClient implements LivyClient {
         }
     });
     isAlive = true;
-  }
-
-  @Override
-  public String clientId() {
-    return clientId;
   }
 
   @Override
@@ -273,8 +267,8 @@ public class LocalClient implements LivyClient {
         }
         allProps.put(key, e.getValue());
       }
-      allProps.put(LocalConf.SPARK_CONF_PREFIX + CLIENT_ID.key, clientId);
-      allProps.put(LocalConf.SPARK_CONF_PREFIX + CLIENT_SECRET.key, secret);
+      allProps.put(LocalConf.SPARK_CONF_PREFIX + CLIENT_ID.key(), clientId);
+      allProps.put(LocalConf.SPARK_CONF_PREFIX + CLIENT_SECRET.key(), secret);
       allProps.put(DRIVER_OPTS_KEY, driverJavaOpts);
       allProps.put(EXECUTOR_OPTS_KEY, executorJavaOpts);
 
@@ -360,7 +354,7 @@ public class LocalClient implements LivyClient {
       if (livyJars == null) {
         String livyHome = System.getenv("LIVY_HOME");
         Preconditions.checkState(livyHome != null,
-          "Need one of LIVY_HOME or %s set.", LIVY_JARS.key);
+          "Need one of LIVY_HOME or %s set.", LIVY_JARS.key());
 
         File clientJars = new File(livyHome, "client-jars");
         Preconditions.checkState(clientJars.isDirectory(),

--- a/client-local/src/main/java/com/cloudera/livy/client/local/driver/RemoteDriver.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/driver/RemoteDriver.java
@@ -88,9 +88,9 @@ public class RemoteDriver {
       } else if (key.equals("--remote-port")) {
         serverPort = Integer.parseInt(getArg(args, idx));
       } else if (key.equals("--client-id")) {
-        conf.set(LocalConf.SPARK_CONF_PREFIX + CLIENT_ID.key, getArg(args, idx));
+        conf.set(LocalConf.SPARK_CONF_PREFIX + CLIENT_ID.key(), getArg(args, idx));
       } else if (key.equals("--secret")) {
-        conf.set(LocalConf.SPARK_CONF_PREFIX + CLIENT_SECRET.key, getArg(args, idx));
+        conf.set(LocalConf.SPARK_CONF_PREFIX + CLIENT_SECRET.key(), getArg(args, idx));
       } else if (key.equals("--conf")) {
         String[] val = getArg(args, idx).split("[=]", 2);
         conf.set(val[0], val[1]);

--- a/client-local/src/main/java/com/cloudera/livy/client/local/rpc/SaslHandler.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/rpc/SaslHandler.java
@@ -44,7 +44,7 @@ abstract class SaslHandler extends SimpleChannelInboundHandler<Rpc.SaslMessage>
   private boolean hasAuthResponse = false;
 
   protected SaslHandler(LocalConf config) {
-    this.requiresEncryption = Rpc.SASL_AUTH_CONF.equals(config.get(LocalConf.Entry.SASL_QOP.key));
+    this.requiresEncryption = Rpc.SASL_AUTH_CONF.equals(config.get(LocalConf.Entry.SASL_QOP));
     this.LOG = LoggerFactory.getLogger(getClass());
   }
 

--- a/client-local/src/test/java/com/cloudera/livy/client/local/TestSparkClient.java
+++ b/client-local/src/test/java/com/cloudera/livy/client/local/TestSparkClient.java
@@ -69,7 +69,7 @@ public class TestSparkClient {
   private Properties createConf(boolean local) {
     Properties conf = new Properties();
     if (local) {
-      conf.put(CLIENT_IN_PROCESS.key, "true");
+      conf.put(CLIENT_IN_PROCESS.key(), "true");
       conf.put("spark.master", "local");
       conf.put("spark.app.name", "SparkClientSuite Local App");
     } else {
@@ -78,7 +78,7 @@ public class TestSparkClient {
       conf.put("spark.app.name", "SparkClientSuite Remote App");
       conf.put("spark.driver.extraClassPath", classpath);
       conf.put("spark.executor.extraClassPath", classpath);
-      conf.put(LIVY_JARS.key, "");
+      conf.put(LIVY_JARS.key(), "");
     }
 
     return conf;

--- a/client-local/src/test/java/com/cloudera/livy/client/local/rpc/TestRpc.java
+++ b/client-local/src/test/java/com/cloudera/livy/client/local/rpc/TestRpc.java
@@ -55,7 +55,7 @@ public class TestRpc {
   public void setUp() {
     closeables = Lists.newArrayList();
     emptyConfig = new LocalConf(null);
-    emptyConfig.set(RPC_CHANNEL_LOG_LEVEL.key, "DEBUG");
+    emptyConfig.set(RPC_CHANNEL_LOG_LEVEL.key(), "DEBUG");
   }
 
   @After

--- a/spark/src/main/scala/com/cloudera/livy/spark/client/SessionCache.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/client/SessionCache.scala
@@ -83,7 +83,7 @@ class SessionCache extends Logging{
       sparkClient,
       timeout,
       evictionExecutor.schedule(ClientCloser(sparkClient), timeout, TimeUnit.SECONDS))
-    info("Added client with id: " + sparkClient.clientId() + " for sessionId: " + sessionId)
+    info("Added client for sessionId: " + sessionId)
   }
 
   /**


### PR DESCRIPTION
I'll need something like LocalConf for the HTTP client also, so
break the useful parts into an abstract class and modify LocalConf
to inherit from it; the new class does not inherit from Hadoop's
Configuration, so some code needed to be reimplemented.

Also removed "clientId()" from the public API since that is not
really important for users. At least not now.