### PR TITLE
LIVY-76. Fix propagation of Livy config in cluster mode.

### DIFF
--- a/client-local/pom.xml
+++ b/client-local/pom.xml
@@ -106,6 +106,44 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>shade</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedArtifactAttached>false</shadedArtifactAttached>
+              <artifactSet>
+                <includes>
+                  <include>com.cloudera.livy:livy-client-common</include>
+                  <include>com.esotericsoftware.kryo:kryo</include>
+                </includes>
+              </artifactSet>
+              <filters>
+                <!-- Some artifacts (e.g. kryo) bundle jars inside them, for some reason. -->
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>*.jar</exclude>
+                    <exclude>META-INF/maven/**</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <relocations>
+                <relocation>
+                  <pattern>com.esotericsoftware</pattern>
+                  <shadedPattern>com.cloudera.livy.shaded.kryo</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
@@ -113,6 +151,9 @@
             <goals>
               <goal>copy-dependencies</goal>
             </goals>
+            <configuration>
+              <excludeArtifactIds>livy-client-common,kryo</excludeArtifactIds>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/client-local/src/main/java/com/cloudera/livy/client/local/LocalConf.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/LocalConf.java
@@ -36,6 +36,7 @@ import com.cloudera.livy.client.common.ClientConf;
 public class LocalConf extends ClientConf<LocalConf> {
 
   public static final String SPARK_CONF_PREFIX = "spark.";
+  public static final String LIVY_SPARK_PREFIX = SPARK_CONF_PREFIX + "__livy__.";
 
   private static final Logger LOG = LoggerFactory.getLogger(LocalConf.class);
 

--- a/client-local/src/main/java/com/cloudera/livy/client/local/rpc/Rpc.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/rpc/Rpc.java
@@ -484,7 +484,7 @@ public class Rpc implements Closeable {
     void sendHello(Channel c) throws Exception {
       byte[] hello = client.hasInitialResponse() ?
         client.evaluateChallenge(new byte[0]) : new byte[0];
-      c.writeAndFlush(new SaslMessage(clientId, hello));
+      c.writeAndFlush(new SaslMessage(clientId, hello)).sync();
     }
 
   }


### PR DESCRIPTION
Go back to embedding the Livy configuration in the Spark config so
that it's properly propagated to the driver in cluster mode. This
is a little ugly since it requires using Scala APIs in Java code,
but we can't use "--files" and SparkFiles because that class needs
the SparkContext to be initialized, and we need this config before
that.

Also, while testing, I noticed after some debugging that the RPC
code was failing; that's because it was using Spark's Kryo, which
is not binary compatible with the version we compile against. So
now Kryo is shaded. I also added a "sync()" call when sending the
initial SASL message so that if it errors out, we actually get to see the
exception.