### PR TITLE
Fix hadoop dependencies scope in client-http.

### DIFF
--- a/client-http/pom.xml
+++ b/client-http/pom.xml
@@ -31,6 +31,7 @@
 
   <properties>
     <skipDeploy>false</skipDeploy>
+    <hadoop.scope>test</hadoop.scope>
   </properties>
 
   <dependencies>

--- a/client-local/pom.xml
+++ b/client-local/pom.xml
@@ -32,6 +32,7 @@
   <properties>
     <copyright.header>${asf.copyright.header}</copyright.header>
     <skipDeploy>false</skipDeploy>
+    <hadoop.scope>test</hadoop.scope>
   </properties>
 
   <dependencies>

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -31,6 +31,10 @@
     <version>0.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
+    <properties>
+      <hadoop.scope>provided</hadoop.scope>
+    </properties>
+
     <dependencies>
 
         <dependency>


### PR DESCRIPTION
d8842102dd upgraded hadoop dependencies to be "compile" by default,
instead of inheriting the scope from the transitive dependencies.
So the client-http artifact ballooned up to 70MB.

So override the scope back to "test", bringing the jar back down to
a more manageable 3MB (which is also much faster to build).