### PR TITLE
LIVY-53. Implement job cancellation, Spark job monitoring in http client.

### DIFF
--- a/client-common/src/main/java/com/cloudera/livy/client/common/HttpMessages.java
+++ b/client-common/src/main/java/com/cloudera/livy/client/common/HttpMessages.java
@@ -18,6 +18,7 @@
 
 package com.cloudera.livy.client.common;
 
+import java.util.List;
 import java.util.Map;
 
 import com.cloudera.livy.JobHandle.State;
@@ -102,11 +103,14 @@ public class HttpMessages {
     public final State state;
     public final byte[] result;
     public final String error;
+    public final List<Integer> newSparkJobs;
 
-    public JobStatus(long id, State state, byte[] result, String error) {
+    public JobStatus(long id, State state, byte[] result, String error,
+        List<Integer> newSparkJobs) {
       this.id = id;
       this.state = state;
       this.error = error;
+      this.newSparkJobs = newSparkJobs;
 
       // json4s, at least, seems confused about whether a "null" in the JSON payload should
       // become a null array or a byte array with length 0. Since there shouldn't be any
@@ -123,7 +127,7 @@ public class HttpMessages {
     }
 
     private JobStatus() {
-      this(-1, null, null, null);
+      this(-1, null, null, null, null);
     }
 
   }

--- a/client-http/src/main/java/com/cloudera/livy/client/http/HttpClient.java
+++ b/client-http/src/main/java/com/cloudera/livy/client/http/HttpClient.java
@@ -39,7 +39,6 @@ import static com.cloudera.livy.client.http.HttpConf.Entry.*;
 
 /**
  * What is currently missing:
- * - cancel jobs
  * - monitoring of spark job IDs launched by jobs
  */
 class HttpClient implements LivyClient {
@@ -160,8 +159,8 @@ class HttpClient implements LivyClient {
 
   private <T> JobHandleImpl<T> sendJob(final String command, Job<T> job) {
     final ByteBuffer serializedJob = serializer.serialize(job);
-    JobHandleImpl<T> handle = new JobHandleImpl<T>(config, conn, executor, serializer);
-    handle.start(sessionId, command, serializedJob);
+    JobHandleImpl<T> handle = new JobHandleImpl<T>(config, conn, sessionId, executor, serializer);
+    handle.start(command, serializedJob);
     return handle;
   }
 

--- a/client-local/src/main/java/com/cloudera/livy/client/local/BypassJobStatus.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/BypassJobStatus.java
@@ -17,6 +17,8 @@
 
 package com.cloudera.livy.client.local;
 
+import java.util.List;
+
 import com.google.common.base.Throwables;
 
 import com.cloudera.livy.Job;
@@ -30,17 +32,19 @@ public class BypassJobStatus {
   public final byte[] result;
   public final String error;
   public final MetricsCollection metrics;
+  public final List<Integer> newSparkJobs;
 
   public BypassJobStatus(JobHandle.State state, byte[] result, String error,
-      MetricsCollection metrics) {
+      MetricsCollection metrics, List<Integer> newSparkJobs) {
     this.state = state;
     this.result = result;
     this.error = error;
     this.metrics = metrics;
+    this.newSparkJobs = newSparkJobs;
   }
 
   BypassJobStatus() {
-    this(null, null, null, null);
+    this(null, null, null, null, null);
   }
 
 }

--- a/client-local/src/main/java/com/cloudera/livy/client/local/LocalClient.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/LocalClient.java
@@ -188,7 +188,7 @@ public class LocalClient implements LivyClient {
     return protocol.getBypassJobStatus(id);
   }
 
-  void cancel(String jobId) {
+  public void cancel(String jobId) {
     protocol.cancel(jobId);
   }
 

--- a/client-local/src/main/java/com/cloudera/livy/client/local/driver/JobWrapper.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/driver/JobWrapper.java
@@ -122,6 +122,10 @@ class JobWrapper<T> implements Callable<Void> {
     return false;
   }
 
+  void recordNewJob(int sparkJobId) {
+    driver.protocol.jobSubmitted(jobId, sparkJobId);
+  }
+
   void updateMetrics(int sparkJobId, int stageId, long taskId, Metrics metrics) {
     driver.protocol.sendMetrics(jobId, sparkJobId, stageId, taskId, metrics);
   }

--- a/server/src/main/scala/com/cloudera/livy/server/client/ClientSessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/client/ClientSessionServlet.scala
@@ -40,7 +40,7 @@ class ClientSessionServlet(sessionManager: SessionManager[ClientSession, CreateC
       try {
       require(req.job != null && req.job.length > 0, "no job provided.")
       val jobId = session.submitJob(req.job)
-      Created(new JobStatus(jobId, JobHandle.State.SENT, null, null))
+      Created(new JobStatus(jobId, JobHandle.State.SENT, null, null, null))
       } catch {
         case e: Throwable =>
           e.printStackTrace()
@@ -53,7 +53,7 @@ class ClientSessionServlet(sessionManager: SessionManager[ClientSession, CreateC
     withSession { session =>
       require(req.job != null && req.job.length > 0, "no job provided.")
       val jobId = session.runJob(req.job)
-      Created(new JobStatus(jobId, JobHandle.State.SENT, null, null))
+      Created(new JobStatus(jobId, JobHandle.State.SENT, null, null, null))
     }
   }
 
@@ -105,6 +105,13 @@ class ClientSessionServlet(sessionManager: SessionManager[ClientSession, CreateC
     withSession { lsession =>
       val jobId = params("jobid").toLong
       doAsync { Ok(lsession.jobStatus(jobId)) }
+    }
+  }
+
+  jpost[Unit]("/:id/jobs/:jobid/cancel") { _ =>
+    withSession { lsession =>
+      val jobId = params("jobid").toLong
+      doAsync { lsession.cancel(jobId) }
     }
   }
 

--- a/spark/src/main/scala/com/cloudera/livy/spark/client/ClientSession.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/client/ClientSession.scala
@@ -96,7 +96,11 @@ class ClientSession(val sessionId: Int, createRequest: CreateClientRequest, livy
     val clientJobId = operations(id)
     // TODO: don't block indefinitely?
     val status = client.getBypassJobStatus(clientJobId).get()
-    new JobStatus(id, status.state, status.result, status.error)
+    new JobStatus(id, status.state, status.result, status.error, status.newSparkJobs)
+  }
+
+  def cancel(id: Long): Unit = {
+    operations.remove(id).foreach { client.cancel }
   }
 
   private def copyResourceToHDFS(dataStream: InputStream, name: String): URI = {


### PR DESCRIPTION
These two features were missing from the HTTP client. Some changes
were made to the local client implementation to send diffs of the
Spark jobs being monitored back to the client; previously, only the
first job started by Spark would be reported.