### PR TITLE
Fix potential race in local client driver shutdown.

### DIFF
--- a/client-local/src/main/java/com/cloudera/livy/client/local/LocalClient.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/LocalClient.java
@@ -140,23 +140,22 @@ public class LocalClient implements LivyClient {
       isAlive = false;
       try {
         protocol.endSession();
+
+        try {
+          driverThread.join(DEFAULT_SHUTDOWN_TIMEOUT);
+        } catch (InterruptedException ie) {
+          LOG.debug("Interrupted before driver thread was finished.");
+        }
+        if (driverThread.isAlive()) {
+          LOG.warn("Timed out shutting down remote driver, interrupting...");
+          driverThread.interrupt();
+        }
       } catch (Exception e) {
         LOG.warn("Exception while waiting for end session reply.", e);
       } finally {
         driverRpc.close();
         factory.unref();
       }
-    }
-
-    long endTime = System.currentTimeMillis() + DEFAULT_SHUTDOWN_TIMEOUT;
-    try {
-      driverThread.join(DEFAULT_SHUTDOWN_TIMEOUT);
-    } catch (InterruptedException ie) {
-      LOG.debug("Interrupted before driver thread was finished.");
-    }
-    if (endTime - System.currentTimeMillis() <= 0) {
-      LOG.warn("Timed out shutting down remote driver, interrupting...");
-      driverThread.interrupt();
     }
   }
 

--- a/client-local/src/main/java/com/cloudera/livy/client/local/driver/JobContextImpl.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/driver/JobContextImpl.java
@@ -111,7 +111,10 @@ class JobContextImpl implements JobContext {
     monitorCb.set(cb);
   }
 
-  void stop() {
+  synchronized void stop() {
+    if (streamingctx != null) {
+      stopStreamingCtx();
+    }
     sc.stop();
   }
 

--- a/client-local/src/test/resources/log4j.properties
+++ b/client-local/src/test/resources/log4j.properties
@@ -21,3 +21,6 @@ log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.target=System.err
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+
+# Silence some verbose logs.
+log4j.logger.org.spark-project.jetty=WARN


### PR DESCRIPTION
I believe this is the cause of the timeouts that sometimes show up
in travis runs. Looking at logs from previous runs, it seems that
a new SparkContext is being instantiated while the old one is still
shutting down, meaning that both operations can run into each other
(there was an NPE in the logs that seems caused by that).

The reason seems to be that the client side requests a shutdown of
the driver, but doesn't wait until it actually shuts down completely
before tearing down RPC channels; that could cause the client to think
the driver was shut down when it was still in the process of doing it,
among other issues in the code.

The change makes the client wait for the driver to shutdown before
closing the RPC channel, and also changes the shutdown order in the
driver to be a little safer. Also, a small change to silence logs
that aren't really useful.