### PR TITLE
LIVY-64, LIVY-69. Make JsonServlet process all route outputs.

### DIFF
--- a/server/src/main/scala/com/cloudera/livy/server/JsonServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/JsonServlet.scala
@@ -36,7 +36,7 @@ import org.scalatra._
  * Serialization and deserialization are done through Jackson directly, so all Jackson features
  * are available.
  */
-abstract class JsonServlet extends ScalatraServlet with FutureSupport {
+abstract class JsonServlet extends ScalatraServlet with ApiFormats with FutureSupport {
 
   override protected implicit def executor: ExecutionContext = ExecutionContext.global
 
@@ -51,71 +51,51 @@ abstract class JsonServlet extends ScalatraServlet with FutureSupport {
 
   protected final val mapper = createMapper()
 
+  before() {
+    contentType = formats("json")
+  }
+
   error {
     case e: JsonParseException => BadRequest(e.getMessage)
   }
 
-  protected def jdelete(t: RouteTransformer*)(action: => Any): Route = {
-    delete(t: _*) {
-      doAction[Unit](request, response, _ => action)
-    }
-  }
-
-  protected def jget(t: RouteTransformer*)(action: => Any): Route = {
-    get(t: _*) {
-      doAction[Unit](request, response, _ => action)
-    }
-  }
-
   protected def jpatch[T: ClassTag](t: RouteTransformer*)(action: T => Any): Route = {
     patch(t: _*) {
-      doAction(request, response, action)
+      doAction(request, action)
     }
   }
 
   protected def jpost[T: ClassTag](t: RouteTransformer*)(action: T => Any): Route = {
     post(t: _*) {
-      doAction(request, response, action)
+      doAction(request, action)
     }
   }
 
   protected def jput[T: ClassTag](t: RouteTransformer*)(action: T => Any): Route = {
     put(t: _*) {
-      doAction[T](request, response, action)
+      doAction(request, action)
     }
+  }
+
+  override protected def renderResponse(actionResult: Any): Unit = {
+    val result = actionResult match {
+      case async: AsyncResult =>
+        async
+      case ActionResult(status, body, headers) if format == "json" =>
+        ActionResult(status, toJson(body), headers)
+      case other if format == "json" =>
+        Ok(toJson(other))
+      case other =>
+        other
+    }
+    super.renderResponse(result)
   }
 
   private def doAction[T: ClassTag](
       req: HttpServletRequest,
-      res: HttpServletResponse,
       action: T => Any)(implicit klass: ClassTag[T]): Any = {
-    val arg =
-      if (klass.runtimeClass != classOf[Unit]) {
-        mapper.readValue(req.getInputStream(), klass.runtimeClass).asInstanceOf[T]
-      } else {
-        ()
-      }
-
-    toResult(action(arg.asInstanceOf[T]), res)
-  }
-
-  private def isJson(res: HttpServletResponse, headers: Map[String, String] = Map()): Boolean = {
-    val ctypeHeader = "Content-Type"
-    headers.get(ctypeHeader).orElse(Option(res.getHeader(ctypeHeader)))
-      .map(_.startsWith("application/json")).getOrElse(false)
-  }
-
-  private def toResult(obj: Any, res: HttpServletResponse): Any = obj match {
-    case async: AsyncResult =>
-      new AsyncResult {
-        val is = async.is.map(toResult(_, res))
-      }
-    case ActionResult(status, body, headers) if isJson(res, headers) =>
-      ActionResult(status, toJson(body), headers)
-    case body if isJson(res) =>
-      Ok(toJson(body))
-    case other =>
-      other
+    val arg = mapper.readValue(req.getInputStream(), klass.runtimeClass).asInstanceOf[T]
+    action(arg.asInstanceOf[T])
   }
 
   private def toJson(obj: Any): Any = {

--- a/server/src/main/scala/com/cloudera/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/SessionServlet.scala
@@ -52,11 +52,7 @@ abstract class SessionServlet[S <: Session, R: ClassTag](sessionManager: Session
    */
   protected def clientSessionView(session: S, req: HttpServletRequest): Any = session
 
-  before() {
-    contentType = "application/json"
-  }
-
-  jget("/") {
+  get("/") {
     val from = params.get("from").map(_.toInt).getOrElse(0)
     val size = params.get("size").map(_.toInt).getOrElse(100)
 
@@ -69,19 +65,19 @@ abstract class SessionServlet[S <: Session, R: ClassTag](sessionManager: Session
     )
   }
 
-  val getSession = jget("/:id") {
+  val getSession = get("/:id") {
     withUnprotectedSession { session =>
       clientSessionView(session, request)
     }
   }
 
-  jget("/:id/state") {
+  get("/:id/state") {
     withUnprotectedSession { session =>
       Map("id" -> session.id, "state" -> session.state.toString)
     }
   }
 
-  jget("/:id/log") {
+  get("/:id/log") {
     withSession { session =>
       val from = params.get("from").map(_.toInt)
       val size = params.get("size").map(_.toInt)
@@ -95,7 +91,7 @@ abstract class SessionServlet[S <: Session, R: ClassTag](sessionManager: Session
     }
   }
 
-  jdelete("/:id") {
+  delete("/:id") {
     withSession { session =>
       sessionManager.delete(session.id) match {
       case Some(future) =>

--- a/server/src/main/scala/com/cloudera/livy/server/client/ClientSessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/client/ClientSessionServlet.scala
@@ -58,7 +58,7 @@ class ClientSessionServlet(sessionManager: SessionManager[ClientSession, CreateC
     }
   }
 
-  jpost[Unit]("/:id/upload-jar") { _ =>
+  post("/:id/upload-jar") {
     withSession { lsession =>
       fileParams.get("jar") match {
         case Some(file) =>
@@ -71,7 +71,7 @@ class ClientSessionServlet(sessionManager: SessionManager[ClientSession, CreateC
     }
   }
 
-  jpost[Unit]("/:id/upload-file") { _ =>
+  post("/:id/upload-file") {
     withSession { lsession =>
       fileParams.get("file") match {
         case Some(file) =>
@@ -102,14 +102,14 @@ class ClientSessionServlet(sessionManager: SessionManager[ClientSession, CreateC
     }
   }
 
-  jget("/:id/jobs/:jobid") {
+  get("/:id/jobs/:jobid") {
     withSession { lsession =>
       val jobId = params("jobid").toLong
       doAsync { Ok(lsession.jobStatus(jobId)) }
     }
   }
 
-  jpost[Unit]("/:id/jobs/:jobid/cancel") { _ =>
+  post("/:id/jobs/:jobid/cancel") {
     withSession { lsession =>
       val jobId = params("jobid").toLong
       doAsync { lsession.cancel(jobId) }

--- a/server/src/test/scala/com/cloudera/livy/server/JsonServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/JsonServletSpec.scala
@@ -92,11 +92,11 @@ private class TestJsonServlet extends JsonServlet {
     contentType = "application/json"
   }
 
-  jdelete("/delete") {
+  delete("/delete") {
     Ok(MethodReturn("delete"))
   }
 
-  jget("/get") {
+  get("/get") {
     Ok(MethodReturn("get"))
   }
 
@@ -113,7 +113,7 @@ private class TestJsonServlet extends JsonServlet {
     NotFound(arg.value)
   }
 
-  jget("/empty") {
+  get("/empty") {
     ()
   }
 

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionServletSpec.scala
@@ -129,6 +129,11 @@ class InteractiveSessionServletSpec
       data("output") should be (Map("value" -> 42))
     }
 
+    jget[Map[String, Any]]("/0/statements") { data =>
+      data("total_statements") should be (1)
+      data("statements").asInstanceOf[Seq[Map[String, Any]]](0)("id") should be (0)
+    }
+
     jdelete[Map[String, Any]]("/0") { data =>
       data should equal (Map("msg" -> "deleted"))
 


### PR DESCRIPTION
This change makes JsonServlet map the output object to JSON
whenever the result's type is json, not just when one of the
"j*" methods are used. This means that "get", "post" and friends
also use Jackson to map their results.

As a result, "jget" and "jdelete" are not needed anymore, and
the other methods don't need the weird syntax used to bypass
deserialization of the body. It also fixes existing routes that
were missed when JsonServlet was introduced.