### PR TITLE
LIVY-13. Send back plots from the interpreter

### DIFF
--- a/repl/src/main/resources/fake_shell.py
+++ b/repl/src/main/resources/fake_shell.py
@@ -347,11 +347,14 @@ def magic_matplot(name):
         exc_type, exc_value, tb = sys.exc_info()
         return execute_reply_error(exc_type, exc_value, [])
 
-    fig = value.gcf()
-    imgdata = StringIO.StringIO()
-    fig.savefig(imgdata, format='png')
-    imgdata.seek(0)
-    encode = base64.b64encode(imgdata.buf)
+    try:
+        fig = value.gcf()
+        imgdata = StringIO.StringIO()
+        fig.savefig(imgdata, format='png')
+        imgdata.seek(0)
+        encode = base64.b64encode(imgdata.buf)
+    except:
+        raise ExecutionError(sys.exc_info())
 
     return {
         'image/png': encode,

--- a/repl/src/main/resources/fake_shell.py
+++ b/repl/src/main/resources/fake_shell.py
@@ -354,7 +354,10 @@ def magic_matplot(name):
         imgdata.seek(0)
         encode = base64.b64encode(imgdata.buf)
     except:
-        raise ExecutionError(sys.exc_info())
+        exc_type = Exception
+        return execute_reply_error(exc_type, sys.exc_info, [])
+
+#        raise ExecutionError(sys.exc_info())
 
     return {
         'image/png': encode,

--- a/repl/src/main/resources/fake_shell.py
+++ b/repl/src/main/resources/fake_shell.py
@@ -343,21 +343,15 @@ def magic_json(name):
 def magic_matplot(name):
     try:
         value = global_dict[name]
-    except KeyError:
-        exc_type, exc_value, tb = sys.exc_info()
-        return execute_reply_error(exc_type, exc_value, [])
 
-    try:
         fig = value.gcf()
         imgdata = StringIO.StringIO()
         fig.savefig(imgdata, format='png')
         imgdata.seek(0)
         encode = base64.b64encode(imgdata.buf)
     except:
-        exc_type = Exception
-        return execute_reply_error(exc_type, sys.exc_info, [])
-
-#        raise ExecutionError(sys.exc_info())
+        exc_type, exc_value, tb = sys.exc_info()
+        return execute_reply_error(exc_type, exc_value, [])
 
     return {
         'image/png': encode,

--- a/repl/src/main/resources/fake_shell.py
+++ b/repl/src/main/resources/fake_shell.py
@@ -22,6 +22,8 @@ import json
 import logging
 import sys
 import traceback
+import StringIO
+import base64
 
 logging.basicConfig()
 LOG = logging.getLogger('fake_shell')
@@ -338,6 +340,23 @@ def magic_json(name):
         'application/json': value,
     }
 
+def magic_matplot(name):
+    try:
+        value = global_dict[name]
+    except KeyError:
+        exc_type, exc_value, tb = sys.exc_info()
+        return execute_reply_error(exc_type, exc_value, [])
+
+    fig = value.gcf()
+    imgdata = StringIO.StringIO()
+    fig.savefig(imgdata, format='png')
+    imgdata.seek(0)
+    encode = base64.b64encode(imgdata.buf)
+
+    return {
+        'image/png': encode,
+        'text/plain': "",
+    }
 
 def shutdown_request(_content):
     sys.exit()
@@ -346,6 +365,7 @@ def shutdown_request(_content):
 magic_router = {
     'table': magic_table,
     'json': magic_json,
+    'matplot': magic_matplot,
 }
 
 msg_type_router = {


### PR DESCRIPTION
send back matplotlib plots imgage from the python interpretor
 - use likes %matplot plt
 - working with Hue master branch
 - plan to support another plot library..
