### PR TITLE
Fix session manager test.

### DIFF
--- a/core/src/main/scala/com/cloudera/livy/sessions/Session.scala
+++ b/core/src/main/scala/com/cloudera/livy/sessions/Session.scala
@@ -24,17 +24,13 @@ import scala.concurrent.Future
 
 abstract class Session(val id: Int, val owner: String) {
 
-  private var _lastActivity = 0L
+  private var _lastActivity = System.nanoTime()
 
-  def lastActivity: Option[Long] = if (_lastActivity == 0L) None else Some(_lastActivity)
-
-  def stoppedTime: Option[Long] = {
-    state match {
-      case SessionState.Error(time) => Some(time)
-      case SessionState.Dead(time) => Some(time)
-      case SessionState.Success(time) => Some(time)
-      case _ => None
-    }
+  def lastActivity: Long = state match {
+    case SessionState.Error(time) => time
+    case SessionState.Dead(time) => time
+    case SessionState.Success(time) => time
+    case _ => _lastActivity
   }
 
   val timeout: Long = TimeUnit.HOURS.toNanos(1)

--- a/core/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
+++ b/core/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
@@ -76,13 +76,8 @@ class SessionManager[S <: Session](val livyConf: LivyConf) extends Logging {
 
   def collectGarbage(): Future[Iterable[Unit]] = {
     def expired(session: Session): Boolean = {
-      session.lastActivity.orElse(session.stoppedTime) match {
-        case Some(lastActivity) =>
-          val currentTime = System.nanoTime()
-          currentTime - lastActivity > math.max(sessionTimeout, session.timeout)
-        case None =>
-          false
-      }
+      val currentTime = System.nanoTime()
+      currentTime - session.lastActivity > math.max(sessionTimeout, session.timeout)
     }
 
     Future.sequence(all().filter(expired).map(delete))

--- a/server/src/main/scala/com/cloudera/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/SessionServlet.scala
@@ -122,6 +122,9 @@ abstract class SessionServlet[S <: Session](livyConf: LivyConf)
     new AsyncResult {
       val is = Future {
         val session = sessionManager.register(createSession(request))
+        // Because it may take some time to establish the session, update the last activity
+        // time before returning the session info to the client.
+        session.recordActivity()
         Created(clientSessionView(session, request),
           headers = Map("Location" -> url(getSession, "id" -> session.id.toString))
         )


### PR DESCRIPTION
The main cause was that the mock session used by the test was not
overriding the default timeout (1 hour), so the test was failing.

I used the opportunity to clean things up a bit: lastActivity now
always returns something, and activity is recorded as soon as the
session is created. The test also tries a few times to avoid issues
with thread scheduling.

This means that sessions can timeout before they're returned to
clients, but that should be rare (and at the same time, desired,
since sessions should have an upper bound on the time it takes for
them to be created).