### PR TITLE
LIVY-65. Dependency and package cleanup.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -19,17 +19,18 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.cloudera.livy</groupId>
-    <artifactId>livy-main_2.10</artifactId>
+    <artifactId>livy-main</artifactId>
     <version>0.2.0-SNAPSHOT</version>
   </parent>
 
   <groupId>com.cloudera.livy</groupId>
-  <artifactId>livy-api_2.10</artifactId>
+  <artifactId>livy-api</artifactId>
   <version>0.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <properties>
     <copyright.header>${asf.copyright.header}</copyright.header>
+    <skipDeploy>false</skipDeploy>
   </properties>
 
   <dependencies>

--- a/assembly/assembly.xml
+++ b/assembly/assembly.xml
@@ -3,46 +3,41 @@
   xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
   <id>livy-server</id>
   <formats>
-    <format>tar.gz</format>
+    <format>zip</format>
   </formats>
   <includeBaseDirectory>false</includeBaseDirectory>
   <fileSets>
     <fileSet>
-      <directory>${project.build.directory}/libs</directory>
-      <outputDirectory>${install.dir}/libs</outputDirectory>
-    </fileSet>
-    <fileSet>
-      <directory>${project.build.directory}/jars</directory>
-      <outputDirectory>${install.dir}/jars</outputDirectory>
-    </fileSet>
-    <fileSet>
-      <directory>${project.build.directory}/client-jars</directory>
-      <outputDirectory>${install.dir}/client-jars</outputDirectory>
-    </fileSet>
-    <fileSet>
       <directory>${project.parent.basedir}/bin</directory>
-      <outputDirectory>${install.dir}/bin</outputDirectory>
+      <outputDirectory>${assembly.name}/bin</outputDirectory>
       <includes>
         <include>*</include>
       </includes>
     </fileSet>
     <fileSet>
       <directory>${project.parent.basedir}/conf</directory>
-      <outputDirectory>${install.dir}/conf</outputDirectory>
+      <outputDirectory>${assembly.name}/conf</outputDirectory>
       <includes>
         <include>*</include>
       </includes>
     </fileSet>
     <fileSet>
       <directory>${project.parent.basedir}/client-local/target/jars</directory>
-      <outputDirectory>${install.dir}/client-jars</outputDirectory>
+      <outputDirectory>${assembly.name}/client-jars</outputDirectory>
       <includes>
         <include>*</include>
       </includes>
     </fileSet>
     <fileSet>
       <directory>${project.parent.basedir}/repl/target/jars</directory>
-      <outputDirectory>${install.dir}/repl-jars</outputDirectory>
+      <outputDirectory>${assembly.name}/repl-jars</outputDirectory>
+      <includes>
+        <include>*</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.parent.basedir}/server/target/jars</directory>
+      <outputDirectory>${assembly.name}/jars</outputDirectory>
       <includes>
         <include>*</include>
       </includes>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -20,40 +20,35 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.cloudera.livy</groupId>
-    <artifactId>livy-main_2.10</artifactId>
+    <artifactId>livy-main</artifactId>
     <version>0.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>livy-assembly_2.10</artifactId>
+  <artifactId>livy-assembly</artifactId>
   <version>0.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>
-    <install.dir>livy-server</install.dir>
-    <assembly.finalName>livy-server-${project.version}_${scala.binary.version}</assembly.finalName>
+    <assembly.name>livy-server-${project.version}</assembly.name>
   </properties>
 
   <dependencies>
-
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>livy-repl_${scala.binary.version}</artifactId>
+      <artifactId>livy-client-local</artifactId>
       <version>${project.version}</version>
     </dependency>
-
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>livy-yarn_${scala.binary.version}</artifactId>
+      <artifactId>livy-repl</artifactId>
       <version>${project.version}</version>
     </dependency>
-
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>livy-server_${scala.binary.version}</artifactId>
+      <artifactId>livy-server</artifactId>
       <version>${project.version}</version>
     </dependency>
-
   </dependencies>
 
   <build>
@@ -61,57 +56,22 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>copy-dependencies</id>
-            <phase>package</phase>
-            <goals>
-              <goal>copy-dependencies</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}/jars</outputDirectory>
-              <useSubDirectoryPerType>false</useSubDirectoryPerType>
-              <includeScope>runtime</includeScope>
-              <silent>true</silent>
-              <overWriteReleases>true</overWriteReleases>
-              <overWriteSnapshots>true</overWriteSnapshots>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <configuration>
-          <appendAssemblyId>false</appendAssemblyId>
-          <descriptors>
-            <descriptor>assembly.xml</descriptor>
-          </descriptors>
-        </configuration>
         <executions>
           <execution>
-            <id>livy-assembly</id>
             <phase>package</phase>
             <goals>
               <goal>single</goal>
             </goals>
             <configuration>
-              <finalName>${assembly.finalName}</finalName>
-              <formats>
-                <format>zip</format>
-              </formats>
+              <finalName>${assembly.name}</finalName>
+              <appendAssemblyId>false</appendAssemblyId>
+              <descriptors>
+                <descriptor>assembly.xml</descriptor>
+              </descriptors>
             </configuration>
           </execution>
         </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
       </plugin>
 
       <plugin>
@@ -122,7 +82,7 @@
         </configuration>
       </plugin>
 
-    </plugins>
+      </plugins>
   </build>
 
 </project>

--- a/bin/livy-server
+++ b/bin/livy-server
@@ -25,7 +25,7 @@ cd $LIVY_HOME
 
 LIBDIR="$LIVY_HOME/jars"
 if [ ! -d "$LIBDIR" ]; then
-  LIBDIR="$LIVY_HOME/assembly/target/jars"
+  LIBDIR="$LIVY_HOME/server/target/jars"
 fi
 if [ ! -d "$LIBDIR" ]; then
   echo "Could not find Livy jars directory." 1>&2

--- a/client-common/pom.xml
+++ b/client-common/pom.xml
@@ -20,19 +20,23 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.cloudera.livy</groupId>
-    <artifactId>livy-main_2.10</artifactId>
+    <artifactId>livy-main</artifactId>
     <version>0.2.0-SNAPSHOT</version>
   </parent>
 
   <groupId>com.cloudera.livy</groupId>
-  <artifactId>livy-client-common_2.10</artifactId>
+  <artifactId>livy-client-common</artifactId>
   <version>0.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
+
+  <properties>
+    <skipDeploy>false</skipDeploy>
+  </properties>
 
   <dependencies>
     <dependency>
       <groupId>com.cloudera.livy</groupId>
-      <artifactId>livy-api_${scala.binary.version}</artifactId>
+      <artifactId>livy-api</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/client-http/pom.xml
+++ b/client-http/pom.xml
@@ -20,27 +20,28 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.cloudera.livy</groupId>
-    <artifactId>livy-main_2.10</artifactId>
+    <artifactId>livy-main</artifactId>
     <version>0.2.0-SNAPSHOT</version>
   </parent>
 
   <groupId>com.cloudera.livy</groupId>
-  <artifactId>livy-client-http_2.10</artifactId>
+  <artifactId>livy-client-http</artifactId>
   <version>0.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <properties>
-
+    <skipDeploy>false</skipDeploy>
   </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.cloudera.livy</groupId>
-      <artifactId>livy-api_${scala.binary.version}</artifactId>
+      <artifactId>livy-api</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.cloudera.livy</groupId>
-      <artifactId>livy-client-common_${scala.binary.version}</artifactId>
+      <artifactId>livy-client-common</artifactId>
       <version>${project.version}</version>
     </dependency>
 
@@ -62,17 +63,17 @@
       <artifactId>httpcore</artifactId>
       <version>4.4.4</version>
     </dependency>
-
-    <dependency>
-      <groupId>com.cloudera.livy</groupId>
-      <artifactId>livy-server_${scala.binary.version}</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpmime</artifactId>
       <version>4.5.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.cloudera.livy</groupId>
+      <artifactId>livy-server</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 
@@ -94,6 +95,10 @@
                 <includes>
                   <include>*:*</include>
                 </includes>
+                <excludes>
+                  <exclude>com.cloudera.livy:livy-api</exclude>
+                  <exclude>com.cloudera.livy:livy-client-common</exclude>
+                </excludes>
               </artifactSet>
               <filters>
                 <!-- Some artifacts (e.g. kryo) bundle jars inside them, for some reason. -->
@@ -109,23 +114,14 @@
                 <relocation>
                   <pattern>com.esotericsoftware</pattern>
                   <shadedPattern>com.cloudera.livy.shaded.kryo</shadedPattern>
-                  <includes>
-                    <include>com.esotericsoftware.**</include>
-                  </includes>
                 </relocation>
                 <relocation>
                   <pattern>com.fasterxml.jackson</pattern>
                   <shadedPattern>com.cloudera.livy.shaded.jackson</shadedPattern>
-                  <includes>
-                    <include>com.fasterxml.jackson.**</include>
-                  </includes>
                 </relocation>
                 <relocation>
                   <pattern>org.apache</pattern>
                   <shadedPattern>com.cloudera.livy.shaded.apache</shadedPattern>
-                  <includes>
-                    <include>org.apache.**</include>
-                  </includes>
                 </relocation>
               </relocations>
             </configuration>

--- a/client-local/pom.xml
+++ b/client-local/pom.xml
@@ -20,28 +20,29 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.cloudera.livy</groupId>
-    <artifactId>livy-main_2.10</artifactId>
+    <artifactId>livy-main</artifactId>
     <version>0.2.0-SNAPSHOT</version>
   </parent>
 
   <groupId>com.cloudera.livy</groupId>
-  <artifactId>livy-client-local_2.10</artifactId>
+  <artifactId>livy-client-local</artifactId>
   <version>0.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <properties>
     <copyright.header>${asf.copyright.header}</copyright.header>
+    <skipDeploy>false</skipDeploy>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>com.cloudera.livy</groupId>
-      <artifactId>livy-api_${scala.binary.version}</artifactId>
+      <artifactId>livy-api</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.cloudera.livy</groupId>
-      <artifactId>livy-client-common_${scala.binary.version}</artifactId>
+      <artifactId>livy-client-common</artifactId>
       <version>${project.version}</version>
     </dependency>
 
@@ -108,19 +109,10 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
-            <id>copy-dependencies</id>
             <phase>package</phase>
             <goals>
               <goal>copy-dependencies</goal>
             </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}/jars</outputDirectory>
-              <useSubDirectoryPerType>false</useSubDirectoryPerType>
-              <includeScope>runtime</includeScope>
-              <silent>true</silent>
-              <overWriteReleases>true</overWriteReleases>
-              <overWriteSnapshots>true</overWriteSnapshots>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/client-local/src/main/java/com/cloudera/livy/client/local/LocalClient.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/LocalClient.java
@@ -52,7 +52,6 @@ import com.google.common.io.Resources;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.Promise;
-import org.apache.spark.SparkException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,7 +85,7 @@ public class LocalClient implements LivyClient {
   private final ClientProtocol protocol;
   private volatile boolean isAlive;
 
-  LocalClient(LocalClientFactory factory, LocalConf conf) throws IOException, SparkException {
+  LocalClient(LocalClientFactory factory, LocalConf conf) throws IOException {
     this.factory = factory;
     this.conf = conf;
     this.childIdGenerator = new AtomicInteger();
@@ -506,7 +505,8 @@ public class LocalClient implements LivyClient {
       JobHandleImpl<?> handle = jobs.remove(msg.id);
       if (handle != null) {
         LOG.info("Received result for {}", msg.id);
-        Throwable error = msg.error != null ? new SparkException(msg.error) : null;
+        // TODO: need a better exception for this.
+        Throwable error = msg.error != null ? new RuntimeException(msg.error) : null;
         if (error == null) {
           handle.setSuccess(msg.result);
         } else {

--- a/client-local/src/test/java/com/cloudera/livy/client/local/TestSparkClient.java
+++ b/client-local/src/test/java/com/cloudera/livy/client/local/TestSparkClient.java
@@ -35,7 +35,6 @@ import java.util.zip.ZipEntry;
 import com.google.common.base.Objects;
 import com.google.common.base.Strings;
 import com.google.common.io.ByteStreams;
-import org.apache.spark.SparkException;
 import org.apache.spark.SparkFiles;
 import org.apache.spark.api.java.JavaFutureAction;
 import org.apache.spark.api.java.JavaRDD;
@@ -129,7 +128,6 @@ public class TestSparkClient {
           handle.get(TIMEOUT, TimeUnit.SECONDS);
           fail("Should have thrown an exception.");
         } catch (ExecutionException ee) {
-          assertTrue(ee.getCause() instanceof SparkException);
           assertTrue(ee.getCause().getMessage().contains("IllegalStateException: Hello"));
         }
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,19 +22,19 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.cloudera.livy</groupId>
-    <artifactId>livy-main_2.10</artifactId>
+    <artifactId>livy-main</artifactId>
     <version>0.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>livy-core_2.10</artifactId>
+  <artifactId>livy-core</artifactId>
   <version>0.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <dependencies>
     <dependency>
       <groupId>com.cloudera.livy</groupId>
-      <artifactId>livy-client-common_${scala.binary.version}</artifactId>
+      <artifactId>livy-client-common</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.cloudera.livy</groupId>
-  <artifactId>livy-main_2.10</artifactId>
+  <artifactId>livy-main</artifactId>
   <version>0.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
@@ -61,7 +61,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <py4j.version>0.8.2.1</py4j.version>
     <scala.binary.version>2.10</scala.binary.version>
-    <scala.compat.version>2.10</scala.compat.version>
     <scala.version>2.10.4</scala.version>
     <scalatest.version>2.2.4</scalatest.version>
     <scalatra.version>2.3.0</scalatra.version>
@@ -75,6 +74,12 @@
       Properties for the copyright header style checks. Modules that use the ASF header
       should override the "copyright.header" property.
     -->
+
+    <!--
+      By default artifacts are not deployed. Artifacts that should be deployed to a maven
+      repo should override the "skipDeploy" property in their pom.
+    -->
+    <skipDeploy>true</skipDeploy>
 
     <asf.copyright.header><![CDATA[/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -841,6 +846,28 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>${skipDeploy}</skip>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.10</version>
+        <configuration>
+          <outputDirectory>${project.build.directory}/jars</outputDirectory>
+          <useSubDirectoryPerType>false</useSubDirectoryPerType>
+          <includeScope>runtime</includeScope>
+          <silent>true</silent>
+          <overWriteReleases>true</overWriteReleases>
+          <overWriteSnapshots>true</overWriteSnapshots>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
       </plugin>
 
@@ -871,6 +898,7 @@
           </execution>
         </executions>
       </plugin>
+
     </plugins>
 
   </build>

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -22,12 +22,12 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.cloudera.livy</groupId>
-        <artifactId>livy-main_2.10</artifactId>
+        <artifactId>livy-main</artifactId>
         <relativePath>../pom.xml</relativePath>
         <version>0.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>livy-repl_2.10</artifactId>
+    <artifactId>livy-repl</artifactId>
     <version>0.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
@@ -35,7 +35,7 @@
 
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>livy-core_${scala.binary.version}</artifactId>
+            <artifactId>livy-core</artifactId>
             <version>${project.version}</version>
         </dependency>
 
@@ -202,19 +202,10 @@
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>copy-dependencies</id>
                         <phase>package</phase>
                         <goals>
                             <goal>copy-dependencies</goal>
                         </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/jars</outputDirectory>
-                            <useSubDirectoryPerType>false</useSubDirectoryPerType>
-                            <includeScope>runtime</includeScope>
-                            <silent>true</silent>
-                            <overWriteReleases>true</overWriteReleases>
-                            <overWriteSnapshots>true</overWriteSnapshots>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -22,12 +22,12 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.cloudera.livy</groupId>
-        <artifactId>livy-main_2.10</artifactId>
+        <artifactId>livy-main</artifactId>
         <relativePath>../pom.xml</relativePath>
         <version>0.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>livy-server_2.10</artifactId>
+    <artifactId>livy-server</artifactId>
     <version>0.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
@@ -35,27 +35,19 @@
 
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>livy-core_${scala.binary.version}</artifactId>
+            <artifactId>livy-core</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>livy-core_${scala.binary.version}</artifactId>
-            <version>${project.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>livy-spark_${scala.binary.version}</artifactId>
+            <artifactId>livy-spark</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>livy-yarn_${scala.binary.version}</artifactId>
+            <artifactId>livy-yarn</artifactId>
             <version>${project.version}</version>
         </dependency>
 
@@ -67,6 +59,11 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
         </dependency>
 
         <dependency>
@@ -92,11 +89,23 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
+            <exclusions>
+              <exclusion>
+                <groupId>javax.servlet</groupId>
+                <artifactId>servlet-api</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -177,7 +186,6 @@
 
     <build>
         <plugins>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -187,25 +195,21 @@
                             <mainClass>com.cloudera.livy.server.Main</mainClass>
                         </manifest>
                     </archive>
+                    <outputDirectory>${project.build.directory}/jars</outputDirectory>
                 </configuration>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <groupId>org.scalatest</groupId>
-                <artifactId>scalatest-maven-plugin</artifactId>
-                <configuration>
-                    <systemProperties>
-                        <spark.master>local</spark.master>
-                        <spark.ui.enabled>false</spark.ui.enabled>
-                        <settings.usejavacp.value>true</settings.usejavacp.value>
-                        <livy.repl.jar>../livy-repl/target/livy-repl_${scala.binary.version}-${project.version}.jar</livy.repl.jar>
-                    </systemProperties>
-                </configuration>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
         </plugins>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -22,12 +22,12 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.cloudera.livy</groupId>
-    <artifactId>livy-main_2.10</artifactId>
+    <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
     <version>0.2.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>livy-spark_2.10</artifactId>
+  <artifactId>livy-spark</artifactId>
   <version>0.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
@@ -35,19 +35,19 @@
 
     <dependency>
       <groupId>com.cloudera.livy</groupId>
-      <artifactId>livy-client-local_${scala.binary.version}</artifactId>
+      <artifactId>livy-client-local</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>com.cloudera.livy</groupId>
-      <artifactId>livy-core_${scala.binary.version}</artifactId>
+      <artifactId>livy-core</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>com.cloudera.livy</groupId>
-      <artifactId>livy-core_${scala.binary.version}</artifactId>
+      <artifactId>livy-core</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
@@ -55,25 +55,26 @@
 
     <dependency>
       <groupId>com.cloudera.livy</groupId>
-      <artifactId>livy-repl_${scala.binary.version}</artifactId>
+      <artifactId>livy-repl</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>com.cloudera.livy</groupId>
-      <artifactId>livy-yarn_${scala.binary.version}</artifactId>
+      <artifactId>livy-yarn</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -97,11 +98,6 @@
     <dependency>
       <groupId>org.json4s</groupId>
       <artifactId>json4s-core_${scala.binary.version}</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.10</artifactId>
     </dependency>
 
     <dependency>
@@ -147,9 +143,6 @@
             <spark.master>local</spark.master>
             <spark.ui.enabled>false</spark.ui.enabled>
             <settings.usejavacp.value>true</settings.usejavacp.value>
-            <livy.repl.jar>
-              ../livy-repl/target/livy-repl_${scala.binary.version}-${project.version}.jar
-            </livy.repl.jar>
           </systemProperties>
         </configuration>
       </plugin>

--- a/spark/src/main/scala/com/cloudera/livy/spark/interactive/CreateInteractiveRequest.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/interactive/CreateInteractiveRequest.scala
@@ -18,13 +18,11 @@
 
 package com.cloudera.livy.spark.interactive
 
-import com.fasterxml.jackson.annotation.JsonProperty
-
 import com.cloudera.livy.sessions.Kind
 
 class CreateInteractiveRequest {
 
-  @JsonProperty(required = true) var kind: Kind = _
+  var kind: Kind = _
   var proxyUser: Option[String] = None
   var jars: List[String] = List()
   var pyFiles: List[String] = List()

--- a/yarn/pom.xml
+++ b/yarn/pom.xml
@@ -22,12 +22,12 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.cloudera.livy</groupId>
-        <artifactId>livy-main_2.10</artifactId>
+        <artifactId>livy-main</artifactId>
         <relativePath>../pom.xml</relativePath>
         <version>0.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>livy-yarn_2.10</artifactId>
+    <artifactId>livy-yarn</artifactId>
     <version>0.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
@@ -40,7 +40,7 @@
 
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>livy-core_${scala.binary.version}</artifactId>
+            <artifactId>livy-core</artifactId>
             <version>${project.version}</version>
         </dependency>
 


### PR DESCRIPTION
A few changes to the build and packaging:

- Drop the "_2.10" prefix from Livy artifacts. The version of Scala does
  not matter for Livy; the server can talk to backends running whatever
  version of Scala (or no Scala at all). So it doesn't make sense to
  expose that.

- Remove Spark classes that leaked through the public API paths; this makes
  sure clients can run without Spark classes in the classpath.

- Clean up the module poms and assembly descriptor a bit.

- Make deployment to a maven repo "opt in", so that we control artifacts that
  should be published.

Note that Scala dependencies are still stuck at 2.10. This means Livy cannot
currently run (or even compile) its repl against a Spark that's using 2.11.
That's a separate future enhancement, though.