### PR TITLE
LIVY-68. Add SPNEGO authentication, basic authorization.

### DIFF
--- a/client-http/src/test/scala/com/cloudera/livy/client/http/HttpClientSpec.scala
+++ b/client-http/src/test/scala/com/cloudera/livy/client/http/HttpClientSpec.scala
@@ -262,7 +262,7 @@ private class HttpClientTestBootstrap extends LifeCycle {
 
   override def init(context: ServletContext): Unit = {
     val factory = mock(classOf[SessionFactory[ClientSession, CreateClientRequest]])
-    when(factory.create(anyInt(), any(classOf[CreateClientRequest]))).thenAnswer(
+    when(factory.create(anyInt(), anyString(), any(classOf[CreateClientRequest]))).thenAnswer(
       new Answer[ClientSession]() {
         override def answer(args: InvocationOnMock): ClientSession = {
           val session = mock(classOf[ClientSession])

--- a/core/src/main/scala/com/cloudera/livy/LivyConf.scala
+++ b/core/src/main/scala/com/cloudera/livy/LivyConf.scala
@@ -34,6 +34,8 @@ object LivyConf {
     def apply(key: String, dflt: Long): Entry = Entry(key, dflt: JLong)
   }
 
+  val TEST_MODE = sys.env.get("livy.test").map(_.toBoolean).getOrElse(false)
+
   val SESSION_FACTORY = Entry("livy.server.session.factory", "process")
   val SPARK_HOME = Entry("livy.server.spark-home", null)
   val SPARK_SUBMIT_KEY = Entry("livy.server.spark-submit", null)

--- a/core/src/main/scala/com/cloudera/livy/sessions/Session.scala
+++ b/core/src/main/scala/com/cloudera/livy/sessions/Session.scala
@@ -22,11 +22,9 @@ import java.util.concurrent.TimeUnit
 
 import scala.concurrent.Future
 
-trait Session {
+abstract class Session(val id: Int, val owner: String) {
 
   private var _lastActivity = 0L
-
-  def id: Int
 
   def lastActivity: Option[Long] = if (_lastActivity == 0L) None else Some(_lastActivity)
 
@@ -50,4 +48,5 @@ trait Session {
   }
 
   def logLines(): IndexedSeq[String]
+
 }

--- a/core/src/main/scala/com/cloudera/livy/sessions/SessionFactory.scala
+++ b/core/src/main/scala/com/cloudera/livy/sessions/SessionFactory.scala
@@ -22,7 +22,7 @@ abstract class SessionFactory[S <: Session, R] {
 
   protected var livyHome: String = null
 
-  def create(id: Int, createRequest: R): S
+  def create(id: Int, owner: String, createRequest: R): S
 
   def setLivyHome(livyHome: String): Unit = {
     this.livyHome = livyHome

--- a/core/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
+++ b/core/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
@@ -43,8 +43,7 @@ class SessionManager[S <: Session, R](val livyConf: LivyConf, factory: SessionFa
     TimeUnit.MILLISECONDS.toNanos(livyConf.getTimeAsMs(SessionManager.SESSION_TIMEOUT))
 
   val livyHome = livyConf.livyHome().getOrElse {
-    val isTest = sys.env.get("livy.test").map(_ == "true").isDefined
-    if (isTest) {
+    if (LivyConf.TEST_MODE) {
        Files.createTempDirectory("livyTemp").toUri.toString
     } else {
       throw new RuntimeException("livy.home must be specified!")
@@ -60,9 +59,9 @@ class SessionManager[S <: Session, R](val livyConf: LivyConf, factory: SessionFa
   garbageCollector.setDaemon(true)
   garbageCollector.start()
 
-  def create(createRequest: R): S = {
+  def create(createRequest: R, owner: String): S = {
     val id = _idCounter.getAndIncrement
-    val session: S = factory.create(id, createRequest)
+    val session: S = factory.create(id, owner, createRequest)
 
     info("created session %s" format session.id)
 

--- a/core/src/main/scala/com/cloudera/livy/sessions/batch/BatchSession.scala
+++ b/core/src/main/scala/com/cloudera/livy/sessions/batch/BatchSession.scala
@@ -20,4 +20,4 @@ package com.cloudera.livy.sessions.batch
 
 import com.cloudera.livy.sessions.Session
 
-trait BatchSession extends Session
+abstract class BatchSession(id: Int, owner: String) extends Session(id, owner)

--- a/core/src/main/scala/com/cloudera/livy/sessions/interactive/InteractiveSession.scala
+++ b/core/src/main/scala/com/cloudera/livy/sessions/interactive/InteractiveSession.scala
@@ -33,12 +33,10 @@ object InteractiveSession {
   class StatementNotFound extends Exception
 }
 
-trait InteractiveSession extends Session {
+abstract class InteractiveSession(id: Int, owner: String) extends Session(id, owner) {
   def kind: Kind
 
   def proxyUser: Option[String]
-
-  override def lastActivity: Option[Long]
 
   def url: Option[URL]
 

--- a/core/src/test/scala/com/cloudera/livy/sessions/SessionManagerSpec.scala
+++ b/core/src/test/scala/com/cloudera/livy/sessions/SessionManagerSpec.scala
@@ -19,7 +19,6 @@
 package com.cloudera.livy.sessions
 
 import com.cloudera.livy.LivyConf
-import org.json4s.JsonAST.{JNothing, JValue}
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.concurrent.duration.Duration
@@ -27,7 +26,7 @@ import scala.concurrent.{Await, Future}
 
 class SessionManagerSpec extends FlatSpec with Matchers {
 
-  class MockSession(val id: Int) extends Session {
+  class MockSession(id: Int, owner: String) extends Session(id, owner) {
     override def stop(): Future[Unit] = Future.successful(())
 
     override def logLines(): IndexedSeq[String] = IndexedSeq()
@@ -36,14 +35,16 @@ class SessionManagerSpec extends FlatSpec with Matchers {
   }
 
   class MockSessionFactory extends SessionFactory[MockSession, AnyRef] {
-    override def create(id: Int, createRequest: AnyRef): MockSession = new MockSession(id)
+    override def create(id: Int, owner: String, createRequest: AnyRef): MockSession = {
+      new MockSession(id, owner)
+    }
   }
 
   it should "garbage collect old sessions" in {
     val livyConf = new LivyConf()
     livyConf.set(SessionManager.SESSION_TIMEOUT, "100")
     val manager = new SessionManager(livyConf, new MockSessionFactory)
-    val session = manager.create(JNothing)
+    val session = manager.create(null, null)
     manager.get(session.id).isDefined should be(true)
     Await.result(manager.collectGarbage(), Duration.Inf)
     manager.get(session.id).isEmpty should be(true)

--- a/pom.xml
+++ b/pom.xml
@@ -278,6 +278,12 @@
 
       <dependency>
         <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-auth</artifactId>
+        <version>${hadoop.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-common</artifactId>
         <version>${hadoop.version}</version>
         <exclusions>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -86,14 +86,12 @@
 
         <dependency>
             <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-common</artifactId>
-            <scope>provided</scope>
+            <artifactId>hadoop-auth</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/server/src/main/scala/com/cloudera/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/SessionServlet.scala
@@ -18,6 +18,8 @@
 
 package com.cloudera.livy.server
 
+import javax.servlet.http.HttpServletRequest
+
 import scala.concurrent.Future
 import scala.reflect.ClassTag
 
@@ -31,6 +33,9 @@ import com.cloudera.livy.spark.ConfigOptionNotAllowed
 object SessionServlet extends Logging
 
 /**
+ * Base servlet for session management. All helper methods in this class assume that the session
+ * id parameter in the handler's URI is "id".
+ *
  * Type parameters:
  *  S: the session type
  *  R: the type representing the session create parameters.
@@ -45,7 +50,7 @@ abstract class SessionServlet[S <: Session, R: ClassTag](sessionManager: Session
   /**
    * Returns a object representing the session data to be sent back to the client.
    */
-  protected def clientSessionView(session: S): Any = session
+  protected def clientSessionView(session: S, req: HttpServletRequest): Any = session
 
   before() {
     contentType = "application/json"
@@ -60,54 +65,45 @@ abstract class SessionServlet[S <: Session, R: ClassTag](sessionManager: Session
     Map(
       "from" -> from,
       "total" -> sessionManager.size(),
-      "sessions" -> sessions.view(from, from + size).map(clientSessionView)
+      "sessions" -> sessions.view(from, from + size).map(clientSessionView(_, request))
     )
   }
 
   val getSession = jget("/:id") {
-    val id = params("id").toInt
-
-    sessionManager.get(id) match {
-      case None => NotFound("session not found")
-      case Some(session) => clientSessionView(session)
+    withUnprotectedSession { session =>
+      clientSessionView(session, request)
     }
   }
 
   jget("/:id/state") {
-    val id = params("id").toInt
-
-    sessionManager.get(id) match {
-      case None => NotFound("batch not found")
-      case Some(batch) =>
-        Map("id" -> batch.id, "state" -> batch.state.toString)
+    withUnprotectedSession { session =>
+      Map("id" -> session.id, "state" -> session.state.toString)
     }
   }
 
   jget("/:id/log") {
-    val id = params("id").toInt
+    withSession { session =>
+      val from = params.get("from").map(_.toInt)
+      val size = params.get("size").map(_.toInt)
+      val (from_, total, logLines) = serializeLogs(session, from, size)
 
-    sessionManager.get(id) match {
-      case None => NotFound("session not found")
-      case Some(session) =>
-        val from = params.get("from").map(_.toInt)
-        val size = params.get("size").map(_.toInt)
-        val (from_, total, logLines) = serializeLogs(session, from, size)
-
-        Map(
-          "id" -> session.id,
-          "from" -> from_,
-          "total" -> total,
-          "log" -> logLines)
+      Map(
+        "id" -> session.id,
+        "from" -> from_,
+        "total" -> total,
+        "log" -> logLines)
     }
   }
 
   jdelete("/:id") {
-    val id = params("id").toInt
-
-    sessionManager.delete(id) match {
-      case None => NotFound("session not found")
-      case Some(future) => new AsyncResult {
-        val is = future.map { case () => Ok(Map("msg" -> "deleted")) }
+    withSession { session =>
+      sessionManager.delete(session.id) match {
+      case Some(future) =>
+        new AsyncResult {
+          val is = future.map { case () => Ok(Map("msg" -> "deleted")) }
+        }
+      case None =>
+        NotFound(s"Session ${session.id} already stopped.")
       }
     }
   }
@@ -115,8 +111,8 @@ abstract class SessionServlet[S <: Session, R: ClassTag](sessionManager: Session
   jpost[R]("/") { createRequest =>
     new AsyncResult {
       val is = Future {
-        val session = sessionManager.create(createRequest)
-        Created(clientSessionView(session),
+        val session = sessionManager.create(createRequest, remoteUser(request))
+        Created(clientSessionView(session, request),
           headers = Map("Location" -> url(getSession, "id" -> session.id.toString))
         )
       }
@@ -133,20 +129,49 @@ abstract class SessionServlet[S <: Session, R: ClassTag](sessionManager: Session
       InternalServerError(e.toString)
   }
 
-  protected val sessionIdParam: String = "id"
-
   protected def doAsync(fn: => Any): AsyncResult = {
     new AsyncResult {
       val is = Future { fn }
     }
   }
 
-  protected def withSession(fn: (S => Any)): Any = {
-    val sessionId = params(sessionIdParam).toInt
+  /**
+   * Returns the remote user for the given request. Separate method so that tests can override it.
+   */
+  protected def remoteUser(req: HttpServletRequest): String = req.getRemoteUser()
+
+  /**
+   * Performs an operation on the session, without checking for ownership. Operations executed
+   * via this method must not modify the session in any way, or return potentially sensitive
+   * information.
+   */
+  protected def withUnprotectedSession(fn: (S => Any)): Any = doWithSession(fn, true)
+
+  /**
+   * Performs an operation on the session, verifying whether the caller is the owner of the
+   * session.
+   */
+  protected def withSession(fn: (S => Any)): Any = doWithSession(fn, false)
+
+  private def doWithSession(fn: (S => Any), allowAll: Boolean): Any = {
+    val sessionId = params("id").toInt
     sessionManager.get(sessionId) match {
-      case Some(session) => fn(session)
-      case None => NotFound(s"Session '$sessionId' not found.")
+      case Some(session) =>
+        if (allowAll || isOwner(session, request)) {
+          fn(session)
+        } else {
+          Forbidden()
+        }
+      case None =>
+        NotFound(s"Session '$sessionId' not found.")
     }
+  }
+
+  /**
+   * Returns whether the current request's user is the owner of the given session.
+   */
+  protected def isOwner(session: Session, req: HttpServletRequest): Boolean = {
+    session.owner == remoteUser(req)
   }
 
   private def serializeLogs(session: S, fromOpt: Option[Int], sizeOpt: Option[Int]) = {

--- a/server/src/main/scala/com/cloudera/livy/server/client/ClientSessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/client/ClientSessionServlet.scala
@@ -19,6 +19,7 @@
 package com.cloudera.livy.server.client
 
 import java.net.URI
+import javax.servlet.http.HttpServletRequest
 
 import org.scalatra._
 import org.scalatra.servlet.{FileUploadSupport, MultipartConfig}
@@ -115,7 +116,7 @@ class ClientSessionServlet(sessionManager: SessionManager[ClientSession, CreateC
     }
   }
 
-  override protected def clientSessionView(session: ClientSession): Any = {
+  override protected def clientSessionView(session: ClientSession, req: HttpServletRequest): Any = {
     new SessionInfo(session.id, session.state.toString)
   }
 

--- a/server/src/test/scala/com/cloudera/livy/server/BaseJsonServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/BaseJsonServletSpec.scala
@@ -18,6 +18,8 @@
 
 package com.cloudera.livy.server
 
+import javax.servlet.http.HttpServletResponse._
+
 import scala.reflect.ClassTag
 
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -39,34 +41,57 @@ abstract class BaseJsonServletSpec extends ScalatraSuite with FunSpecLike {
   protected val mapper = new ObjectMapper()
     .registerModule(com.fasterxml.jackson.module.scala.DefaultScalaModule)
 
-  protected val headers: Map[String, String] = Map("Content-Type" -> "application/json")
+  protected val defaultHeaders: Map[String, String] = Map("Content-Type" -> "application/json")
 
-  protected def jdelete[R: ClassTag](uri: String, expectedStatus: Int = 200)
+  protected def jdelete[R: ClassTag](
+      uri: String,
+      expectedStatus: Int = SC_OK,
+      headers: Map[String, String] = defaultHeaders)
       (fn: R => Unit): Unit = {
     delete(uri, headers = headers)(doTest(expectedStatus, fn))
   }
 
-  protected def jget[R: ClassTag](uri: String, expectedStatus: Int = 200)
+  protected def jget[R: ClassTag](
+      uri: String,
+      expectedStatus: Int = SC_OK,
+      headers: Map[String, String] = defaultHeaders)
       (fn: R => Unit): Unit = {
     get(uri, headers = headers)(doTest(expectedStatus, fn))
   }
 
-  protected def jpatch[R: ClassTag](uri: String, body: AnyRef, expectedStatus: Int = 200)
+  protected def jpatch[R: ClassTag](
+      uri: String,
+      body: AnyRef,
+      expectedStatus: Int = SC_OK,
+      headers: Map[String, String] = defaultHeaders)
       (fn: R => Unit): Unit = {
     patch(uri, body = toJson(body), headers = headers)(doTest(expectedStatus, fn))
   }
 
-  protected def jpost[R: ClassTag](uri: String, body: AnyRef, expectedStatus: Int = 201)
+  protected def jpost[R: ClassTag](
+      uri: String,
+      body: AnyRef,
+      expectedStatus: Int = SC_CREATED,
+      headers: Map[String, String] = defaultHeaders)
       (fn: R => Unit): Unit = {
     post(uri, body = toJson(body), headers = headers)(doTest(expectedStatus, fn))
   }
 
-  protected def jpost[R: ClassTag](uri: String, files: Iterable[(String, Any)], expectedStatus: Int)
-    (fn: R => Unit): Unit = {
+  /** A version of jpost specific for testing file upload. */
+  protected def jupload[R: ClassTag](
+      uri: String,
+      files: Iterable[(String, Any)],
+      headers: Map[String, String] = Map(),
+      expectedStatus: Int = SC_OK)
+      (fn: R => Unit): Unit = {
     post(uri, Map.empty, files)(doTest(expectedStatus, fn))
   }
 
-  protected def jput[R: ClassTag](uri: String, body: AnyRef, expectedStatus: Int = 200)
+  protected def jput[R: ClassTag](
+      uri: String,
+      body: AnyRef,
+      expectedStatus: Int = SC_OK,
+      headers: Map[String, String] = defaultHeaders)
       (fn: R => Unit): Unit = {
     put(uri, body = toJson(body), headers = headers)(doTest(expectedStatus, fn))
   }

--- a/server/src/test/scala/com/cloudera/livy/server/BaseSessionServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/BaseSessionServletSpec.scala
@@ -23,12 +23,14 @@ import org.scalatest.BeforeAndAfterAll
 import com.cloudera.livy.LivyConf
 import com.cloudera.livy.sessions.{Session, SessionFactory, SessionManager}
 
-abstract class BaseSessionServletSpec[S <: Session, R]
+abstract class BaseSessionServletSpec[S <: Session, R](needsSpark: Boolean = true)
   extends BaseJsonServletSpec
   with BeforeAndAfterAll {
 
   override protected def withFixture(test: NoArgTest) = {
-    assume(sys.env.get("SPARK_HOME").isDefined, "SPARK_HOME is not set.")
+    if (needsSpark) {
+      assume(sys.env.get("SPARK_HOME").isDefined, "SPARK_HOME is not set.")
+    }
     test()
   }
 

--- a/server/src/test/scala/com/cloudera/livy/server/JsonServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/JsonServletSpec.scala
@@ -42,31 +42,31 @@ class JsonServletSpec extends BaseJsonServletSpec {
     }
 
     it("should serialize an ActionResult's body") {
-      jpost[MethodReturn]("/post", body = MethodArg("post")) { result =>
+      jpost[MethodReturn]("/post", MethodArg("post")) { result =>
         assert(result.value === "post")
       }
     }
 
     it("should wrap a raw result") {
-      jput[MethodReturn]("/put", body = MethodArg("put")) { result =>
+      jput[MethodReturn]("/put", MethodArg("put")) { result =>
         assert(result.value === "put")
       }
     }
 
     it("should bypass non-json results") {
-      jpatch[Unit]("/patch", body = MethodArg("patch"), expectedStatus = 404) { _ =>
+      jpatch[Unit]("/patch", MethodArg("patch"), expectedStatus = SC_NOT_FOUND) { _ =>
         assert(response.body === "patch")
       }
     }
 
     it("should translate JSON errors to BadRequest") {
-      post("/post", body = "abcde".getBytes(UTF_8), headers = headers) {
+      post("/post", "abcde".getBytes(UTF_8), headers = defaultHeaders) {
         assert(status === SC_BAD_REQUEST)
       }
     }
 
     it("should respect user-installed error handlers") {
-      post("/error", headers = headers) {
+      post("/error", headers = defaultHeaders) {
         assert(status === SC_SERVICE_UNAVAILABLE)
         assert(response.body === "error")
       }

--- a/server/src/test/scala/com/cloudera/livy/server/SessionServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/SessionServletSpec.scala
@@ -1,0 +1,110 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.server
+
+
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse._
+
+import scala.concurrent.Future
+
+import com.cloudera.livy.sessions.{Session, SessionFactory, SessionManager, SessionState}
+
+object SessionServletSpec {
+
+  val REMOTE_USER_HEADER = "X-Livy-SessionServlet-User"
+
+  class MockSession(id: Int, owner: String) extends Session(id, owner) {
+
+    def state: SessionState = SessionState.Idle()
+
+    def stop(): Future[Unit] = Future.successful()
+
+    def logLines(): IndexedSeq[String] = IndexedSeq("log")
+
+  }
+
+  case class MockSessionView(id: Int, owner: String, logs: Seq[String])
+
+}
+
+class SessionServletSpec
+  extends BaseSessionServletSpec[Session, Map[String, String]](needsSpark = false) {
+
+  import SessionServletSpec._
+
+  def sessionFactory: SessionFactory[Session, Map[String, String]] = {
+    new SessionFactory[Session, Map[String, String]]() {
+      override def create(id: Int, owner: String, createRequest: Map[String, String]): Session = {
+        new MockSession(id, owner)
+      }
+    }
+  }
+
+  def servlet: SessionServlet[Session, Map[String, String]] = {
+    new SessionServlet(sessionManager) {
+      override protected def clientSessionView(session: Session, req: HttpServletRequest): Any = {
+        val logs = if (isOwner(session, req)) session.logLines() else Nil
+        MockSessionView(session.id, session.owner, logs)
+      }
+
+      override protected def remoteUser(req: HttpServletRequest): String = {
+        req.getHeader(REMOTE_USER_HEADER)
+      }
+    }
+  }
+
+  private val aliceHeaders = defaultHeaders ++ Map(REMOTE_USER_HEADER -> "alice")
+  private val bobHeaders = defaultHeaders ++ Map(REMOTE_USER_HEADER -> "bob")
+
+  private def delete(id: Int, headers: Map[String, String], expectedStatus: Int): Unit = {
+    jdelete[Map[String, Any]](s"/$id", headers = headers, expectedStatus = expectedStatus) { _ =>
+      // Nothing to do.
+    }
+  }
+
+  describe("SessionServlet") {
+
+    it("should attach owner information to sessions") {
+      jpost[MockSessionView]("/", Map(), headers = aliceHeaders) { res =>
+        assert(res.owner === "alice")
+        assert(res.logs === IndexedSeq("log"))
+        delete(res.id, aliceHeaders, SC_OK)
+      }
+    }
+
+    it("should allow other users to see non-sensitive information") {
+      jpost[MockSessionView]("/", Map(), headers = aliceHeaders) { res =>
+        jget[MockSessionView](s"/${res.id}", headers = bobHeaders) { res =>
+          assert(res.owner === "alice")
+          assert(res.logs === Nil)
+        }
+        delete(res.id, aliceHeaders, SC_OK)
+      }
+    }
+
+    it("should prevent non-owners from modifying sessions") {
+      jpost[MockSessionView]("/", Map(), headers = aliceHeaders) { res =>
+        delete(res.id, bobHeaders, SC_FORBIDDEN)
+      }
+    }
+
+  }
+
+}

--- a/server/src/test/scala/com/cloudera/livy/server/client/ClientServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/client/ClientServletSpec.scala
@@ -24,6 +24,7 @@ import java.nio.ByteBuffer
 import java.nio.file.{Paths, Files}
 import java.util.{ArrayList, HashMap}
 import java.util.concurrent.TimeUnit
+import javax.servlet.http.HttpServletResponse._
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
@@ -42,11 +43,8 @@ import com.cloudera.livy.client.common.HttpMessages._
 import com.cloudera.livy.server.BaseSessionServletSpec
 import com.cloudera.livy.spark.client._
 
-class ClientServletSpec extends BaseSessionServletSpec[ClientSession, CreateClientRequest] {
-
-  override protected def withFixture(test: NoArgTest) = {
-    test()
-  }
+class ClientServletSpec
+  extends BaseSessionServletSpec[ClientSession, CreateClientRequest](needsSpark = false) {
 
   override def sessionFactory = new ClientSessionFactory()
 
@@ -143,7 +141,7 @@ class ClientServletSpec extends BaseSessionServletSpec[ClientSession, CreateClie
 
     Files.write(Paths.get(f.getAbsolutePath), "Test data".getBytes())
 
-    jpost[Unit](s"/$sessionId/upload-$cmd", Map(cmd -> f), 200) { _ =>
+    jupload[Unit](s"/$sessionId/upload-$cmd", Map(cmd -> f), expectedStatus = SC_OK) { _ =>
       val resultFile = new File(new URI(s"${sessionManager.livyHome}/$sessionId/${f.getName}"))
       resultFile.deleteOnExit()
       resultFile.exists() should be(true)

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionServletSpec.scala
@@ -39,7 +39,7 @@ class InteractiveSessionServletSpec
   mapper.registerModule(new SessionKindModule())
     .registerModule(new Json4sScalaModule())
 
-  class MockInteractiveSession(val id: Int) extends InteractiveSession {
+  class MockInteractiveSession(id: Int, owner: String) extends InteractiveSession(id, owner) {
     var _state: SessionState = SessionState.Idle()
 
     var _idCounter = new AtomicInteger()
@@ -79,13 +79,18 @@ class InteractiveSessionServletSpec
   class MockInteractiveSessionFactory(processFactory: SparkProcessBuilderFactory)
     extends InteractiveSessionFactory(processFactory) {
 
-    override def create(id: Int, request: CreateInteractiveRequest): InteractiveSession = {
-      new MockInteractiveSession(id)
+    override def create(
+        id: Int,
+        owner: String,
+        request: CreateInteractiveRequest): InteractiveSession = {
+      new MockInteractiveSession(id, null)
     }
 
-    protected override def create(id: Int,
-                                  process: SparkProcess,
-                                  request: CreateInteractiveRequest): InteractiveSession = {
+    protected override def create(
+        id: Int,
+        owner: String,
+        process: SparkProcess,
+        request: CreateInteractiveRequest): InteractiveSession = {
       throw new UnsupportedOperationException()
     }
   }

--- a/spark/src/main/scala/com/cloudera/livy/spark/batch/BatchSessionFactory.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/batch/BatchSessionFactory.scala
@@ -30,14 +30,14 @@ import com.cloudera.livy.spark.SparkProcessBuilder.RelativePath
 abstract class BatchSessionFactory(factory: SparkProcessBuilderFactory)
   extends SessionFactory[BatchSession, CreateBatchRequest] {
 
-  def create(id: Int, request: CreateBatchRequest): BatchSession = {
+  override def create(id: Int, owner: String, request: CreateBatchRequest): BatchSession = {
     require(request.file != null, "File is required.")
     val builder = sparkBuilder(request)
     val process = builder.start(Some(RelativePath(request.file)), request.args)
-    create(id, process)
+    create(id, owner, process)
   }
 
-  protected def create(id: Int, process: SparkProcess): BatchSession
+  protected def create(id: Int, owner: String, process: SparkProcess): BatchSession
 
   protected def sparkBuilder(request: CreateBatchRequest): SparkProcessBuilder = {
     val builder = factory.builder()

--- a/spark/src/main/scala/com/cloudera/livy/spark/batch/BatchSessionProcess.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/batch/BatchSessionProcess.scala
@@ -25,14 +25,9 @@ import com.cloudera.livy.sessions.SessionState
 import com.cloudera.livy.sessions.batch.BatchSession
 import com.cloudera.livy.spark.SparkProcess
 
-object BatchSessionProcess {
-  def apply(id: Int, process: SparkProcess): BatchSession = {
-    new BatchSessionProcess(id, process)
-  }
-}
+class BatchSessionProcess(
+    id: Int, owner: String, process: LineBufferedProcess) extends BatchSession(id, owner) {
 
-private class BatchSessionProcess(val id: Int,
-                                  process: LineBufferedProcess) extends BatchSession {
   protected implicit def executor: ExecutionContextExecutor = ExecutionContext.global
 
   private[this] var _state: SessionState = SessionState.Running()

--- a/spark/src/main/scala/com/cloudera/livy/spark/batch/BatchSessionProcessFactory.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/batch/BatchSessionProcessFactory.scala
@@ -24,7 +24,7 @@ import com.cloudera.livy.spark.{SparkProcess, SparkProcessBuilderFactory}
 class BatchSessionProcessFactory(processFactory: SparkProcessBuilderFactory)
   extends BatchSessionFactory(processFactory)
 {
-  protected override def create(id: Int, process: SparkProcess): BatchSession = {
-    BatchSessionProcess(id, process)
+  protected override def create(id: Int, owner: String, process: SparkProcess): BatchSession = {
+    new BatchSessionProcess(id, owner, process)
   }
 }

--- a/spark/src/main/scala/com/cloudera/livy/spark/batch/BatchSessionYarn.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/batch/BatchSessionYarn.scala
@@ -30,18 +30,19 @@ import com.cloudera.livy.yarn._
 object BatchSessionYarn {
   implicit def executor: ExecutionContextExecutor = ExecutionContext.global
 
-  def apply(client: LivyYarnClient, id: Int, process: SparkProcess): BatchSession = {
+  def apply(client: LivyYarnClient, id: Int, owner: String, process: SparkProcess): BatchSession = {
     val job = Future {
       client.getJobFromProcess(process)
     }
-    new BatchSessionYarn(id, process, job)
+    new BatchSessionYarn(id, owner, process, job)
   }
 }
 
 private class BatchSessionYarn(
-    val id: Int,
+    id: Int,
+    owner: String,
     process: LineBufferedProcess,
-    jobFuture: Future[Job]) extends BatchSession {
+    jobFuture: Future[Job]) extends BatchSession(id, owner) {
 
   implicit def executor: ExecutionContextExecutor = ExecutionContext.global
 

--- a/spark/src/main/scala/com/cloudera/livy/spark/batch/BatchSessionYarnFactory.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/batch/BatchSessionYarnFactory.scala
@@ -25,8 +25,8 @@ import com.cloudera.livy.yarn.LivyYarnClient
 class BatchSessionYarnFactory(client: LivyYarnClient, factory: SparkProcessBuilderFactory)
   extends BatchSessionFactory(factory) {
 
-  protected override def create(id: Int, process: SparkProcess): BatchSession =
-    BatchSessionYarn(client, id, process)
+  protected override def create(id: Int, owner: String, process: SparkProcess): BatchSession =
+    BatchSessionYarn(client, id, owner, process)
 
   override def sparkBuilder(request: CreateBatchRequest): SparkProcessBuilder = {
     val builder = super.sparkBuilder(request)

--- a/spark/src/main/scala/com/cloudera/livy/spark/client/ClientSessionFactory.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/client/ClientSessionFactory.scala
@@ -23,7 +23,8 @@ import com.cloudera.livy.sessions.SessionFactory
 
 class ClientSessionFactory extends SessionFactory[ClientSession, CreateClientRequest]{
 
-  override def create(id: Int, request: CreateClientRequest): ClientSession = {
-    new ClientSession(id, request, livyHome)
+  override def create(id: Int, owner: String, request: CreateClientRequest): ClientSession = {
+    new ClientSession(id, owner, request, livyHome)
   }
+
 }

--- a/spark/src/main/scala/com/cloudera/livy/spark/interactive/InteractiveSessionFactory.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/interactive/InteractiveSessionFactory.scala
@@ -44,17 +44,21 @@ abstract class InteractiveSessionFactory(processFactory: SparkProcessBuilderFact
 
   import InteractiveSessionFactory._
 
-  def create(id: Int, request: CreateInteractiveRequest): InteractiveSession = {
+  override def create(
+      id: Int,
+      owner: String,
+      request: CreateInteractiveRequest): InteractiveSession = {
     require(request.kind != null, "Session kind is required.")
     val builder = sparkBuilder(id, request)
     val kind = request.kind.toString
     val process = builder.start(None, List(kind))
 
-    create(id, process, request)
+    create(id, owner, process, request)
   }
 
   protected def create(
       id: Int,
+      owner: String,
       process: SparkProcess,
       request: CreateInteractiveRequest): InteractiveSession
 

--- a/spark/src/main/scala/com/cloudera/livy/spark/interactive/InteractiveSessionProcess.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/interactive/InteractiveSessionProcess.scala
@@ -23,23 +23,14 @@ import java.net.URL
 import scala.annotation.tailrec
 import scala.concurrent.Future
 
-import com.cloudera.livy.Logging
-import com.cloudera.livy.sessions.interactive.InteractiveSession
 import com.cloudera.livy.spark.SparkProcess
 
-object InteractiveSessionProcess extends Logging {
-
-  def apply(id: Int,
-            process: SparkProcess,
-            createInteractiveRequest: CreateInteractiveRequest): InteractiveSession = {
-    new InteractiveSessionProcess(id, process, createInteractiveRequest)
-  }
-}
-
-private class InteractiveSessionProcess(id: Int,
-                                        process: SparkProcess,
-                                        request: CreateInteractiveRequest)
-  extends InteractiveWebSession(id, process, request) {
+private class InteractiveSessionProcess(
+    id: Int,
+    owner: String,
+    process: SparkProcess,
+    request: CreateInteractiveRequest)
+  extends InteractiveWebSession(id, owner, process, request) {
 
   val stdoutThread = new Thread {
     override def run() = {

--- a/spark/src/main/scala/com/cloudera/livy/spark/interactive/InteractiveSessionProcessFactory.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/interactive/InteractiveSessionProcessFactory.scala
@@ -30,8 +30,9 @@ class InteractiveSessionProcessFactory(processFactory: SparkProcessBuilderFactor
 
   protected override def create(
       id: Int,
+      owner: String,
       process: SparkProcess,
       createInteractiveRequest: CreateInteractiveRequest): InteractiveSession = {
-    InteractiveSessionProcess(id, process, createInteractiveRequest)
+    new InteractiveSessionProcess(id, owner, process, createInteractiveRequest)
   }
 }

--- a/spark/src/main/scala/com/cloudera/livy/spark/interactive/InteractiveSessionYarn.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/interactive/InteractiveSessionYarn.scala
@@ -28,29 +28,16 @@ import com.cloudera.livy.sessions.interactive.InteractiveSession
 import com.cloudera.livy.spark.SparkProcess
 import com.cloudera.livy.yarn.LivyYarnClient
 
-object InteractiveSessionYarn {
-  protected implicit def executor: ExecutionContextExecutor = ExecutionContext.global
-
-  private lazy val regex = """Application report for (\w+)""".r.unanchored
-
-  def apply(client: LivyYarnClient,
-            id: Int,
-            process: SparkProcess,
-            request: CreateInteractiveRequest): InteractiveSession = {
-    new InteractiveSessionYarn(id, client, process, request)
-  }
-}
-
-private class InteractiveSessionYarn(id: Int,
-                                     client: LivyYarnClient,
-                                     process: SparkProcess,
-                                     request: CreateInteractiveRequest)
-  extends InteractiveWebSession(id, process, request) {
+private class InteractiveSessionYarn(
+    id: Int,
+    owner: String,
+    client: LivyYarnClient,
+    process: SparkProcess,
+    request: CreateInteractiveRequest)
+  extends InteractiveWebSession(id, owner, process, request) {
 
   private val job = Future {
-    val job = client.getJobFromProcess(process)
-
-    job
+    client.getJobFromProcess(process)
   }
 
   job.onFailure { case _ =>

--- a/spark/src/main/scala/com/cloudera/livy/spark/interactive/InteractiveSessionYarnFactory.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/interactive/InteractiveSessionYarnFactory.scala
@@ -31,10 +31,12 @@ class InteractiveSessionYarnFactory(
 
   implicit def executor: ExecutionContext = ExecutionContext.global
 
-  protected override def create(id: Int,
-                                process: SparkProcess,
-                                request: CreateInteractiveRequest): InteractiveSession = {
-    InteractiveSessionYarn(client, id, process, request)
+  protected override def create(
+      id: Int,
+      owner: String,
+      process: SparkProcess,
+      request: CreateInteractiveRequest): InteractiveSession = {
+    new InteractiveSessionYarn(id, owner, client, process, request)
   }
 
   override def sparkBuilder(id: Int, request: CreateInteractiveRequest): SparkProcessBuilder = {

--- a/spark/src/main/scala/com/cloudera/livy/spark/interactive/InteractiveWebSession.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/interactive/InteractiveWebSession.scala
@@ -35,10 +35,12 @@ import com.cloudera.livy.sessions._
 import com.cloudera.livy.sessions.interactive.{InteractiveSession, Statement}
 import com.cloudera.livy.spark.SparkProcess
 
-abstract class InteractiveWebSession(val id: Int,
-                                     process: SparkProcess,
-                                     request: CreateInteractiveRequest)
-  extends InteractiveSession
+abstract class InteractiveWebSession(
+    id: Int,
+    owner: String,
+    process: SparkProcess,
+    request: CreateInteractiveRequest)
+  extends InteractiveSession(id, owner)
   with Logging {
 
   protected implicit def executor: ExecutionContextExecutor = ExecutionContext.global

--- a/spark/src/test/scala/com/cloudera/livy/spark/batch/BatchProcessSpec.scala
+++ b/spark/src/test/scala/com/cloudera/livy/spark/batch/BatchProcessSpec.scala
@@ -61,7 +61,7 @@ class BatchProcessSpec
 
       val livyConf = new LivyConf()
       val builder = new BatchSessionProcessFactory(new SparkProcessBuilderFactory(livyConf))
-      val batch = builder.create(0, req)
+      val batch = builder.create(0, null, req)
 
       Utils.waitUntil({ () => !batch.state.isActive }, Duration(10, TimeUnit.SECONDS))
       (batch.state match {

--- a/spark/src/test/scala/com/cloudera/livy/spark/interactive/InteractiveSessionProcessSpec.scala
+++ b/spark/src/test/scala/com/cloudera/livy/spark/interactive/InteractiveSessionProcessSpec.scala
@@ -36,6 +36,6 @@ class InteractiveSessionProcessSpec extends BaseInteractiveSessionSpec {
 
     val req = new CreateInteractiveRequest()
     req.kind = PySpark()
-    interactiveFactory.create(0, req)
+    interactiveFactory.create(0, null, req)
   }
 }


### PR DESCRIPTION
This change adds support for SPNEGO authentication (a.k.a.
Kerberos) using the hadoop-auth library; it also adds basic
authorization to SessionServlet, so that only owners of
sessions can modify them.

The changes to implement the above are kinda small. To see them,
filter through all the noise by looking at these files directly.

- Main.scala: configure and install the SPNEGO filter.
- SessionServlet.scala: do authorization checks when performing
  actions on sessions.
- SessionServletSpec.scala: test suite for the authorization part.

There were minor changes to the batch and interactive servlets to
use the APIs that do auth checks, instead of the copy & pasted code
they currently were using.

Everything else is noise needed to plumb the owner info through all
the different session factories and types...