### PR TITLE
Automatically load default configuration from the classpath.

### DIFF
--- a/api/src/main/java/com/cloudera/livy/LivyClientBuilder.java
+++ b/api/src/main/java/com/cloudera/livy/LivyClientBuilder.java
@@ -17,29 +17,71 @@
 
 package com.cloudera.livy;
 
+import java.io.InputStreamReader;
+import java.io.IOException;
+import java.io.Reader;
 import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.Map;
 import java.util.Properties;
 import java.util.ServiceLoader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * A builder for Livy clients.
  */
 public final class LivyClientBuilder {
 
+  public static final String LIVY_URI_KEY = "livy.uri";
+
   private static final Logger LOG = Logger.getLogger(LivyClientBuilder.class.getName());
 
-  private final URI uri;
   private final Properties config;
 
-  public LivyClientBuilder(URI uri) {
-    if (uri == null) {
-      throw new IllegalArgumentException("URI must be provided.");
-    }
-    this.uri = uri;
+  /**
+   * Creates a new builder that will automatically load the default Livy and Spark configuration
+   * from the classpath.
+   */
+  public LivyClientBuilder() throws IOException {
+    this(true);
+  }
+
+  /**
+   * Creates a new builder that will optionally load the default Livy and Spark configuration
+   * from the classpath.
+   *
+   * Livy client configuration is stored in a file called "livy-client.conf", and Spark client
+   * configuration is stored in a file called "spark-defaults.conf", both in the root of the
+   * application's classpath. Livy configuration takes precedence over Spark's (in case
+   * configuration entries are duplicated), and configuration set in this builder object will
+   * override the values in those files.
+   */
+  public LivyClientBuilder(boolean loadDefaults) throws IOException {
     this.config = new Properties();
+
+    if (loadDefaults) {
+      String[] confFiles = { "spark-defaults.conf", "livy-client.conf" };
+
+      for (String file : confFiles) {
+        URL url = classLoader().getResource(file);
+        if (url != null) {
+          Reader r = new InputStreamReader(url.openStream(), UTF_8);
+          try {
+            config.load(r);
+          } finally {
+            r.close();
+          }
+        }
+      }
+    }
+  }
+
+  public LivyClientBuilder setURI(URI uri) {
+    config.setProperty(LIVY_URI_KEY, uri.toString());
+    return this;
   }
 
   public LivyClientBuilder setConf(String key, String value) {
@@ -57,21 +99,21 @@ public final class LivyClientBuilder {
     return this;
   }
 
-  public LivyClientBuilder setIfMissing(String key, String value) {
-    if (!config.containsKey(key)) {
-      setConf(key, value);
-    }
-    return this;
-  }
-
   public LivyClient build() {
-    ClassLoader cl = Thread.currentThread().getContextClassLoader();
-    if (cl == null) {
-      cl = getClass().getClassLoader();
+    String uriStr = config.getProperty(LIVY_URI_KEY);
+    if (uriStr == null) {
+      throw new IllegalArgumentException("URI must be provided.");
+    }
+    URI uri;
+    try {
+      uri = new URI(uriStr);
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException("Invalid URI.", e);
     }
 
     LivyClient client = null;
-    ServiceLoader<LivyClientFactory> loader = ServiceLoader.load(LivyClientFactory.class, cl);
+    ServiceLoader<LivyClientFactory> loader = ServiceLoader.load(LivyClientFactory.class,
+      classLoader());
     if (!loader.iterator().hasNext()) {
       throw new IllegalStateException("No LivyClientFactory implementation was found.");
     }
@@ -99,6 +141,14 @@ public final class LivyClientBuilder {
         "URI '%s' is not supported by any registered client factories.", uri), error);
     }
     return client;
+  }
+
+  private ClassLoader classLoader() {
+    ClassLoader cl = Thread.currentThread().getContextClassLoader();
+    if (cl == null) {
+      cl = getClass().getClassLoader();
+    }
+    return cl;
   }
 
 }

--- a/api/src/test/java/com/cloudera/livy/TestLivyClientBuilder.java
+++ b/api/src/test/java/com/cloudera/livy/TestLivyClientBuilder.java
@@ -32,7 +32,8 @@ public class TestLivyClientBuilder {
     props.setProperty("prop3", "prop3");
 
     TestClientFactory.Client client = (TestClientFactory.Client)
-      new LivyClientBuilder(new URI("match"))
+      new LivyClientBuilder(false)
+        .setURI(new URI("match"))
         .setConf("prop1", "prop1")
         .setConf("prop2", "prop2")
         .setAll(props)
@@ -45,23 +46,30 @@ public class TestLivyClientBuilder {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testMissingUri() {
-    new LivyClientBuilder(null);
+  public void testMissingUri() throws Exception {
+    new LivyClientBuilder(false).build();
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testMismatch() throws Exception {
-    assertNull(new LivyClientBuilder(new URI("mismatch")).build());
+    assertNull(new LivyClientBuilder(false).setURI(new URI("mismatch")).build());
   }
 
   @Test
   public void testFactoryError() throws Exception {
     try {
-      assertNull(new LivyClientBuilder(new URI("error")).build());
+      assertNull(new LivyClientBuilder(false).setURI(new URI("error")).build());
     } catch (IllegalArgumentException e) {
       assertNotNull(e.getCause());
       assertTrue(e.getCause() instanceof IllegalStateException);
     }
+  }
+
+  @Test
+  public void testDefaultConfig() throws Exception {
+    TestClientFactory.Client client = (TestClientFactory.Client)
+      new LivyClientBuilder().build();
+    assertEquals("override", client.config.getProperty("spark.config"));
   }
 
 }

--- a/api/src/test/resources/livy-client.conf
+++ b/api/src/test/resources/livy-client.conf
@@ -1,0 +1,2 @@
+livy.uri=match
+spark.config=override

--- a/api/src/test/resources/spark-defaults.conf
+++ b/api/src/test/resources/spark-defaults.conf
@@ -1,0 +1,1 @@
+spark.config=default

--- a/client-http/src/test/scala/com/cloudera/livy/client/http/HttpClientSpec.scala
+++ b/client-http/src/test/scala/com/cloudera/livy/client/http/HttpClientSpec.scala
@@ -88,7 +88,7 @@ class HttpClientSpec extends FunSpecLike with BeforeAndAfterAll {
       // WebServer does this internally instad of respecting "0.0.0.0", so try to use the same
       // address.
       val uri = s"http://${InetAddress.getLocalHost.getHostAddress}:${server.port}/"
-      client = new LivyClientBuilder(new URI(uri)).build()
+      client = new LivyClientBuilder(false).setURI(new URI(uri)).build()
     }
 
     withClient("should run and monitor asynchronous jobs") {

--- a/client-local/src/main/java/com/cloudera/livy/client/local/LocalConf.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/LocalConf.java
@@ -36,13 +36,9 @@ import com.cloudera.livy.client.common.ClientConf;
 
 public class LocalConf extends ClientConf<LocalConf> {
 
-  private static final Logger LOG = LoggerFactory.getLogger(LocalConf.class);
+  public static final String SPARK_CONF_PREFIX = "spark.";
 
-  /**
-   * Prefix for Livy configurations embedded in SparkConf properties, since SparkConf
-   * disallows anything that does not start with "spark.".
-   */
-  public static final String SPARK_CONF_PREFIX = "spark.__livy__.";
+  private static final Logger LOG = LoggerFactory.getLogger(LocalConf.class);
 
   public static enum Entry implements ConfEntry {
     CLIENT_ID("client.auth.id", null),

--- a/client-local/src/test/java/com/cloudera/livy/client/local/TestSparkClient.java
+++ b/client-local/src/test/java/com/cloudera/livy/client/local/TestSparkClient.java
@@ -364,7 +364,7 @@ public class TestSparkClient {
     LivyClient client = null;
     try {
       test.config(conf);
-      client = new LivyClientBuilder(new URI("local:spark"))
+      client = new LivyClientBuilder(false).setURI(new URI("local:spark"))
         .setAll(conf)
         .build();
       test.call(client);

--- a/server/src/test/scala/com/cloudera/livy/server/client/ClientServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/client/ClientServletSpec.scala
@@ -57,7 +57,7 @@ class ClientServletSpec extends BaseSessionServletSpec[ClientSession] {
     it("should create client sessions") {
       val classpath = sys.props("java.class.path")
       val conf = new HashMap[String, String]
-      conf.put("master", "local")
+      conf.put("spark.master", "local")
       conf.put("livy.local.jars", "")
       conf.put("spark.driver.extraClassPath", classpath)
       conf.put("spark.executor.extraClassPath", classpath)

--- a/spark/src/main/scala/com/cloudera/livy/spark/client/ClientSession.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/client/ClientSession.scala
@@ -27,8 +27,6 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
-import org.apache.spark.SparkConf
-
 import com.cloudera.livy.{LivyClientBuilder, Logging}
 import com.cloudera.livy.client.common.HttpMessages._
 import com.cloudera.livy.client.local.LocalClient
@@ -44,12 +42,11 @@ class ClientSession(val sessionId: Int, createRequest: CreateClientRequest)
 
   private val client = {
     info("Creating LivyClient for sessionId: " + sessionId)
-    val builder = new LivyClientBuilder(new URI("local:spark"))
-    new SparkConf(true).getAll.foreach { case (k, v) => builder.setConf(k, v) }
-    builder
+    new LivyClientBuilder()
+      .setConf("spark.master", "yarn-cluster")
       .setAll(createRequest.conf)
+      .setURI(new URI("local:spark"))
       .setConf("livy.client.sessionId", sessionId.toString)
-      .setIfMissing("spark.master", "yarn-cluster")
       .build()
   }.asInstanceOf[LocalClient]
 


### PR DESCRIPTION
To make it easier to manage client configurations, allow LivyClientBuilder
to load configuration from files present in the classpath, mimicking what
other Hadoop APIs also do. The class will look for two files (livy-client.conf
and spark-defaults.conf) and load their contents if they're present.

On the server side, the ClientSession implementation was changed to
use this instead of trying to load Spark configuration from the system
properties. This should allow server-specific defaults to be configured
while allowing clients to override individual configs using the
session create request.

In the client-local implementation, I broke Spark and Livy configurations
into two separate files, to (arguably) simplify the code a bit. This is
not strictly related to the client configs change; but I also changed the
fact that client-local was loading spark-defaults.conf on its own, and
that's not needed anymore.