### PR TITLE
Add style checker for copyright header.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -28,6 +28,10 @@
   <version>0.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
+  <properties>
+    <copyright.header>${asf.copyright.header}</copyright.header>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.spark</groupId>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -24,7 +24,11 @@
 
   <property name="severity" value="error"/>
 
-  <property name="fileExtensions" value="java, properties, xml"/>
+  <property name="fileExtensions" value="java"/>
+
+  <module name="Header">
+    <property name="headerFile" value="{{HEADER_FILE}}"/>
+  </module>
 
   <module name="SuppressionFilter">
     <property name="file" value="checkstyle-suppressions.xml"/>

--- a/client-common/src/main/java/com/cloudera/livy/client/common/AbstractJobHandle.java
+++ b/client-common/src/main/java/com/cloudera/livy/client/common/AbstractJobHandle.java
@@ -1,12 +1,13 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/client-local/pom.xml
+++ b/client-local/pom.xml
@@ -29,6 +29,10 @@
   <version>0.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
+  <properties>
+    <copyright.header>${asf.copyright.header}</copyright.header>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.cloudera.livy</groupId>

--- a/client-local/src/main/java/com/cloudera/livy/client/local/LocalConf.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/LocalConf.java
@@ -1,21 +1,20 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package com.cloudera.livy.client.local;
 
 import java.io.IOException;

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,48 @@
     <minJavaVersion>1.7</minJavaVersion>
     <maxJavaVersion>1.8</maxJavaVersion>
     <test.redirectToFile>true</test.redirectToFile>
+    <execution.root>${user.dir}</execution.root>
+    <!--
+      Properties for the copyright header style checks. Modules that use the ASF header
+      should override the "copyright.header" property.
+    -->
+
+    <asf.copyright.header><![CDATA[/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */]]></asf.copyright.header>
+
+    <cloudera.copyright.header><![CDATA[/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */]]></cloudera.copyright.header>
+
+    <copyright.header>${cloudera.copyright.header}</copyright.header>
 
     <MaxPermGen>512m</MaxPermGen>
     <CodeCacheSize>512m</CodeCacheSize>
@@ -709,6 +751,33 @@
               </target>
             </configuration>
           </execution>
+          <!--
+            Copy the template scalastyle / checkstyle configuration and replace the copyright
+            header.
+          -->
+          <execution>
+            <id>setup-style-checker</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <copy file="${execution.root}/scalastyle.xml"
+                  tofile="${project.build.directory}/scalastyle.xml" />
+                <replace file="${project.build.directory}/scalastyle.xml"
+                  token="{{COPYRIGHT_HEADER}}"
+                  value="${copyright.header}" />
+                <copy file="${execution.root}/checkstyle.xml"
+                  tofile="${project.build.directory}/checkstyle.xml" />
+                <echo file="${project.build.directory}/checkstyle.header"
+                  message="${copyright.header}" />
+                <replace file="${project.build.directory}/checkstyle.xml"
+                  token="{{HEADER_FILE}}"
+                  value="${project.build.directory}/checkstyle.header" />
+              </target>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
 
@@ -723,7 +792,7 @@
           <failOnWarning>false</failOnWarning>
           <sourceDirectory>${basedir}/src/main/scala</sourceDirectory>
           <testSourceDirectory>${basedir}/src/test/scala</testSourceDirectory>
-          <configLocation>scalastyle.xml</configLocation>
+          <configLocation>${project.build.directory}/scalastyle.xml</configLocation>
           <outputFile>${basedir}/target/scalastyle-output.xml</outputFile>
           <inputEncoding>${project.build.sourceEncoding}</inputEncoding>
           <outputEncoding>${project.reporting.outputEncoding}</outputEncoding>
@@ -748,7 +817,7 @@
           <failOnWarning>false</failOnWarning>
           <sourceDirectory>${basedir}/src/main/java</sourceDirectory>
           <testSourceDirectory>${basedir}/src/test/java</testSourceDirectory>
-          <configLocation>checkstyle.xml</configLocation>
+          <configLocation>${project.build.directory}/checkstyle.xml</configLocation>
           <outputFile>${basedir}/target/checkstyle-output.xml</outputFile>
           <inputEncoding>${project.build.sourceEncoding}</inputEncoding>
           <outputEncoding>${project.reporting.outputEncoding}</outputEncoding>

--- a/scalastyle.xml
+++ b/scalastyle.xml
@@ -17,6 +17,12 @@
   ~ limitations under the License.
 -->
 <scalastyle>
+  <check level="error" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
+    <parameters>
+      <parameter name="header"><![CDATA[{{COPYRIGHT_HEADER}}]]></parameter>
+    </parameters>
+  </check>
+
   <check level="error" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
 
   <check level="error" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>

--- a/spark/src/main/scala/com/cloudera/livy/spark/SparkProcess.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/SparkProcess.scala
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cloudera.livy.spark
 
 import com.cloudera.livy.LineBufferedProcess


### PR DESCRIPTION
Because we have different headers in different modules, some hackery
is needed to pre-process the style checker configuration. And because
maven makes it oh so impossible to figure out the root dir of the
project, this change requires that maven is always executed from the
top-level project directory (otherwise things will fail).