### PR TITLE
Add explicit dependency to spark-launcher in client-local.

### DIFF
--- a/client-local/pom.xml
+++ b/client-local/pom.xml
@@ -58,6 +58,10 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-launcher_${scala.binary.version}</artifactId>
+    </dependency>
 
     <!-- Needed by Spark but excluded in the Livy root pom. -->
     <dependency>
@@ -152,7 +156,11 @@
               <goal>copy-dependencies</goal>
             </goals>
             <configuration>
-              <excludeArtifactIds>livy-client-common,kryo</excludeArtifactIds>
+              <excludeArtifactIds>
+                livy-client-common,
+                kryo,
+                spark-launcher_${scala.binary.version},
+              </excludeArtifactIds>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -353,6 +353,18 @@
 
       <dependency>
         <groupId>org.apache.spark</groupId>
+        <artifactId>spark-launcher_${scala.binary.version}</artifactId>
+        <version>${spark.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.spark-project.spark</groupId>
+            <artifactId>unused</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.spark</groupId>
         <artifactId>spark-sql_${scala.binary.version}</artifactId>
         <version>${spark.version}</version>
       </dependency>


### PR DESCRIPTION
The code now needs that library to run, so it needs to be packaged
with Livy. It's not needed on the driver side of the RSC, so avoid
packaging it under the client-jars directory.