### PR TITLE
Replace JsonSupport with a Jackson-based servlet.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,6 +43,16 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
     </dependency>

--- a/core/src/main/scala/com/cloudera/livy/sessions/SessionFactory.scala
+++ b/core/src/main/scala/com/cloudera/livy/sessions/SessionFactory.scala
@@ -18,13 +18,9 @@
 
 package com.cloudera.livy.sessions
 
-import org.json4s.{DefaultFormats, Formats, JValue}
+abstract class SessionFactory[S <: Session, R] {
 
-abstract class SessionFactory[S <: Session] {
-
-  protected implicit def jsonFormats: Formats = DefaultFormats
-
-  def create(id: Int, createRequest: JValue): S
+  def create(id: Int, createRequest: R): S
 
   def close(): Unit = {}
 }

--- a/core/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
+++ b/core/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
@@ -22,7 +22,6 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 import com.cloudera.livy.{LivyConf, Logging}
-import org.json4s.JValue
 
 import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}
@@ -31,7 +30,7 @@ object SessionManager {
   val SESSION_TIMEOUT = "livy.server.session.timeout"
 }
 
-class SessionManager[S <: Session](livyConf: LivyConf, factory: SessionFactory[S])
+class SessionManager[S <: Session, R](livyConf: LivyConf, factory: SessionFactory[S, R])
   extends Logging {
 
   private implicit def executor: ExecutionContext = ExecutionContext.global
@@ -47,7 +46,7 @@ class SessionManager[S <: Session](livyConf: LivyConf, factory: SessionFactory[S
   garbageCollector.setDaemon(true)
   garbageCollector.start()
 
-  def create(createRequest: JValue): S = {
+  def create(createRequest: R): S = {
     val id = _idCounter.getAndIncrement
     val session: S = factory.create(id, createRequest)
 

--- a/core/src/test/scala/com/cloudera/livy/sessions/SessionManagerSpec.scala
+++ b/core/src/test/scala/com/cloudera/livy/sessions/SessionManagerSpec.scala
@@ -35,8 +35,8 @@ class SessionManagerSpec extends FlatSpec with Matchers {
     override def state: SessionState = SessionState.Success(0)
   }
 
-  class MockSessionFactory extends SessionFactory[MockSession] {
-    override def create(id: Int, createRequest: JValue): MockSession = new MockSession(id)
+  class MockSessionFactory extends SessionFactory[MockSession, AnyRef] {
+    override def create(id: Int, createRequest: AnyRef): MockSession = new MockSession(id)
   }
 
   it should "garbage collect old sessions" in {

--- a/server/src/main/scala/com/cloudera/livy/server/JsonServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/JsonServlet.scala
@@ -1,0 +1,129 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.server
+
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
+
+import scala.concurrent.ExecutionContext
+import scala.reflect.ClassTag
+
+import com.fasterxml.jackson.core.JsonParseException
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.scalatra._
+
+/**
+ * An abstract servlet that provides overridden implementations for "post", "put" and "patch"
+ * that can deserialize JSON data directly into user-defined types, without having to go through
+ * a json4s intermediate. Results are also automatically serialized into JSON if the content type
+ * says so.
+ *
+ * Serialization and deserialization are done through Jackson directly, so all Jackson features
+ * are available.
+ */
+abstract class JsonServlet extends ScalatraServlet with FutureSupport {
+
+  override protected implicit def executor: ExecutionContext = ExecutionContext.global
+
+  private lazy val _defaultMapper = new ObjectMapper()
+    .registerModule(com.fasterxml.jackson.module.scala.DefaultScalaModule)
+
+  /**
+   * Override this method if you need a custom Jackson object mapper; the default mapper
+   * has the default configuration, plus the Scala module.
+   */
+  protected def createMapper(): ObjectMapper = _defaultMapper
+
+  protected final val mapper = createMapper()
+
+  error {
+    case e: JsonParseException => BadRequest(e.getMessage)
+  }
+
+  protected def jdelete(t: RouteTransformer*)(action: => Any): Route = {
+    delete(t: _*) {
+      doAction[Unit](request, response, _ => action)
+    }
+  }
+
+  protected def jget(t: RouteTransformer*)(action: => Any): Route = {
+    get(t: _*) {
+      doAction[Unit](request, response, _ => action)
+    }
+  }
+
+  protected def jpatch[T: ClassTag](t: RouteTransformer*)(action: T => Any): Route = {
+    patch(t: _*) {
+      doAction(request, response, action)
+    }
+  }
+
+  protected def jpost[T: ClassTag](t: RouteTransformer*)(action: T => Any): Route = {
+    post(t: _*) {
+      doAction(request, response, action)
+    }
+  }
+
+  protected def jput[T: ClassTag](t: RouteTransformer*)(action: T => Any): Route = {
+    put(t: _*) {
+      doAction[T](request, response, action)
+    }
+  }
+
+  private def doAction[T: ClassTag](
+      req: HttpServletRequest,
+      res: HttpServletResponse,
+      action: T => Any)(implicit klass: ClassTag[T]): Any = {
+    val arg =
+      if (klass.runtimeClass != classOf[Unit]) {
+        mapper.readValue(req.getInputStream(), klass.runtimeClass).asInstanceOf[T]
+      } else {
+        ()
+      }
+
+    toResult(action(arg.asInstanceOf[T]), res)
+  }
+
+  private def isJson(res: HttpServletResponse, headers: Map[String, String] = Map()): Boolean = {
+    val ctypeHeader = "Content-Type"
+    headers.get(ctypeHeader).orElse(Option(res.getHeader(ctypeHeader)))
+      .map(_.startsWith("application/json")).getOrElse(false)
+  }
+
+  private def toResult(obj: Any, res: HttpServletResponse): Any = obj match {
+    case async: AsyncResult =>
+      new AsyncResult {
+        val is = async.is.map(toResult(_, res))
+      }
+    case ActionResult(status, body, headers) if isJson(res, headers) =>
+      ActionResult(status, toJson(body), headers)
+    case body if isJson(res) =>
+      Ok(toJson(body))
+    case other =>
+      other
+  }
+
+  private def toJson(obj: Any): Any = {
+    if (obj != null && obj != ()) {
+      mapper.writeValueAsBytes(obj)
+    } else {
+      null
+    }
+  }
+
+}

--- a/server/src/main/scala/com/cloudera/livy/server/client/ClientSessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/client/ClientSessionServlet.scala
@@ -20,30 +20,20 @@ package com.cloudera.livy.server.client
 
 import java.net.URI
 
-import scala.reflect.ClassTag
-
-import com.fasterxml.jackson.databind.ObjectMapper
-import org.json4s._
-import org.json4s.jackson.JsonMethods
-import org.json4s.jackson.JsonMethods._
-import org.json4s.jackson.Serialization.write
 import org.scalatra._
 
 import com.cloudera.livy.JobHandle
 import com.cloudera.livy.client.common.HttpMessages._
 import com.cloudera.livy.server.SessionServlet
-import com.cloudera.livy.sessions.{SessionManager, SessionState}
+import com.cloudera.livy.sessions.SessionManager
 import com.cloudera.livy.spark.client._
 
-class ClientSessionServlet(sessionManager: SessionManager[ClientSession])
-  extends SessionServlet[ClientSession](sessionManager) {
+class ClientSessionServlet(sessionManager: SessionManager[ClientSession, CreateClientRequest])
+  extends SessionServlet(sessionManager) {
 
-  override protected implicit lazy val jsonFormats: Formats = DefaultFormats ++ Serializers.Formats
-
-  post("/:id/submit-job") {
+  jpost[SerializedJob]("/:id/submit-job") { req =>
     withSession { session =>
       try {
-      val req = extract[SerializedJob]
       require(req.job != null && req.job.length > 0, "no job provided.")
       val jobId = session.submitJob(req.job)
       Created(new JobStatus(jobId, JobHandle.State.SENT, null, null))
@@ -55,80 +45,37 @@ class ClientSessionServlet(sessionManager: SessionManager[ClientSession])
     }
   }
 
-  post("/:id/run-job") {
+  jpost[SerializedJob]("/:id/run-job") { req =>
     withSession { session =>
-      val req = extract[SerializedJob]
       require(req.job != null && req.job.length > 0, "no job provided.")
       val jobId = session.runJob(req.job)
       Created(new JobStatus(jobId, JobHandle.State.SENT, null, null))
     }
   }
 
-  post("/:id/add-jar") {
+  jpost[AddResource]("/:id/add-jar") { req =>
     withSession { lsession =>
-      val uri = new URI(extract[AddResource].uri)
+      val uri = new URI(req.uri)
       doAsync { lsession.addJar(uri) }
     }
   }
 
-  post("/:id/add-file") {
+  jpost[AddResource]("/:id/add-file") { req =>
     withSession { lsession =>
-      val uri = new URI(extract[AddResource].uri)
+      val uri = new URI(req.uri)
       doAsync { lsession.addFile(uri) }
     }
   }
 
-  get("/:id/jobs/:jobid") {
+  jget("/:id/jobs/:jobid") {
     withSession { lsession =>
       val jobId = params("jobid").toLong
       doAsync { Ok(lsession.jobStatus(jobId)) }
     }
   }
 
-  private def extract[T: ClassTag](implicit tag: ClassTag[T]): T = {
-    mapper.readValue(request.body, tag.runtimeClass).asInstanceOf[T]
+  override protected def clientSessionView(session: ClientSession): Any = {
+    new SessionInfo(session.id, session.state.toString)
   }
-
-  override protected def serializeSession(session: ClientSession): JValue = {
-    val view = new SessionInfo(session.id, session.state.toString)
-    parse(write(view))
-  }
-
-}
-
-/**
- * Serializers for the Java messages used for the client protocol. json4s seems to be miffed
- * by the existence of types that can be written in Java, and just refuses to serialize them,
- * or maybe it's Scalatra that is messing things up, but long story short, without this, the
- * Java messages are not serialized. Le sigh.
- */
-private[client] object Serializers extends JsonMethods {
-
-  val Formats: List[CustomSerializer[_]] = List(ClientMessageSerializer, StateSerializer)
-
-  private implicit val jsonFormats: Formats = DefaultFormats ++ List(StateSerializer)
-
-  private def serialize(msg: ClientMessage): JValue = {
-    // This is horribly expensive but json4s makes it pretty much impossible to do anything
-    // else. What a horrible library.
-    parse(write(msg))
-  }
-
-  private case object ClientMessageSerializer extends CustomSerializer[ClientMessage](
-    implicit formats => ( {
-      // We don't need deserialization?
-      PartialFunction.empty
-    }, {
-      case msg: ClientMessage => serialize(msg)
-    })
-  )
-
-  private case object StateSerializer extends CustomSerializer[JobHandle.State](
-    implicit formats => ( {
-      case JString(value) => JobHandle.State.valueOf(value)
-    }, {
-      case state: JobHandle.State => JString(state.name())
-    })
-  )
 
 }

--- a/server/src/test/scala/com/cloudera/livy/server/BaseJsonServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/BaseJsonServletSpec.scala
@@ -1,0 +1,88 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.server
+
+import scala.reflect.ClassTag
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.scalatest.FunSpecLike
+import org.scalatra._
+import org.scalatra.test.scalatest.ScalatraSuite
+
+/**
+ * Base class that enhances ScalatraSuite so that it's easier to test JsonServlet
+ * implementations. Variants of the test methods (get, post, etc) exist with the "j"
+ * prefix; these automatically serialize the body of the request to JSON, and
+ * deserialize the result from JSON.
+ *
+ * In case the response is not JSON, the expected type for the test function should be
+ * `Unit`, and the `response` object should be checked directly.
+ */
+abstract class BaseJsonServletSpec extends ScalatraSuite with FunSpecLike {
+
+  protected val mapper = new ObjectMapper()
+    .registerModule(com.fasterxml.jackson.module.scala.DefaultScalaModule)
+
+  protected val headers: Map[String, String] = Map("Content-Type" -> "application/json")
+
+  protected def jdelete[R: ClassTag](uri: String, expectedStatus: Int = 200)
+      (fn: R => Unit): Unit = {
+    delete(uri, headers = headers)(doTest(expectedStatus, fn))
+  }
+
+  protected def jget[R: ClassTag](uri: String, expectedStatus: Int = 200)
+      (fn: R => Unit): Unit = {
+    get(uri, headers = headers)(doTest(expectedStatus, fn))
+  }
+
+  protected def jpatch[R: ClassTag](uri: String, body: AnyRef, expectedStatus: Int = 200)
+      (fn: R => Unit): Unit = {
+    patch(uri, body = toJson(body), headers = headers)(doTest(expectedStatus, fn))
+  }
+
+  protected def jpost[R: ClassTag](uri: String, body: AnyRef, expectedStatus: Int = 201)
+      (fn: R => Unit): Unit = {
+    post(uri, body = toJson(body), headers = headers)(doTest(expectedStatus, fn))
+  }
+
+  protected def jput[R: ClassTag](uri: String, body: AnyRef, expectedStatus: Int = 200)
+      (fn: R => Unit): Unit = {
+    put(uri, body = toJson(body), headers = headers)(doTest(expectedStatus, fn))
+  }
+
+  private def doTest[R: ClassTag](expectedStatus: Int, fn: R => Unit)
+      (implicit klass: ClassTag[R]): Unit = {
+    status should be (expectedStatus)
+    val result =
+      if (header("Content-Type").startsWith("application/json")) {
+        if (header("Content-Length").toInt > 0) {
+          mapper.readValue(response.inputStream, klass.runtimeClass)
+        } else {
+          null
+        }
+      } else {
+        assert(klass.runtimeClass == classOf[Unit])
+        ()
+      }
+    fn(result.asInstanceOf[R])
+  }
+
+  private def toJson(obj: Any): Array[Byte] = mapper.writeValueAsBytes(obj)
+
+}

--- a/server/src/test/scala/com/cloudera/livy/server/JsonServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/JsonServletSpec.scala
@@ -1,0 +1,132 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.server
+
+import java.nio.charset.StandardCharsets.UTF_8
+import javax.servlet.http.HttpServletResponse._
+
+import org.scalatra._
+
+class JsonServletSpec extends BaseJsonServletSpec {
+
+  addServlet(new TestJsonServlet(), "/*")
+
+  describe("The JSON servlet") {
+
+    it("should serialize result of delete") {
+      jdelete[MethodReturn]("/delete") { result =>
+        assert(result.value === "delete")
+      }
+    }
+
+    it("should serialize result of get") {
+      jget[MethodReturn]("/get") { result =>
+        assert(result.value === "get")
+      }
+    }
+
+    it("should serialize an ActionResult's body") {
+      jpost[MethodReturn]("/post", body = MethodArg("post")) { result =>
+        assert(result.value === "post")
+      }
+    }
+
+    it("should wrap a raw result") {
+      jput[MethodReturn]("/put", body = MethodArg("put")) { result =>
+        assert(result.value === "put")
+      }
+    }
+
+    it("should bypass non-json results") {
+      jpatch[Unit]("/patch", body = MethodArg("patch"), expectedStatus = 404) { _ =>
+        assert(response.body === "patch")
+      }
+    }
+
+    it("should translate JSON errors to BadRequest") {
+      post("/post", body = "abcde".getBytes(UTF_8), headers = headers) {
+        assert(status === SC_BAD_REQUEST)
+      }
+    }
+
+    it("should respect user-installed error handlers") {
+      post("/error", headers = headers) {
+        assert(status === SC_SERVICE_UNAVAILABLE)
+        assert(response.body === "error")
+      }
+    }
+
+    it("should handle empty return values") {
+      jget[MethodReturn]("/empty") { result =>
+        assert(result == null)
+      }
+    }
+
+  }
+
+}
+
+private case class MethodArg(value: String)
+
+private case class MethodReturn(value: String)
+
+private class TestJsonServlet extends JsonServlet {
+
+  before() {
+    contentType = "application/json"
+  }
+
+  jdelete("/delete") {
+    Ok(MethodReturn("delete"))
+  }
+
+  jget("/get") {
+    Ok(MethodReturn("get"))
+  }
+
+  jpost[MethodArg]("/post") { arg =>
+    Created(MethodReturn(arg.value))
+  }
+
+  jput[MethodArg]("/put") { arg =>
+    MethodReturn(arg.value)
+  }
+
+  jpatch[MethodArg]("/patch") { arg =>
+    contentType = "text/plain"
+    NotFound(arg.value)
+  }
+
+  jget("/empty") {
+    ()
+  }
+
+  post("/error") {
+    throw new IllegalStateException("error")
+  }
+
+  // Install an error handler to make sure the parent's still work.
+  error {
+    case e: IllegalStateException =>
+      contentType = "text/plain"
+      ServiceUnavailable(e.getMessage())
+  }
+
+}
+

--- a/server/src/test/scala/com/cloudera/livy/server/client/ClientServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/client/ClientServletSpec.scala
@@ -19,15 +19,11 @@
 package com.cloudera.livy.server.client
 
 import java.nio.ByteBuffer
-import java.util.{HashMap, Map => JMap}
+import java.util.HashMap
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import org.json4s._
-import org.json4s.jackson.JsonMethods._
-import org.json4s.jackson.Serialization.write
 import org.scalatest.concurrent.Eventually._
 
 import com.cloudera.livy.{Job, JobContext}
@@ -36,13 +32,11 @@ import com.cloudera.livy.client.common.HttpMessages._
 import com.cloudera.livy.server.BaseSessionServletSpec
 import com.cloudera.livy.spark.client._
 
-class ClientServletSpec extends BaseSessionServletSpec[ClientSession] {
+class ClientServletSpec extends BaseSessionServletSpec[ClientSession, CreateClientRequest] {
 
   override def sessionFactory = new ClientSessionFactory()
   override def servlet = new ClientSessionServlet(sessionManager)
-  override protected implicit lazy val jsonFormats: Formats = DefaultFormats ++ Serializers.Formats
 
-  private val mapper = new ObjectMapper()
   private var sessionId: Int = -1
 
   def withSessionId(desc: String)(fn: (Int) => Unit): Unit = {
@@ -62,17 +56,17 @@ class ClientServletSpec extends BaseSessionServletSpec[ClientSession] {
       conf.put("spark.driver.extraClassPath", classpath)
       conf.put("spark.executor.extraClassPath", classpath)
 
-      postJson("/", new CreateClientRequest(10000L, conf)) { data =>
+      jpost[SessionInfo]("/", new CreateClientRequest(10000L, conf)) { data =>
         header("Location") should equal("/0")
-        data \ "id" should equal (JInt(0))
-        sessionId = (data \ "id").extract[Int]
+        data.id should equal (0)
+        sessionId = data.id
       }
     }
 
     it("should list existing sessions") {
-      getJson("/") { data =>
-        (data \ "sessions") match {
-          case JArray(contents) => contents.size should equal (1)
+      jget[Map[String, Any]]("/") { data =>
+        data("sessions") match {
+          case contents: Seq[_] => contents.size should equal (1)
           case _ => fail("Response is not an array.")
         }
       }
@@ -83,34 +77,28 @@ class ClientServletSpec extends BaseSessionServletSpec[ClientSession] {
     withSessionId("should handle synchronous jobs") { testJobSubmission(_, true) }
 
     withSessionId("should tear down sessions") { id =>
-      deleteJson(s"/$id") { data =>
-        // TODO: check data when it exists.
+      jdelete[Map[String, Any]](s"/$id") { data =>
+        data should equal (Map("msg" -> "deleted"))
       }
-      getJson("/") { data =>
-        (data \ "sessions") match {
-          case JArray(contents) => contents.size should equal (0)
+      jget[Map[String, Any]]("/") { data =>
+        data("sessions") match {
+          case contents: Seq[_] => contents.size should equal (0)
           case _ => fail("Response is not an array.")
         }
       }
     }
-
   }
-
-  // Because json4s does not know how to serialize obscure types such as JAVA MAPS AND ENUMS, we
-  // override the base class so that we use a sane library for serialization.
-  override protected def toJson(msg: AnyRef): String = mapper.writeValueAsString(msg)
 
   private def testJobSubmission(sid: Int, sync: Boolean): Unit = {
     val ser = new Serializer()
     val job = BufferUtils.toByteArray(ser.serialize(new TestJob()))
     val route = if (sync) s"/$sid/submit-job" else s"/$sid/run-job"
     var jobId: Long = -1L
-    postJson(route, new SerializedJob(job)) { data =>
-      jobId = data.extract[JobStatus].id
+    jpost[JobStatus](route, new SerializedJob(job)) { data =>
+      jobId = data.id
     }
     eventually(timeout(1 minute), interval(100 millis)) {
-      getJson(s"/$sid/jobs/$jobId") { statusData =>
-        val status = statusData.extract[JobStatus]
+      jget[JobStatus](s"/$sid/jobs/$jobId") { status =>
         status.id should be (jobId)
         val result = ser.deserialize(ByteBuffer.wrap(status.result))
         result should be (42)

--- a/spark/src/main/scala/com/cloudera/livy/spark/SparkManager.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/SparkManager.scala
@@ -23,8 +23,8 @@ import com.cloudera.livy.LivyConf.{Process, Yarn}
 import com.cloudera.livy.sessions.SessionManager
 import com.cloudera.livy.sessions.batch.BatchSession
 import com.cloudera.livy.sessions.interactive.InteractiveSession
-import com.cloudera.livy.spark.batch.{BatchSessionProcessFactory, BatchSessionYarnFactory}
-import com.cloudera.livy.spark.interactive.{InteractiveSessionProcessFactory, InteractiveSessionYarnFactory}
+import com.cloudera.livy.spark.batch._
+import com.cloudera.livy.spark.interactive._
 import com.cloudera.livy.yarn.Client
 
 import scala.io.Source
@@ -61,9 +61,9 @@ object SparkManager {
 }
 
 trait SparkManager {
-  def batchManager: SessionManager[BatchSession]
+  def batchManager: SessionManager[BatchSession, CreateBatchRequest]
 
-  def interactiveManager: SessionManager[InteractiveSession]
+  def interactiveManager: SessionManager[InteractiveSession, CreateInteractiveRequest]
 
   def shutdown()
 }

--- a/spark/src/main/scala/com/cloudera/livy/spark/batch/BatchSessionFactory.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/batch/BatchSessionFactory.scala
@@ -26,9 +26,8 @@ import com.cloudera.livy.spark.SparkProcessBuilder.RelativePath
 import com.cloudera.livy.spark.{SparkProcess, SparkProcessBuilder, SparkProcessBuilderFactory}
 import org.json4s.JValue
 
-abstract class BatchSessionFactory(factory: SparkProcessBuilderFactory) extends SessionFactory[BatchSession] {
-  override def create(id: Int, createRequest: JValue) =
-    create(id, createRequest.extract[CreateBatchRequest])
+abstract class BatchSessionFactory(factory: SparkProcessBuilderFactory)
+  extends SessionFactory[BatchSession, CreateBatchRequest] {
 
   def create(id: Int, request: CreateBatchRequest): BatchSession = {
     val builder = sparkBuilder(request)

--- a/spark/src/main/scala/com/cloudera/livy/spark/client/ClientSessionFactory.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/client/ClientSessionFactory.scala
@@ -25,13 +25,9 @@ import org.json4s.{JObject, JValue}
 import com.cloudera.livy.client.common.HttpMessages._
 import com.cloudera.livy.sessions.SessionFactory
 
-class ClientSessionFactory extends SessionFactory[ClientSession]{
+class ClientSessionFactory extends SessionFactory[ClientSession, CreateClientRequest]{
 
-  override def create(id: Int, req: JValue): ClientSession = {
-    // json4s doesn't like Java types, so we can't read CreateClientRequest directly; instead,
-    // use the ugly hack below.
-    val timeout = (req \ "timeout").extract[Long]
-    val conf = (req \ "conf").extract[Map[String, String]]
-    new ClientSession(id, new CreateClientRequest(timeout, conf.asJava))
+  override def create(id: Int, request: CreateClientRequest): ClientSession = {
+    new ClientSession(id, request)
   }
 }

--- a/spark/src/main/scala/com/cloudera/livy/spark/interactive/InteractiveSessionFactory.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/interactive/InteractiveSessionFactory.scala
@@ -25,11 +25,10 @@ import java.nio.file.{Paths, Files}
 import scala.collection.JavaConverters._
 
 import com.cloudera.livy.sessions.interactive.InteractiveSession
-import com.cloudera.livy.sessions.{PySpark, SessionFactory, SessionKindSerializer}
+import com.cloudera.livy.sessions.{PySpark, SessionFactory}
 import com.cloudera.livy.spark.SparkProcessBuilder.{AbsolutePath, RelativePath}
 import com.cloudera.livy.spark.{SparkProcess, SparkProcessBuilder, SparkProcessBuilderFactory}
 import com.cloudera.livy.{LivyConf, Utils}
-import org.json4s.{DefaultFormats, Formats, JValue}
 
 object InteractiveSessionFactory {
   val LivyReplDriverClassPath = "livy.repl.driverClassPath"
@@ -43,14 +42,9 @@ object InteractiveSessionFactory {
 }
 
 abstract class InteractiveSessionFactory(processFactory: SparkProcessBuilderFactory)
-  extends SessionFactory[InteractiveSession] {
+  extends SessionFactory[InteractiveSession, CreateInteractiveRequest] {
 
   import InteractiveSessionFactory._
-
-  override protected implicit def jsonFormats: Formats = DefaultFormats ++ List(SessionKindSerializer)
-
-  override def create(id: Int, createRequest: JValue) =
-    create(id, createRequest.extract[CreateInteractiveRequest])
 
   def create(id: Int, request: CreateInteractiveRequest): InteractiveSession = {
     val builder = sparkBuilder(id, request)


### PR DESCRIPTION
I don't like json4s; it makes it hard to work with proper types,
and it doesn't understand Java types. This change replaces Scalatra's
JsonSupport, which is based on json4s, with a new 'JsonServlet', which
is based on Jackson.

The new servlet provides routing methods that give the handlers access
to the deserialized type directly, without the need to interact with
Jackson at all; just define the expected type and the servlet handles
the rest.

A corresponding base test class was added to help with writing tests
for these new methods.

As for the existing code, a few changes had to be made:

- The session class hierarchy had to be modified to take a new
  type argument (the Scala/Java type of the request object, so
  that SessionServlet can automatically deserialize it). Methods
  that depended on json4s APIs were modified accordingly.

- The custom serializer for Kind was converted to a Jackson module.

- The json4s Jackson module is still used by the interactive session
  servlet; I added a new unit tests to make sure it's doing what I
  hope is the right thing, but given the previous complete lack of
  tests for that part of the code, it's hard to tell.

In the process, the hacks to be able to use Java types in the client
session backend were completely removed.