### PR TITLE
Increase test coverage of client-common module.

### DIFF
--- a/client-common/src/main/java/com/cloudera/livy/client/common/ClientConf.java
+++ b/client-common/src/main/java/com/cloudera/livy/client/common/ClientConf.java
@@ -140,14 +140,14 @@ public abstract class ClientConf<T extends ClientConf>
 
     Matcher m = Pattern.compile("(-?[0-9]+)([a-z]+)?").matcher(time.toLowerCase());
     if (!m.matches()) {
-      throw new NumberFormatException("Invalid time string: " + time);
+      throw new IllegalArgumentException("Invalid time string: " + time);
     }
 
     long val = Long.parseLong(m.group(1));
     String suffix = m.group(2);
 
     if (suffix != null && !TIME_SUFFIXES.containsKey(suffix)) {
-      throw new NumberFormatException("Invalid suffix: \"" + suffix + "\"");
+      throw new IllegalArgumentException("Invalid suffix: \"" + suffix + "\"");
     }
 
     return TimeUnit.MILLISECONDS.convert(val,
@@ -178,7 +178,7 @@ public abstract class ClientConf<T extends ClientConf>
   }
 
   private boolean typesMatch(Object test, Object expected) {
-    return getType(test).equals(getType(expected));
+    return test == null || getType(test).equals(getType(expected));
   }
 
   private Class<?> getType(Object o) {

--- a/client-common/src/test/java/com/cloudera/livy/client/common/TestAbstractJobHandle.java
+++ b/client-common/src/test/java/com/cloudera/livy/client/common/TestAbstractJobHandle.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.client.common;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.mockito.InOrder;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import com.cloudera.livy.JobHandle;
+import com.cloudera.livy.JobHandle.State;
+
+public class TestAbstractJobHandle {
+
+  @Test
+  public void testJobHandle() {
+    AbstractJobHandle<Void> handle = new TestJobHandle();
+    assertEquals(0, handle.getMetrics().getJobIds().size());
+    assertEquals(0, handle.getSparkJobIds().size());
+
+    assertTrue(handle.changeState(State.QUEUED));
+    assertEquals(State.QUEUED, handle.getState());
+
+    handle.addSparkJobId(21);
+
+    @SuppressWarnings("unchecked")
+    JobHandle.Listener<Void> l1 = mock(JobHandle.Listener.class);
+    handle.addListener(l1);
+    verify(l1).onJobQueued(handle);
+    verify(l1).onSparkJobStarted(same(handle), eq(21));
+
+    handle.addSparkJobId(42);
+    verify(l1).onSparkJobStarted(same(handle), eq(42));
+
+    assertTrue(handle.changeState(State.STARTED));
+    verify(l1).onJobStarted(handle);
+
+    assertTrue(handle.changeState(State.SUCCEEDED));
+    verify(l1).onJobSucceeded(handle, null);
+
+    assertFalse(handle.changeState(State.CANCELLED));
+
+    // Make sure that after the job is finished the spark job IDs are reported first.
+    @SuppressWarnings("unchecked")
+    JobHandle.Listener<Void> l2 = mock(JobHandle.Listener.class);
+    handle.addListener(l2);
+
+    InOrder inOrder = inOrder(l2);
+    inOrder.verify(l2, times(2)).onSparkJobStarted(same(handle), anyInt());
+    inOrder.verify(l2).onJobSucceeded(handle, null);
+  }
+
+  private static class TestJobHandle extends AbstractJobHandle<Void> {
+
+    @Override
+    protected Void result() {
+      return null;
+    }
+
+    @Override
+    protected Throwable error() {
+      return null;
+    }
+
+    @Override
+    public Void get() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Void get(long l, TimeUnit t) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isDone() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isCancelled() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean cancel(boolean b) {
+      throw new UnsupportedOperationException();
+    }
+
+  }
+
+}

--- a/client-common/src/test/java/com/cloudera/livy/client/common/TestBufferUtils.java
+++ b/client-common/src/test/java/com/cloudera/livy/client/common/TestBufferUtils.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.client.common;
+
+import java.nio.ByteBuffer;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class TestBufferUtils {
+
+  @Test
+  public void testWrappedArray() {
+    byte[] array = new byte[] { 0x1b, 0x2b };
+    byte[] unwrapped = BufferUtils.toByteArray(ByteBuffer.wrap(array));
+    assertSame(array, unwrapped);
+  }
+
+  @Test
+  public void testShortArray() {
+    byte[] array = new byte[] { 0x1b, 0x2b };
+    byte[] unwrapped = BufferUtils.toByteArray(ByteBuffer.wrap(array, 0, 1));
+    assertNotSame(array, unwrapped);
+    assertEquals(1, unwrapped.length);
+  }
+
+  @Test
+  public void testOffsetArray() {
+    byte[] array = new byte[] { 0x1b, 0x2b };
+    byte[] unwrapped = BufferUtils.toByteArray(ByteBuffer.wrap(array, 1, 1));
+    assertNotSame(array, unwrapped);
+    assertEquals(1, unwrapped.length);
+  }
+
+  @Test
+  public void testDirectBuffer() {
+    ByteBuffer direct = ByteBuffer.allocateDirect(1);
+    direct.put((byte) 0x1b);
+    assertFalse(direct.hasArray());
+    direct.flip();
+
+    byte[] unwrapped = BufferUtils.toByteArray(direct);
+    assertEquals(0x1b, unwrapped[0]);
+  }
+
+}

--- a/client-common/src/test/java/com/cloudera/livy/client/common/TestClientConf.java
+++ b/client-common/src/test/java/com/cloudera/livy/client/common/TestClientConf.java
@@ -18,15 +18,19 @@
 
 package com.cloudera.livy.client.common;
 
+import java.util.Map;
+import java.util.Properties;
+
 import org.junit.Test;
 import static org.junit.Assert.*;
 
 public class TestClientConf {
 
   @Test
-  public void testClientConf() {
-    TestConf conf = new TestConf();
+  public void testTypes() {
+    TestConf conf = new TestConf(null);
 
+    assertNull(conf.get(TestConf.Entry.NULL));
     assertEquals("default", conf.get(TestConf.Entry.STRING));
     assertEquals(false, conf.getBoolean(TestConf.Entry.BOOLEAN));
     assertEquals(42, conf.getInt(TestConf.Entry.INT));
@@ -50,18 +54,84 @@ public class TestClientConf {
       // Expected.
     }
 
+    conf.set(TestConf.Entry.STRING, "aString");
+    assertEquals("aString", conf.get(TestConf.Entry.STRING));
+
     conf.set(TestConf.Entry.BOOLEAN, true);
     assertEquals(true, conf.getBoolean(TestConf.Entry.BOOLEAN));
+
+    conf.set(TestConf.Entry.LONG, 42L);
+    assertEquals(42L, conf.getLong(TestConf.Entry.LONG));
+
+    conf.set(TestConf.Entry.LONG, null);
+    assertEquals(84L, conf.getLong(TestConf.Entry.LONG));
+
+    conf.set(TestConf.Entry.TIME_NO_DEFAULT, "100");
+    assertEquals(100L, conf.getTimeAsMs(TestConf.Entry.TIME_NO_DEFAULT));
+  }
+
+  @Test
+  public void testRawProperties() {
+    Properties dflt = new Properties();
+    dflt.put("key1", "val1");
+    dflt.put("key2", "val2");
+
+    TestConf conf = new TestConf(dflt);
+    conf.set("key2", "anotherVal");
+
+    assertEquals("val1", conf.get("key1"));
+    assertEquals("anotherVal", conf.get("key2"));
+
+    conf.setIfMissing("key2", "yetAnotherVal");
+    assertEquals("anotherVal", conf.get("key2"));
+
+    conf.setIfMissing("key3", "val3");
+    assertEquals("val3", conf.get("key3"));
+
+    int count = 0;
+    for (Map.Entry<String, String> e : conf) {
+      count++;
+    }
+    assertEquals(3, count);
+
+    TestConf newProps = new TestConf(null);
+    newProps.set("key4", "val4");
+    newProps.set("key5", "val5");
+    conf.setAll(newProps);
+    assertEquals("val4", conf.get("key4"));
+    assertEquals("val5", conf.get("key5"));
+  }
+
+  @Test(expected=IllegalArgumentException.class)
+  public void testInvalidTime() {
+    TestConf conf = new TestConf(null);
+    conf.set(TestConf.Entry.TIME, "invalid");
+    conf.getTimeAsMs(TestConf.Entry.TIME);
+  }
+
+  @Test(expected=IllegalArgumentException.class)
+  public void testInvalidTimeSuffix() {
+    TestConf conf = new TestConf(null);
+    conf.set(TestConf.Entry.TIME, "100foo");
+    conf.getTimeAsMs(TestConf.Entry.TIME);
+  }
+
+  @Test(expected=IllegalArgumentException.class)
+  public void testTimeWithoutDefault() {
+    TestConf conf = new TestConf(null);
+    conf.getTimeAsMs(TestConf.Entry.TIME_NO_DEFAULT);
   }
 
   private static class TestConf extends ClientConf<TestConf> {
 
     static enum Entry implements ConfEntry {
+      NULL("null", null),
       STRING("string", "default"),
       BOOLEAN("bool", false),
       INT("int", 42),
       LONG("long", 84L),
-      TIME("time", "168ms");
+      TIME("time", "168ms"),
+      TIME_NO_DEFAULT("time2", null);
 
       private final String key;
       private final Object dflt;
@@ -79,8 +149,8 @@ public class TestClientConf {
 
     }
 
-    TestConf() {
-      super(null);
+    TestConf(Properties p) {
+      super(p);
     }
 
   }

--- a/client-common/src/test/java/com/cloudera/livy/client/common/TestHttpMessages.java
+++ b/client-common/src/test/java/com/cloudera/livy/client/common/TestHttpMessages.java
@@ -67,6 +67,16 @@ public class TestHttpMessages {
 
   }
 
+  @Test(expected=IllegalArgumentException.class)
+  public void testJobStatusResultBadState() {
+    new HttpMessages.JobStatus(0L, State.QUEUED, new byte[1], null, null);
+  }
+
+  @Test(expected=IllegalArgumentException.class)
+  public void testJobStatusErrorBadState() {
+    new HttpMessages.JobStatus(0L, State.QUEUED, null, "An Error", null);
+  }
+
   private Object dummyValue(Class<?> klass, Type type) {
     switch (klass.getSimpleName()) {
       case "int":


### PR DESCRIPTION
Some of these paths are tested indirectly in other modules, but it's better
to have more targeted unit tests.