### PR TITLE
Create a fake SPARK_HOME so tests that fork Spark can run.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 
 before_script:
   - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
-  - echo "deb https://cran.cnr.berkeley.edu/bin/linux/ubuntu wily/" | sudo tee -a /etc/apt/sources.list
+  - echo "deb https://cran.cnr.berkeley.edu/bin/linux/ubuntu precise/" | sudo tee -a /etc/apt/sources.list
   - sudo apt-get update -q
   - sudo apt-get install r-base
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,18 @@ language: scala
 jdk:
   - oraclejdk7
 
+addons:
+  apt:
+    sources:
+      r-packages-precise
+    packages:
+      r-base
+
 script:
   - mvn verify -Dtest.redirectToFile=false
 
 before_install:
   - pip install --user codecov
-
-before_script:
-  - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
-  - echo "deb https://cran.cnr.berkeley.edu/bin/linux/ubuntu precise/" | sudo tee -a /etc/apt/sources.list
-  - sudo apt-get update -q
-  - sudo apt-get install r-base
 
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,17 @@ language: scala
 jdk:
   - oraclejdk7
 
-script: 
+script:
   - mvn verify -Dtest.redirectToFile=false
 
 before_install:
   - pip install --user codecov
+
+before_script:
+  - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
+  - echo "deb https://cran.cnr.berkeley.edu/bin/linux/ubuntu wily/" | sudo tee -a /etc/apt/sources.list
+  - sudo apt-get update -q
+  - sudo apt-get install r-base
 
 after_success:
   - codecov

--- a/client-local/src/test/java/com/cloudera/livy/client/local/TestSparkClient.java
+++ b/client-local/src/test/java/com/cloudera/livy/client/local/TestSparkClient.java
@@ -156,8 +156,6 @@ public class TestSparkClient {
 
   @Test
   public void testRemoteClient() throws Exception {
-    assumeTrue("Test requires a Spark installation in SPARK_HOME.",
-      System.getenv("SPARK_HOME") != null);
     runTest(false, new TestFunction() {
       @Override
       public void call(LivyClient client) throws Exception {

--- a/dev/spark/bin/spark-submit
+++ b/dev/spark/bin/spark-submit
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# This is a fake version of "spark-submit" to be used during Livy tests that run Spark as
+# a child process. It does some basic parsing of Spark options to figure out the classpath
+# to be used, and then just runs the SparkSubmit class directly.
+#
+
+PROP_FILE=
+DRIVER_CP=
+CONF_KEY="spark.driver.extraClassPath"
+
+INDEX=1
+ARGS=($@)
+
+for IDX in $(seq 0 ${#ARGS[@]}); do
+  ARG=${ARGS[$IDX]}
+  NEXT=$((IDX + 1))
+  case $ARG in
+    --conf)
+      CONF="${ARGS[$NEXT]}"
+      IFS='=' read KEY VALUE <<< "$CONF"
+      if [ "$KEY" = "$CONF_KEY" ]; then
+        DRIVER_CP="$VALUE"
+      fi
+      ;;
+    --driver-class-path)
+      DRIVER_CP="${ARGS[$NEXT]}"
+      ;;
+    --properties-file)
+      PROP_FILE="${ARGS[$NEXT]}"
+      ;;
+  esac
+done
+
+if [ -n "$PROP_FILE" ] && [ -z "$DRIVER_CP" ]; then
+  CONF=$(grep -s "^$CONF_KEY=" "$PROP_FILE" | tail -n 1)
+  if [ -n "$CONF" ]; then
+    IFS='=' read KEY VALUE <<< "$CONF"
+    DRIVER_CP="$VALUE"
+  fi
+fi
+
+exec $JAVA_HOME/bin/java -cp "$DRIVER_CP" org.apache.spark.deploy.SparkSubmit "$@"

--- a/dev/spark/bin/sparkR
+++ b/dev/spark/bin/sparkR
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# This is a fake version of "sparkR" that just runs "SPARKR_DRIVER_R", which during Livy tests is
+# just plain "R". So it can't really be used to test SparkR, but can be used to test the backend in
+# Livy.
+#
+
+CMD=${SPARKR_DRIVER_R:-R}
+exec $CMD

--- a/pom.xml
+++ b/pom.xml
@@ -626,6 +626,7 @@
           <configuration>
             <environmentVariables>
               <livy.test>true</livy.test>
+              <SPARK_HOME>${execution.root}/dev/spark</SPARK_HOME>
             </environmentVariables>
             <systemProperties>
               <java.awt.headless>true</java.awt.headless>
@@ -646,6 +647,7 @@
           <configuration>
             <environmentVariables>
               <livy.test>true</livy.test>
+              <SPARK_HOME>${execution.root}/dev/spark</SPARK_HOME>
             </environmentVariables>
             <systemProperties>
               <java.awt.headless>true</java.awt.headless>

--- a/repl/src/main/resources/fake_shell.py
+++ b/repl/src/main/resources/fake_shell.py
@@ -368,9 +368,6 @@ def main():
     sys.stderr = fake_stderr
 
     try:
-        # Load spark into the context
-        exec 'from pyspark.shell import sc' in global_dict
-
         print >> sys_stderr, fake_stdout.getvalue()
         print >> sys_stderr, fake_stderr.getvalue()
 
@@ -434,9 +431,6 @@ def main():
             print >> sys_stdout, response
             sys_stdout.flush()
     finally:
-        if 'sc' in global_dict:
-            global_dict['sc'].stop()
-
         sys.stdin = sys_stdin
         sys.stdout = sys_stdout
         sys.stderr = sys_stderr

--- a/repl/src/main/scala/com/cloudera/livy/repl/python/PythonInterpreter.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/python/PythonInterpreter.scala
@@ -31,7 +31,7 @@ import org.json4s.jackson.JsonMethods._
 import org.json4s.jackson.Serialization.write
 import py4j.GatewayServer
 
-import com.cloudera.livy.Logging
+import com.cloudera.livy.{LivyConf, Logging}
 import com.cloudera.livy.repl.Interpreter
 import com.cloudera.livy.repl.process.ProcessInterpreter
 
@@ -49,8 +49,8 @@ object PythonInterpreter extends Logging {
 
     val pythonPath = sys.env.getOrElse("PYTHONPATH", "")
       .split(File.pathSeparator)
-      .++(findPySparkArchives())
-      .++(findPyFiles())
+      .++(if (!LivyConf.TEST_MODE) findPySparkArchives() else Nil)
+      .++(if (!LivyConf.TEST_MODE) findPyFiles() else Nil)
 
     env.put("PYTHONPATH", pythonPath.mkString(File.pathSeparator))
     env.put("PYTHONUNBUFFERED", "YES")

--- a/repl/src/test/scala/com/cloudera/livy/repl/PythonInterpreterSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/PythonInterpreterSpec.scala
@@ -29,12 +29,6 @@ class PythonInterpreterSpec extends BaseInterpreterSpec {
 
   implicit val formats = DefaultFormats
 
-  override protected def withFixture(test: NoArgTest): Outcome = {
-    assume(sys.env.get("SPARK_HOME").isDefined,
-      "Test requires a Spark installation in SPARK_HOME.")
-    test()
-  }
-
   override def createInterpreter(): Interpreter = PythonInterpreter()
 
   it should "execute `1 + 2` == 3" in withInterpreter { interpreter =>
@@ -209,13 +203,4 @@ class PythonInterpreterSpec extends BaseInterpreterSpec {
     ))
   }
 
-
-  it should "execute spark commands" in withInterpreter { interpreter =>
-    val response = interpreter.execute(
-      """sc.parallelize(xrange(0, 2)).map(lambda i: i + 1).collect()""")
-
-    response should equal(Interpreter.ExecuteSuccess(
-      repl.TEXT_PLAIN -> "[1, 2]"
-    ))
-  }
 }

--- a/repl/src/test/scala/com/cloudera/livy/repl/SparkRInterpreterSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/SparkRInterpreterSpec.scala
@@ -28,12 +28,6 @@ class SparkRInterpreterSpec extends BaseInterpreterSpec {
 
   implicit val formats = DefaultFormats
 
-  override protected def withFixture(test: NoArgTest) = {
-    val sparkRExecutable = SparkRInterpreter.sparkRExecutable
-    assume(sparkRExecutable.isDefined, "Cannot find sparkR")
-    test()
-  }
-
   override def createInterpreter(): Interpreter = {
     SparkRInterpreter()
   }
@@ -90,23 +84,4 @@ class SparkRInterpreterSpec extends BaseInterpreterSpec {
     ))
   }
 
-  it should "execute spark commands" in withInterpreter { interpreter =>
-    val response = interpreter.execute(
-      """head(createDataFrame(sqlContext, faithful))""")
-
-    response match {
-      case Interpreter.ExecuteSuccess(map: JValue) =>
-        (map \ "text/plain").extract[String] should include (
-          """  eruptions waiting
-            |1     3.600      79
-            |2     1.800      54
-            |3     3.333      74
-            |4     2.283      62
-            |5     4.533      85
-            |6     2.883      55""".stripMargin)
-      case _ =>
-        throw new Exception("response is not a success")
-    }
-
-  }
 }

--- a/repl/src/test/scala/com/cloudera/livy/repl/SparkRSessionSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/SparkRSessionSpec.scala
@@ -23,17 +23,10 @@ import scala.concurrent.duration.Duration
 
 import org.json4s.Extraction
 import org.json4s.JsonAST.JValue
-import org.scalatest.{BeforeAndAfterAll, Outcome}
 
 import com.cloudera.livy.repl.sparkr.SparkRInterpreter
 
 class SparkRSessionSpec extends BaseSessionSpec {
-
-  override protected def withFixture(test: NoArgTest): Outcome = {
-    val sparkRExecutable = SparkRInterpreter.sparkRExecutable
-    assume(sparkRExecutable.isDefined, "Cannot find sparkR")
-    test()
-  }
 
   override def createInterpreter(): Interpreter = SparkRInterpreter()
 
@@ -53,7 +46,7 @@ class SparkRSessionSpec extends BaseSessionSpec {
     result should equal(expectedResult)
   }
 
-    it should "execute `x = 1`, then `y = 2`, then `x + y`" in withSession { session =>
+  it should "execute `x = 1`, then `y = 2`, then `x + y`" in withSession { session =>
     var statement = session.execute("x = 1")
     statement.id should equal (0)
 
@@ -97,7 +90,7 @@ class SparkRSessionSpec extends BaseSessionSpec {
     result should equal (expectedResult)
   }
 
-    it should "capture stdout from print" in withSession { session =>
+  it should "capture stdout from print" in withSession { session =>
     val statement = session.execute("""print('Hello World')""")
     statement.id should equal (0)
 
@@ -113,7 +106,7 @@ class SparkRSessionSpec extends BaseSessionSpec {
     result should equal (expectedResult)
   }
 
-    it should "capture stdout from cat" in withSession { session =>
+  it should "capture stdout from cat" in withSession { session =>
     val statement = session.execute("""cat(3)""")
     statement.id should equal (0)
 
@@ -129,7 +122,7 @@ class SparkRSessionSpec extends BaseSessionSpec {
     result should equal (expectedResult)
   }
 
-    it should "report an error if accessing an unknown variable" in withSession { session =>
+  it should "report an error if accessing an unknown variable" in withSession { session =>
     val statement = session.execute("""x""")
     statement.id should equal (0)
 
@@ -145,42 +138,4 @@ class SparkRSessionSpec extends BaseSessionSpec {
     result should equal (expectedResult)
   }
 
-    it should "access the spark context" in withSession { session =>
-    val statement = session.execute("""sc""")
-    statement.id should equal (0)
-
-    val result = Await.result(statement.result, Duration.Inf)
-    val resultMap = result.extract[Map[String, JValue]]
-
-    val expectedResult = Extraction.decompose(Map(
-      "status" -> "ok",
-      "execution_count" -> 0,
-      "data" -> Map(
-        "text/plain" -> "Java ref type org.apache.spark.api.java.JavaSparkContext id 0"
-      )
-    ))
-  }
-
-    it should "execute spark commands" in withSession { session =>
-    val statement = session.execute("""
-                                      |head(createDataFrame(sqlContext, faithful))
-                                      |""".stripMargin)
-    statement.id should equal (0)
-
-    val result = Await.result(statement.result, Duration.Inf)
-    val resultMap = result.extract[Map[String, JValue]]
-
-    // Manually extract since sparkr outputs a lot of spark logging information.
-    resultMap("status").extract[String] should equal ("ok")
-    resultMap("execution_count").extract[Int] should equal (0)
-
-    val data = resultMap("data").extract[Map[String, JValue]]
-    data("text/plain").extract[String] should include ("""  eruptions waiting
-                                                         |1     3.600      79
-                                                         |2     1.800      54
-                                                         |3     3.333      74
-                                                         |4     2.283      62
-                                                         |5     4.533      85
-                                                         |6     2.883      55""".stripMargin)
-  }
 }

--- a/server/src/test/scala/com/cloudera/livy/server/BaseSessionServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/BaseSessionServletSpec.scala
@@ -23,16 +23,9 @@ import org.scalatest.BeforeAndAfterAll
 import com.cloudera.livy.LivyConf
 import com.cloudera.livy.sessions.{Session, SessionFactory, SessionManager}
 
-abstract class BaseSessionServletSpec[S <: Session, R](needsSpark: Boolean = true)
+abstract class BaseSessionServletSpec[S <: Session, R]
   extends BaseJsonServletSpec
   with BeforeAndAfterAll {
-
-  override protected def withFixture(test: NoArgTest) = {
-    if (needsSpark) {
-      assume(sys.env.get("SPARK_HOME").isDefined, "SPARK_HOME is not set.")
-    }
-    test()
-  }
 
   override def afterAll(): Unit = {
     super.afterAll()

--- a/server/src/test/scala/com/cloudera/livy/server/SessionServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/SessionServletSpec.scala
@@ -45,7 +45,7 @@ object SessionServletSpec {
 }
 
 class SessionServletSpec
-  extends BaseSessionServletSpec[Session, Map[String, String]](needsSpark = false) {
+  extends BaseSessionServletSpec[Session, Map[String, String]] {
 
   import SessionServletSpec._
 

--- a/server/src/test/scala/com/cloudera/livy/server/batch/BatchServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/batch/BatchServletSpec.scala
@@ -61,6 +61,7 @@ class BatchServletSpec extends BaseSessionServletSpec[BatchSession, CreateBatchR
 
       val createRequest = new CreateBatchRequest()
       createRequest.file = script.toString
+      createRequest.conf = Map("spark.driver.extraClassPath" -> sys.props("java.class.path"))
 
       jpost[Map[String, Any]]("/", createRequest) { data =>
         header("Location") should equal("/0")

--- a/server/src/test/scala/com/cloudera/livy/server/client/ClientServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/client/ClientServletSpec.scala
@@ -44,7 +44,7 @@ import com.cloudera.livy.server.BaseSessionServletSpec
 import com.cloudera.livy.spark.client._
 
 class ClientServletSpec
-  extends BaseSessionServletSpec[ClientSession, CreateClientRequest](needsSpark = false) {
+  extends BaseSessionServletSpec[ClientSession, CreateClientRequest] {
 
   override def sessionFactory: ClientSessionFactory = new ClientSessionFactory()
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -125,6 +125,12 @@
       <artifactId>dispatch-json4s-jackson_${scala.binary.version}</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/spark/src/main/scala/com/cloudera/livy/spark/SparkProcessBuilder.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/SparkProcessBuilder.scala
@@ -121,7 +121,8 @@ class SparkProcessBuilder(
   }
 
   def conf(key: String, value: String, admin: Boolean = false): SparkProcessBuilder = {
-    if (admin || userConfigurableOptions.contains(key)) {
+    if (admin || userConfigurableOptions.contains(key) ||
+        (LivyConf.TEST_MODE && key == "spark.driver.extraClassPath")) {
       this._conf(key) = value
     } else {
       throw new ConfigOptionNotAllowed(key, value)

--- a/spark/src/main/scala/com/cloudera/livy/spark/interactive/InteractiveSessionFactory.scala
+++ b/spark/src/main/scala/com/cloudera/livy/spark/interactive/InteractiveSessionFactory.scala
@@ -88,8 +88,8 @@ abstract class InteractiveSessionFactory(processFactory: SparkProcessBuilderFact
 
         // FIXME: Spark-1.4 seems to require us to manually upload the PySpark support files.
         // We should only do this for Spark 1.4.x
-        val pySparkFiles = findPySparkArchives()
-        builder.files(pySparkFiles.map(AbsolutePath))
+        val pySparkFiles = if (!LivyConf.TEST_MODE) findPySparkArchives() else Nil
+        builder.files(if (!LivyConf.TEST_MODE) pySparkFiles.map(AbsolutePath) else Nil)
 
         // We can't actually use `builder.pyFiles`, because livy-repl is a Jar, and
         // spark-submit will reject it because it isn't a Python file. Instead we'll pass it

--- a/spark/src/test/scala/com/cloudera/livy/spark/batch/BatchProcessSpec.scala
+++ b/spark/src/test/scala/com/cloudera/livy/spark/batch/BatchProcessSpec.scala
@@ -35,11 +35,6 @@ class BatchProcessSpec
   with BeforeAndAfterAll
   with ShouldMatchers {
 
-  override protected def withFixture(test: NoArgTest) = {
-    assume(sys.env.get("SPARK_HOME").isDefined, "SPARK_HOME is not set.")
-    test()
-  }
-
   val script: Path = {
     val script = Files.createTempFile("livy-test", ".py")
     script.toFile.deleteOnExit()
@@ -59,6 +54,7 @@ class BatchProcessSpec
     it("should create a process") {
       val req = new CreateBatchRequest()
       req.file = script.toString
+      req.conf = Map("spark.driver.extraClassPath" -> sys.props("java.class.path"))
 
       val livyConf = new LivyConf()
       val builder = new BatchSessionProcessFactory(new SparkProcessBuilderFactory(livyConf))

--- a/spark/src/test/scala/com/cloudera/livy/spark/interactive/InteractiveSessionProcessSpec.scala
+++ b/spark/src/test/scala/com/cloudera/livy/spark/interactive/InteractiveSessionProcessSpec.scala
@@ -32,7 +32,6 @@ class InteractiveSessionProcessSpec extends BaseInteractiveSessionSpec {
   livyConf.set(InteractiveSessionFactory.LivyReplJars, "")
 
   def createSession(): InteractiveSession = {
-    assume(sys.env.get("SPARK_HOME").isDefined, "SPARK_HOME is not set.")
     val processFactory = new SparkProcessBuilderFactory(livyConf)
     val interactiveFactory = new InteractiveSessionProcessFactory(processFactory)
 


### PR DESCRIPTION
This change adds fake "spark-submit" and fake "sparkR" so that tests
can run them as if they were a proper Spark installation. This works
well for Scala / Java, but for python and R it means no pyspark or
SparkR code can actually be tested - just the interaction with the
underlying shell. So a few tests that tried to run Spark code were
removed.