### PR TITLE
LIVY-60. Work around Jackson/Scala bug by not using case classes.

### DIFF
--- a/server/src/test/scala/com/cloudera/livy/server/batch/BatchServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/batch/BatchServletSpec.scala
@@ -59,7 +59,10 @@ class BatchServletSpec extends BaseSessionServletSpec[BatchSession, CreateBatchR
         data("sessions") should equal (Seq())
       }
 
-      jpost[Map[String, Any]]("/", CreateBatchRequest(file = script.toString)) { data =>
+      val createRequest = new CreateBatchRequest()
+      createRequest.file = script.toString
+
+      jpost[Map[String, Any]]("/", createRequest) { data =>
         header("Location") should equal("/0")
         data("id") should equal (0)
 

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionServletSpec.scala
@@ -100,7 +100,10 @@ class InteractiveSessionServletSpec
       data("sessions") should equal(Seq())
     }
 
-    jpost[Map[String, Any]]("/", CreateInteractiveRequest(kind = Spark())) { data =>
+    val createRequest = new CreateInteractiveRequest()
+    createRequest.kind = Spark()
+
+    jpost[Map[String, Any]]("/", createRequest) { data =>
       header("Location") should equal("/0")
       data("id") should equal (0)
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -67,6 +67,17 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
       <scope>provided</scope>

--- a/spark/src/main/scala/com/cloudera/livy/spark/batch/BatchSessionFactory.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/batch/BatchSessionFactory.scala
@@ -31,6 +31,7 @@ abstract class BatchSessionFactory(factory: SparkProcessBuilderFactory)
   extends SessionFactory[BatchSession, CreateBatchRequest] {
 
   def create(id: Int, request: CreateBatchRequest): BatchSession = {
+    require(request.file != null, "File is required.")
     val builder = sparkBuilder(request)
     val process = builder.start(Some(RelativePath(request.file)), request.args)
     create(id, process)

--- a/spark/src/main/scala/com/cloudera/livy/spark/batch/CreateBatchRequest.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/batch/CreateBatchRequest.scala
@@ -18,20 +18,23 @@
 
 package com.cloudera.livy.spark.batch
 
-case class CreateBatchRequest(
-    file: String,
-    proxyUser: Option[String] = None,
-    args: List[String] = List(),
-    className: Option[String] = None,
-    jars: List[String] = List(),
-    pyFiles: List[String] = List(),
-    files: List[String] = List(),
-    driverMemory: Option[String] = None,
-    driverCores: Option[Int] = None,
-    executorMemory: Option[String] = None,
-    executorCores: Option[Int] = None,
-    numExecutors: Option[Int] = None,
-    archives: List[String] = List(),
-    queue: Option[String] = None,
-    name: Option[String] = None,
-    conf: Map[String, String] = Map())
+class CreateBatchRequest {
+
+  var file: String = _
+  var proxyUser: Option[String] = None
+  var args: List[String] = List()
+  var className: Option[String] = None
+  var jars: List[String] = List()
+  var pyFiles: List[String] = List()
+  var files: List[String] = List()
+  var driverMemory: Option[String] = None
+  var driverCores: Option[Int] = None
+  var executorMemory: Option[String] = None
+  var executorCores: Option[Int] = None
+  var numExecutors: Option[Int] = None
+  var archives: List[String] = List()
+  var queue: Option[String] = None
+  var name: Option[String] = None
+  var conf: Map[String, String] = Map()
+
+}

--- a/spark/src/main/scala/com/cloudera/livy/spark/interactive/CreateInteractiveRequest.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/interactive/CreateInteractiveRequest.scala
@@ -18,20 +18,25 @@
 
 package com.cloudera.livy.spark.interactive
 
+import com.fasterxml.jackson.annotation.JsonProperty
+
 import com.cloudera.livy.sessions.Kind
 
-case class CreateInteractiveRequest(
-    kind: Kind,
-    proxyUser: Option[String] = None,
-    jars: List[String] = List(),
-    pyFiles: List[String] = List(),
-    files: List[String] = List(),
-    driverMemory: Option[String] = None,
-    driverCores: Option[Int] = None,
-    executorMemory: Option[String] = None,
-    executorCores: Option[Int] = None,
-    numExecutors: Option[Int] = None,
-    archives: List[String] = List(),
-    queue: Option[String] = None,
-    name: Option[String] = None,
-    conf: Map[String, String] = Map())
+class CreateInteractiveRequest {
+
+  @JsonProperty(required = true) var kind: Kind = _
+  var proxyUser: Option[String] = None
+  var jars: List[String] = List()
+  var pyFiles: List[String] = List()
+  var files: List[String] = List()
+  var driverMemory: Option[String] = None
+  var driverCores: Option[Int] = None
+  var executorMemory: Option[String] = None
+  var executorCores: Option[Int] = None
+  var numExecutors: Option[Int] = None
+  var archives: List[String] = List()
+  var queue: Option[String] = None
+  var name: Option[String] = None
+  var conf: Map[String, String] = Map()
+
+}

--- a/spark/src/main/scala/com/cloudera/livy/spark/interactive/InteractiveSessionFactory.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/interactive/InteractiveSessionFactory.scala
@@ -45,6 +45,7 @@ abstract class InteractiveSessionFactory(processFactory: SparkProcessBuilderFact
   import InteractiveSessionFactory._
 
   def create(id: Int, request: CreateInteractiveRequest): InteractiveSession = {
+    require(request.kind != null, "Session kind is required.")
     val builder = sparkBuilder(id, request)
     val kind = request.kind.toString
     val process = builder.start(None, List(kind))

--- a/spark/src/test/scala/com/cloudera/livy/spark/batch/BatchProcessSpec.scala
+++ b/spark/src/test/scala/com/cloudera/livy/spark/batch/BatchProcessSpec.scala
@@ -56,9 +56,8 @@ class BatchProcessSpec
 
   describe("A Batch process") {
     it("should create a process") {
-      val req = CreateBatchRequest(
-        file = script.toString
-      )
+      val req = new CreateBatchRequest()
+      req.file = script.toString
 
       val livyConf = new LivyConf()
       val builder = new BatchSessionProcessFactory(new SparkProcessBuilderFactory(livyConf))

--- a/spark/src/test/scala/com/cloudera/livy/spark/batch/CreateBatchRequestSpec.scala
+++ b/spark/src/test/scala/com/cloudera/livy/spark/batch/CreateBatchRequestSpec.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.spark.batch
+
+import com.fasterxml.jackson.databind.{JsonMappingException, ObjectMapper}
+import org.scalatest.FunSpec
+
+class CreateBatchRequestSpec extends FunSpec {
+
+  private val mapper = new ObjectMapper()
+    .registerModule(com.fasterxml.jackson.module.scala.DefaultScalaModule)
+
+  describe("CreateBatchRequest") {
+
+    it("should have default values for fields after deserialization") {
+      val json = """{ "file" : "foo" }"""
+      val req = mapper.readValue(json, classOf[CreateBatchRequest])
+      assert(req.file === "foo")
+      assert(req.proxyUser === None)
+      assert(req.args === List())
+      assert(req.className === None)
+      assert(req.jars === List())
+      assert(req.pyFiles === List())
+      assert(req.files === List())
+      assert(req.driverMemory === None)
+      assert(req.driverCores === None)
+      assert(req.executorMemory === None)
+      assert(req.executorCores === None)
+      assert(req.numExecutors === None)
+      assert(req.archives === List())
+      assert(req.queue === None)
+      assert(req.name === None)
+      assert(req.conf === Map())
+    }
+
+  }
+
+}

--- a/spark/src/test/scala/com/cloudera/livy/spark/interactive/CreateInteractiveRequestSpec.scala
+++ b/spark/src/test/scala/com/cloudera/livy/spark/interactive/CreateInteractiveRequestSpec.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.spark.interactive
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.scalatest.FunSpec
+
+import com.cloudera.livy.sessions.{PySpark, SessionKindModule}
+
+class CreateInteractiveRequestSpec extends FunSpec {
+
+  private val mapper = new ObjectMapper()
+    .registerModule(com.fasterxml.jackson.module.scala.DefaultScalaModule)
+    .registerModule(new SessionKindModule())
+
+  describe("CreateInteractiveRequest") {
+
+    it("should have default values for fields after deserialization") {
+      val json = """{ "kind" : "pyspark" }"""
+      val req = mapper.readValue(json, classOf[CreateInteractiveRequest])
+      assert(req.kind === PySpark())
+      assert(req.proxyUser === None)
+      assert(req.jars === List())
+      assert(req.pyFiles === List())
+      assert(req.files === List())
+      assert(req.driverMemory === None)
+      assert(req.driverCores === None)
+      assert(req.executorMemory === None)
+      assert(req.executorCores === None)
+      assert(req.numExecutors === None)
+      assert(req.archives === List())
+      assert(req.queue === None)
+      assert(req.name === None)
+      assert(req.conf === Map())
+    }
+
+  }
+
+}

--- a/spark/src/test/scala/com/cloudera/livy/spark/interactive/InteractiveSessionProcessSpec.scala
+++ b/spark/src/test/scala/com/cloudera/livy/spark/interactive/InteractiveSessionProcessSpec.scala
@@ -33,6 +33,9 @@ class InteractiveSessionProcessSpec extends BaseInteractiveSessionSpec {
     assume(sys.env.get("SPARK_HOME").isDefined, "SPARK_HOME is not set.")
     val processFactory = new SparkProcessBuilderFactory(livyConf)
     val interactiveFactory = new InteractiveSessionProcessFactory(processFactory)
-    interactiveFactory.create(0, CreateInteractiveRequest(kind = PySpark()))
+
+    val req = new CreateInteractiveRequest()
+    req.kind = PySpark()
+    interactiveFactory.create(0, req)
   }
 }


### PR DESCRIPTION
Jackson doesn't deal well with Scala case classes; the default values
tend to be ignored. I tried a few workarounds (such as special constructors
annotated with @JsonCreator), but those don't always work (same code
sometimes works and sometimes doesn't - maybe because Scala reflection is
not thread-safe in 2.10?).

So, the less ugly fix was to make the offending types not case classes.
The only affected types seem to be the batch and interactive session
requests, so they were modified to be normal classes with mutable fields.
I added unit tests to make sure the default values are there when the
properties are not provided in the JSON payload.