### PR TITLE
Fixed server and repl to quit if they fail to bind ports.

### DIFF
--- a/repl/src/main/scala/com/cloudera/livy/repl/Main.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/Main.scala
@@ -71,9 +71,9 @@ object Main extends Logging {
     server.context.setInitParameter(SESSION_KIND, session_kind)
     callbackUrl.foreach(server.context.setInitParameter(CALLBACK_URL, _))
 
-    server.start()
-
     try {
+      server.start()
+
       val replUrl = s"http://${server.host}:${server.port}"
       System.setProperty("livy.repl.url", replUrl)
 
@@ -81,8 +81,8 @@ object Main extends Logging {
       Console.flush()
 
       server.join()
-      server.stop()
     } finally {
+      server.stop()
       // Make sure to close all our outstanding http requests.
       Http.shutdown()
     }

--- a/server/src/main/scala/com/cloudera/livy/server/Main.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/Main.scala
@@ -55,14 +55,15 @@ object Main {
     server.context.setInitParameter(ScalatraListener.LifeCycleKey, classOf[ScalatraBootstrap].getCanonicalName)
     server.context.addEventListener(new ScalatraListener)
 
-    server.start()
-
     try {
+      server.start()
+
       if (!sys.props.contains("livy.server.serverUrl")) {
         sys.props("livy.server.serverUrl") = f"http://${server.host}:${server.port}"
       }
-    } finally {
+
       server.join()
+    } finally {
       server.stop()
 
       // Make sure to close all our outstanding http requests.


### PR DESCRIPTION
server.start() will throw an exception when it fails to bind port. It also starts some non-daemon thread even if it throws.
Without calling server.stop(), those non-daemon threads will block JVM shutdown.