### PR TITLE
LIVY-61. Simplify LivyConf by extending ClientConf.

### DIFF
--- a/client-common/src/main/java/com/cloudera/livy/client/common/ClientConf.java
+++ b/client-common/src/main/java/com/cloudera/livy/client/common/ClientConf.java
@@ -22,6 +22,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -61,10 +63,10 @@ public abstract class ClientConf<T extends ClientConf>
     TIME_SUFFIXES.put("d", TimeUnit.DAYS);
   }
 
-  protected final Map<String, String> config;
+  protected final ConcurrentMap<String, String> config;
 
   protected ClientConf(Properties config) {
-    this.config = new HashMap<>();
+    this.config = new ConcurrentHashMap<>();
     if (config != null) {
       for (String key : config.stringPropertyNames()) {
         this.config.put(key, config.getProperty(key));
@@ -79,6 +81,12 @@ public abstract class ClientConf<T extends ClientConf>
   @SuppressWarnings("unchecked")
   public T set(String key, String value) {
     config.put(key, value);
+    return (T) this;
+  }
+
+  @SuppressWarnings("unchecked")
+  public T setIfMissing(String key, String value) {
+    config.putIfAbsent(key, value);
     return (T) this;
   }
 

--- a/conf/livy-defaults.conf.template
+++ b/conf/livy-defaults.conf.template
@@ -1,7 +1,7 @@
 # Specifies Livy's environment. May either be "production" or "development". In "development"
 # mode, Livy will enable debugging options, such as reporting possible routes on a 404.
 # defaults to development
-## livy.environment = development
+## livy.environment = production
 
 # Use this keystore for the SSL certificate and key.
 ## livy.keystore =

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -33,6 +33,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.cloudera.livy</groupId>
+      <artifactId>livy-client-common_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
     </dependency>

--- a/core/src/main/scala/com/cloudera/livy/Utils.scala
+++ b/core/src/main/scala/com/cloudera/livy/Utils.scala
@@ -51,31 +51,6 @@ object Utils {
     getLivyConfDir().map(new File(_, name)).filter(_.exists())
   }
 
-  def getLivyConfigFileOrError(name: String): File = {
-    getLivyConfigFile(name).getOrElse {
-      throw new Exception(s"$name does not exist")
-    }
-  }
-
-  def getDefaultPropertiesFile: Option[File] = {
-    getLivyConfigFile("livy-defaults.conf")
-  }
-
-  def loadDefaultLivyProperties(conf: LivyConf, filePath: String = null): Unit = {
-    val file: Option[File] = Option(filePath)
-      .map(new File(_))
-      .orElse(getDefaultPropertiesFile)
-
-    file.foreach { f =>
-      getPropertiesFromFile(f)
-        .filterKeys(_.startsWith("livy."))
-        .foreach { case (k, v) =>
-          conf.setIfMissing(k, v)
-          sys.props.getOrElseUpdate(k, v)
-        }
-    }
-  }
-
   /**
    * Checks if event has occurred during some time period. This performs an exponential backoff
    * to limit the poll calls.

--- a/core/src/main/scala/com/cloudera/livy/WebServer.scala
+++ b/core/src/main/scala/com/cloudera/livy/WebServer.scala
@@ -40,7 +40,7 @@ class WebServer(livyConf: LivyConf, var host: String, var port: Int) extends Log
   server.setStopTimeout(1000)
   server.setStopAtShutdown(true)
 
-  val connector = livyConf.getOption(WebServer.KeystoreKey) match {
+  val connector = Option(livyConf.get(WebServer.KeystoreKey)) match {
     case None =>
       new ServerConnector(server)
 
@@ -50,9 +50,9 @@ class WebServer(livyConf: LivyConf, var host: String, var port: Int) extends Log
 
       val sslContextFactory = new SslContextFactory()
       sslContextFactory.setKeyStorePath(keystore)
-      livyConf.getOption(WebServer.KeystorePasswordKey)
+      Option(livyConf.get(WebServer.KeystorePasswordKey))
         .foreach(sslContextFactory.setKeyStorePassword)
-      livyConf.getOption(WebServer.KeystorePasswordKey)
+      Option(livyConf.get(WebServer.KeystorePasswordKey))
         .foreach(sslContextFactory.setKeyManagerPassword)
 
       new ServerConnector(server,

--- a/core/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
+++ b/core/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
@@ -28,7 +28,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import com.cloudera.livy.{LivyConf, Logging}
 
 object SessionManager {
-  val SESSION_TIMEOUT = "livy.server.session.timeout"
+  val SESSION_TIMEOUT = LivyConf.Entry("livy.server.session.timeout", "1h")
 }
 
 class SessionManager[S <: Session, R](val livyConf: LivyConf, factory: SessionFactory[S, R])
@@ -40,7 +40,7 @@ class SessionManager[S <: Session, R](val livyConf: LivyConf, factory: SessionFa
   private[this] final val _sessions = mutable.Map[Int, S]()
 
   private[this] final val sessionTimeout =
-    TimeUnit.MILLISECONDS.toNanos(livyConf.getLong(SessionManager.SESSION_TIMEOUT, 1000 * 60 * 60))
+    TimeUnit.MILLISECONDS.toNanos(livyConf.getTimeAsMs(SessionManager.SESSION_TIMEOUT))
 
   val livyHome = livyConf.livyHome().getOrElse {
     val isTest = sys.env.get("livy.test").map(_ == "true").isDefined

--- a/pom.xml
+++ b/pom.xml
@@ -654,6 +654,7 @@
             <systemProperties>
               <java.awt.headless>true</java.awt.headless>
               <java.io.tmpdir>${project.build.directory}/tmp</java.io.tmpdir>
+              <livy.environment>development</livy.environment>
             </systemProperties>
             <redirectTestOutputToFile>${test.redirectToFile}</redirectTestOutputToFile>
             <useFile>${test.redirectToFile}</useFile>
@@ -673,6 +674,7 @@
             <systemProperties>
               <java.awt.headless>true</java.awt.headless>
               <java.io.tmpdir>${project.build.directory}/tmp</java.io.tmpdir>
+              <livy.environment>development</livy.environment>
             </systemProperties>
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
             <junitxml>.</junitxml>

--- a/server/src/main/scala/com/cloudera/livy/server/client/ClientSessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/client/ClientSessionServlet.scala
@@ -23,7 +23,7 @@ import java.net.URI
 import org.scalatra._
 import org.scalatra.servlet.{FileUploadSupport, MultipartConfig}
 
-import com.cloudera.livy.JobHandle
+import com.cloudera.livy.{JobHandle, LivyConf}
 import com.cloudera.livy.client.common.HttpMessages._
 import com.cloudera.livy.server.SessionServlet
 import com.cloudera.livy.sessions.SessionManager
@@ -33,7 +33,7 @@ class ClientSessionServlet(sessionManager: SessionManager[ClientSession, CreateC
   extends SessionServlet(sessionManager) with FileUploadSupport {
 
   configureMultipartHandling(MultipartConfig(maxFileSize =
-    Some(sessionManager.livyConf.getLong("livy.file.upload.max.size", 100 * 1024 * 1024))))
+    Some(sessionManager.livyConf.getLong(LivyConf.FILE_UPLOAD_MAX_SIZE))))
 
   jpost[SerializedJob]("/:id/submit-job") { req =>
     withSession { session =>

--- a/spark/src/main/scala/com/cloudera/livy/spark/SparkProcessBuilder.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/SparkProcessBuilder.scala
@@ -251,7 +251,7 @@ class SparkProcessBuilder(
     }
     addList("--driver-class-path", _driverClassPath)
 
-    if (livyConf.getBoolean(LivyConf.IMPERSONATION_ENABLED_KEY, true)) {
+    if (livyConf.getBoolean(LivyConf.IMPERSONATION_ENABLED)) {
       addOpt("--proxy-user", _proxyUser)
     }
 

--- a/spark/src/main/scala/com/cloudera/livy/spark/interactive/InteractiveSessionFactory.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/interactive/InteractiveSessionFactory.scala
@@ -106,7 +106,7 @@ abstract class InteractiveSessionFactory(processFactory: SparkProcessBuilderFact
       builder.conf(SparkDriverExtraJavaOptions, javaOpts, admin = true)
     }
 
-    processFactory.livyConf.getOption(LivyReplDriverClassPath)
+    Option(processFactory.livyConf.get(LivyReplDriverClassPath))
       .foreach(builder.driverClassPath)
 
     sys.props.get(LivyServerUrl).foreach { serverUrl =>
@@ -123,7 +123,7 @@ abstract class InteractiveSessionFactory(processFactory: SparkProcessBuilderFact
   }
 
   private def livyJars(livyConf: LivyConf): Seq[String] = {
-    livyConf.getOption(LivyReplJars).map(_.split(",").toSeq).getOrElse {
+    Option(livyConf.get(LivyReplJars)).map(_.split(",").toSeq).getOrElse {
       val home = sys.env("LIVY_HOME")
       val jars = Option(new File(home, "repl-jars"))
         .filter(_.isDirectory())


### PR DESCRIPTION
That reuses a lot of the type conversion logic; also, declare
some constants in the form of "ConfEntry" objects so that it's
easier to spot their names and default values.

I also changed the server's Main to use a listener instead of
a ScalaBootstrap since that allows using the same LivyConf instance,
instead of having both places initialize the conf object in
different ways.

Finally, I changed the default value for the "environment" config
to "production", since well, the default should not be "development".
The unit tests will set it to "development" explicitly; although it's
all kinda moot since that's not used anywhere.