### PR TITLE
LIVY-47. Added an override for the scope of Hadoop and Spark dependencies.

### DIFF
--- a/client-http/pom.xml
+++ b/client-http/pom.xml
@@ -80,6 +80,21 @@
       <artifactId>spark-core_${scala.binary.version}</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_${scala.binary.version}</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-hive_${scala.binary.version}</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
   <properties>
     <hadoop.version>2.6.0-cdh5.5.0</hadoop.version>
     <spark.version>1.5.0-cdh5.5.0</spark.version>
+    <hadoop.scope>compile</hadoop.scope>
     <commons-codec.version>1.9</commons-codec.version>
     <dispatch.version>0.11.2</dispatch.version>
     <guava.version>14.0.1</guava.version>
@@ -283,6 +284,7 @@
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-auth</artifactId>
         <version>${hadoop.version}</version>
+        <scope>${hadoop.scope}</scope>
       </dependency>
 
       <dependency>
@@ -295,30 +297,35 @@
             <artifactId>servlet-api</artifactId>
           </exclusion>
         </exclusions>
+        <scope>${hadoop.scope}</scope>
       </dependency>
 
       <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-client</artifactId>
         <version>${hadoop.version}</version>
+        <scope>${hadoop.scope}</scope>
       </dependency>
 
       <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-yarn-api</artifactId>
         <version>${hadoop.version}</version>
+        <scope>${hadoop.scope}</scope>
       </dependency>
 
       <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-yarn-client</artifactId>
         <version>${hadoop.version}</version>
+        <scope>${hadoop.scope}</scope>
       </dependency>
 
       <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-yarn-common</artifactId>
         <version>${hadoop.version}</version>
+        <scope>${hadoop.scope}</scope>
       </dependency>
 
       <dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -178,6 +178,24 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-hive_${scala.binary.version}</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.scalatra</groupId>
             <artifactId>scalatra-test_${scala.binary.version}</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
In most environment, users already have Hadoop & Spark's jars available on their clusters.
This change added an override so users can exclude them in Livy assembly and provide them to Livy at runtime using CLASSPATH.
To use it, build with: mvn -Dhadoop.scope=provided -Dspark.scope=provided package