### PR TITLE
LIVY-73. Allow http client to connect to existing sessions.

### DIFF
--- a/api/src/main/java/com/cloudera/livy/LivyClient.java
+++ b/api/src/main/java/com/cloudera/livy/LivyClient.java
@@ -55,8 +55,12 @@ public interface LivyClient {
    * Stops the remote context.
    *
    * Any pending jobs will be cancelled, and the remote context will be torn down.
+   *
+   * @param shutdownContext Whether to shutdown the underlying Spark context. If false, the
+   *                        context will keep running and it's still possible to send commands
+   *                        to it, if the backend being used supports it.
    */
-  void stop();
+  void stop(boolean shutdownContext);
 
   /**
    * Upload a jar to be added to the Spark application classpath

--- a/api/src/test/java/com/cloudera/livy/TestClientFactory.java
+++ b/api/src/test/java/com/cloudera/livy/TestClientFactory.java
@@ -57,7 +57,7 @@ public class TestClientFactory implements LivyClientFactory {
     }
 
     @Override
-    public void stop() {
+    public void stop(boolean shutdownContext) {
       throw new UnsupportedOperationException();
     }
 

--- a/client-http/src/main/java/com/cloudera/livy/client/http/LivyConnection.java
+++ b/client-http/src/main/java/com/cloudera/livy/client/http/LivyConnection.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.util.concurrent.TimeUnit;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpEntity;
@@ -51,6 +52,7 @@ import static com.cloudera.livy.client.http.HttpConf.Entry.*;
  */
 class LivyConnection {
 
+  static final String CLIENT_SESSION_URI = "/clients";
   private static final String APPLICATION_JSON = "application/json";
 
   private final URI server;
@@ -63,7 +65,7 @@ class LivyConnection {
     int port = uri.getPort() > 0 ? uri.getPort() : 8998;
 
     String path = uri.getPath() != null ? uri.getPath() : "";
-    this.uriRoot = path + "/clients";
+    this.uriRoot = path + CLIENT_SESSION_URI;
 
     RequestConfig reqConfig = new RequestConfig() {
       @Override
@@ -110,8 +112,10 @@ class LivyConnection {
       String uri,
       Object... uriParams) throws Exception {
     HttpPost post = new HttpPost();
-    byte[] bodyBytes = mapper.writeValueAsBytes(body);
-    post.setEntity(new ByteArrayEntity(bodyBytes));
+    if (body != null) {
+      byte[] bodyBytes = mapper.writeValueAsBytes(body);
+      post.setEntity(new ByteArrayEntity(bodyBytes));
+    }
     return sendJSONRequest(post, retType, uri, uriParams);
   }
 

--- a/client-local/src/main/java/com/cloudera/livy/client/local/LocalClient.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/LocalClient.java
@@ -134,7 +134,10 @@ public class LocalClient implements LivyClient {
   }
 
   @Override
-  public void stop() {
+  public void stop(boolean shutdownContext) {
+    if (!shutdownContext) {
+      LOG.warn("shutdownContext=false is not supported for local clients.");
+    }
     if (isAlive) {
       isAlive = false;
       try {

--- a/client-local/src/test/java/com/cloudera/livy/client/local/TestSparkClient.java
+++ b/client-local/src/test/java/com/cloudera/livy/client/local/TestSparkClient.java
@@ -339,7 +339,7 @@ public class TestSparkClient {
       test.call(client);
     } finally {
       if (client != null) {
-        client.stop();
+        client.stop(true);
       }
     }
   }

--- a/server/src/main/scala/com/cloudera/livy/server/client/ClientSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/client/ClientSession.scala
@@ -87,21 +87,25 @@ class ClientSession(id: Int, owner: String, createRequest: CreateClientRequest, 
   }
 
   def addFile(uri: URI): Unit = {
+    recordActivity()
     client.addFile(uri).get()
   }
 
   def addJar(uri: URI): Unit = {
+    recordActivity()
     client.addJar(uri).get()
   }
 
   def jobStatus(id: Long): Any = {
     val clientJobId = operations(id)
+    recordActivity()
     // TODO: don't block indefinitely?
     val status = client.getBypassJobStatus(clientJobId).get()
     new JobStatus(id, status.state, status.result, status.error, status.newSparkJobs)
   }
 
-  def cancel(id: Long): Unit = {
+  def cancelJob(id: Long): Unit = {
+    recordActivity()
     operations.remove(id).foreach { client.cancel }
   }
 
@@ -131,7 +135,7 @@ class ClientSession(id: Int, owner: String, createRequest: CreateClientRequest, 
   override def stop(): Future[Unit] = {
     Future {
       sessionState = SessionState.ShuttingDown()
-      client.stop()
+      client.stop(true)
       sessionState = SessionState.Dead()
     }
   }

--- a/server/src/main/scala/com/cloudera/livy/server/client/ClientSessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/client/ClientSessionServlet.scala
@@ -42,6 +42,17 @@ class ClientSessionServlet(livyConf: LivyConf)
     new ClientSession(id, remoteUser(req), createRequest, livyConf.livyHome)
   }
 
+  // This endpoint is used by the client-http module to "connect" to an existing session and
+  // update its last activity time. It performs authorization checks to make sure the caller
+  // has access to the session, so even though it returns the same data, it behaves differently
+  // from get("/:id").
+  post("/:id/connect") {
+    withSession { session =>
+      session.recordActivity()
+      Ok(clientSessionView(session, request))
+    }
+  }
+
   jpost[SerializedJob]("/:id/submit-job") { req =>
     withSession { session =>
       try {
@@ -118,7 +129,7 @@ class ClientSessionServlet(livyConf: LivyConf)
   post("/:id/jobs/:jobid/cancel") {
     withSession { lsession =>
       val jobId = params("jobid").toLong
-      doAsync { lsession.cancel(jobId) }
+      doAsync { lsession.cancelJob(jobId) }
     }
   }
 

--- a/server/src/test/scala/com/cloudera/livy/server/client/ClientServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/client/ClientServletSpec.scala
@@ -119,6 +119,14 @@ class ClientServletSpec
       collectedSparkJobs.size should be (1)
     }
 
+    withSessionId("should update last activity on connect") { sid =>
+      val currentActivity = servlet.sessionManager.get(sid).get.lastActivity
+      jpost[SessionInfo](s"/$sid/connect", null, expectedStatus = SC_OK) { info =>
+        val newActivity = servlet.sessionManager.get(sid).get.lastActivity
+        assert(newActivity > currentActivity)
+      }
+    }
+
     withSessionId("should tear down sessions") { id =>
       jdelete[Map[String, Any]](s"/$id") { data =>
         data should equal (Map("msg" -> "deleted"))


### PR DESCRIPTION
This change makes the URI parsing in the HTTP client detect when
the user is trying to reuse an existing session instead of creating
a new one. A new method was added to the client servlet that is
used by the client to ensure the session exists and the user has
permission to use it.

To properly support the functionality, the public API needed to be
changed so that it's possible to clean up a client's state without
shutting down the underlying session.

On slightly related changes, I updated some spots where the code
was failing to update the last activity time of a session, and
changed an internal method name to be more descriptive.