### PR TITLE
Fix process leak in interactive session test.

### DIFF
--- a/core/src/test/scala/com/cloudera/livy/sessions/BaseInteractiveSessionSpec.scala
+++ b/core/src/test/scala/com/cloudera/livy/sessions/BaseInteractiveSessionSpec.scala
@@ -38,7 +38,7 @@ abstract class BaseInteractiveSessionSpec extends FunSpec with Matchers with Bef
 
   override def afterAll(): Unit = {
     if (session != null) {
-      session.stop()
+      Await.ready(session.stop(), Duration.Inf)
       session = null
     }
     super.afterAll()

--- a/spark/src/main/scala/com/cloudera/livy/spark/interactive/InteractiveWebSession.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/interactive/InteractiveWebSession.scala
@@ -189,7 +189,13 @@ abstract class InteractiveWebSession(val id: Int,
             stop()
           }
         case SessionState.Error(_) | SessionState.Dead(_) | SessionState.Success(_) =>
-          Future.successful(Unit)
+          if (process.isAlive) {
+            Future {
+              process.destroy()
+            }
+          } else {
+            Future.successful(Unit)
+          }
       }
     }
 

--- a/spark/src/test/scala/com/cloudera/livy/spark/interactive/InteractiveSessionProcessSpec.scala
+++ b/spark/src/test/scala/com/cloudera/livy/spark/interactive/InteractiveSessionProcessSpec.scala
@@ -23,11 +23,7 @@ import com.cloudera.livy.sessions.{BaseInteractiveSessionSpec, PySpark}
 import com.cloudera.livy.spark.SparkProcessBuilderFactory
 import org.scalatest.{BeforeAndAfter, FunSpecLike, Matchers}
 
-class InteractiveSessionProcessSpec
-  extends BaseInteractiveSessionSpec
-  with FunSpecLike
-  with Matchers
-  with BeforeAndAfter {
+class InteractiveSessionProcessSpec extends BaseInteractiveSessionSpec {
 
   val livyConf = new LivyConf()
   livyConf.set("livy.repl.driverClassPath", sys.props("java.class.path"))


### PR DESCRIPTION
The session could be in an error state with the underlying process
still alive; need to explicitly kill the process in that case, so
that it doesn't linger around.