### PR TITLE
LIVY-75. Allow a whitelist of URIs to bypass authentication.

### DIFF
--- a/server/src/main/scala/com/cloudera/livy/server/Main.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/Main.scala
@@ -90,7 +90,8 @@ object Main extends Logging {
         require(principal != null,
           s"Kerberos auth requires ${KERBEROS_KEYTAB.key} to be provided.")
 
-        val holder = new FilterHolder(new AuthenticationFilter())
+        val holder = new FilterHolder(new SelectiveFilter(new AuthenticationFilter()))
+        holder.setInitParameter(SelectiveFilter.BYPASS_PATH_RE_LIST, "/sessions/[0-9]+/callback")
         holder.setInitParameter(AuthenticationFilter.AUTH_TYPE, authType)
         holder.setInitParameter(KerberosAuthenticationHandler.PRINCIPAL, principal)
         holder.setInitParameter(KerberosAuthenticationHandler.KEYTAB, keytab)

--- a/server/src/main/scala/com/cloudera/livy/server/SelectiveFilter.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/SelectiveFilter.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.server
+
+import java.util.regex.Pattern
+import javax.servlet._
+import javax.servlet.http.HttpServletRequest
+
+object SelectiveFilter {
+
+  val BYPASS_PATH_RE_LIST = "livy.auth.filter.bypass_paths"
+
+}
+
+/**
+ * A servlet filter that wraps another filter, and bypasses it for a configured set of URIs.
+ */
+class SelectiveFilter(wrapped: Filter) extends Filter {
+
+  private var bypassPaths: Seq[Pattern] = Nil
+
+  override def init(config: FilterConfig): Unit = {
+    Option(config.getInitParameter(SelectiveFilter.BYPASS_PATH_RE_LIST)).foreach { cfg =>
+      bypassPaths = cfg.split(",").map(_.trim).filter(_.nonEmpty).map(Pattern.compile).toSeq
+    }
+    wrapped.init(config)
+  }
+
+  override def destroy(): Unit = {
+    wrapped.destroy()
+  }
+
+  override def doFilter(
+      request: ServletRequest,
+      response: ServletResponse,
+      chain: FilterChain): Unit = {
+    val req = request.asInstanceOf[HttpServletRequest]
+    val servlet = req.getServletPath().stripSuffix("/")
+    val path = servlet + Option(req.getPathInfo()).getOrElse("")
+
+    if (bypassPaths.exists(_.matcher(path).matches())) {
+      chain.doFilter(request, response)
+    } else {
+      wrapped.doFilter(request, response, chain)
+    }
+  }
+
+}

--- a/server/src/test/scala/com/cloudera/livy/server/SelectiveFilterSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/SelectiveFilterSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.server
+
+import javax.servlet._
+import javax.servlet.http.HttpServletRequest
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.Mockito._
+import org.scalatest.FunSpec
+
+class SelectiveFilterSpec extends FunSpec {
+
+  describe("The filter") {
+
+    it("should bypass configured paths") {
+      val wrapped = mock(classOf[Filter])
+      val filter = new SelectiveFilter(wrapped)
+
+      val config = mock(classOf[FilterConfig])
+      when(config.getInitParameter(meq(SelectiveFilter.BYPASS_PATH_RE_LIST)))
+        .thenReturn("/bypass,/anotherBypass[0-9]+")
+      filter.init(config)
+      verify(wrapped).init(config)
+
+      val res = mock(classOf[ServletResponse])
+      val chain = mock(classOf[FilterChain])
+      val req = mock(classOf[HttpServletRequest])
+      when(req.getServletPath()).thenReturn("/")
+
+      when(req.getPathInfo()).thenReturn("/bypass")
+      filter.doFilter(req, res, chain)
+      verify(wrapped, never()).doFilter(any(), any(), any())
+
+      when(req.getPathInfo()).thenReturn("/anotherBypass1234")
+      filter.doFilter(req, res, chain)
+      verify(wrapped, never()).doFilter(any(), any(), any())
+
+      when(req.getPathInfo()).thenReturn("/goThrough")
+      filter.doFilter(req, res, chain)
+      when(req.getPathInfo()).thenReturn("/bypass/noMatch")
+      filter.doFilter(req, res, chain)
+      verify(wrapped, times(2)).doFilter(any(), any(), any())
+
+      filter.destroy()
+      verify(wrapped).destroy()
+    }
+
+  }
+
+}


### PR DESCRIPTION
At least until we get to LIVY-46, the repl code needs to POST
results back to the Livy server. Since it doesn't run with
proper kerberos credentials (it's running as a proxy user in
a YARN container), allow the callback URI to bypass SPNEGO.
This is achieved by wrapping the auth filter in another filter
that will not do auth when certain URIs are requested.

While this might be seen as making the repl less secure (which
is true), the repl is currently not secure anyway, since it runs
its own web server and doesn't really perform authorization when
requests arrive.