### PR TITLE
LIVY-58. Allow connections between Livy and RSC to be re-established.

### DIFF
--- a/api/src/main/java/com/cloudera/livy/LivyClientBuilder.java
+++ b/api/src/main/java/com/cloudera/livy/LivyClientBuilder.java
@@ -137,6 +137,13 @@ public final class LivyClientBuilder {
     }
 
     if (client == null) {
+      // Redact any user information from the URI when throwing user-visible exceptions that might
+      // be logged.
+      if (uri.getUserInfo() != null) {
+        uri = new URI(uri.getScheme(), "[redacted]", uri.getHost(), uri.getPort(), uri.getPath(),
+          uri.getQuery(), uri.getFragment());
+      }
+
       throw new IllegalArgumentException(String.format(
         "URI '%s' is not supported by any registered client factories.", uri), error);
     }

--- a/api/src/main/java/com/cloudera/livy/LivyClientBuilder.java
+++ b/api/src/main/java/com/cloudera/livy/LivyClientBuilder.java
@@ -140,8 +140,13 @@ public final class LivyClientBuilder {
       // Redact any user information from the URI when throwing user-visible exceptions that might
       // be logged.
       if (uri.getUserInfo() != null) {
-        uri = new URI(uri.getScheme(), "[redacted]", uri.getHost(), uri.getPort(), uri.getPath(),
-          uri.getQuery(), uri.getFragment());
+        try {
+          uri = new URI(uri.getScheme(), "[redacted]", uri.getHost(), uri.getPort(), uri.getPath(),
+            uri.getQuery(), uri.getFragment());
+        } catch (URISyntaxException e) {
+          // Shouldn't really happen.
+          throw new RuntimeException(e);
+        }
       }
 
       throw new IllegalArgumentException(String.format(

--- a/api/src/test/java/com/cloudera/livy/TestLivyClientBuilder.java
+++ b/api/src/test/java/com/cloudera/livy/TestLivyClientBuilder.java
@@ -72,4 +72,15 @@ public class TestLivyClientBuilder {
     assertEquals("override", client.config.getProperty("spark.config"));
   }
 
+  @Test
+  public void testRedaction() throws Exception {
+    try {
+      new LivyClientBuilder(false).setURI(new URI("mismatch://user@host")).build();
+      fail("Should have failed to create client.");
+    } catch (IllegalArgumentException e) {
+      assertFalse("Should have redacted user information.",
+        e.getMessage().contains("user@host"));
+    }
+  }
+
 }

--- a/client-local/src/main/java/com/cloudera/livy/client/local/BaseProtocol.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/BaseProtocol.java
@@ -171,4 +171,20 @@ public abstract class BaseProtocol extends RpcDispatcher {
 
   }
 
+  public static class RemoteDriverAddress {
+
+    public final String host;
+    public final int port;
+
+    public RemoteDriverAddress(String host, int port) {
+      this.host = host;
+      this.port = port;
+    }
+
+    public RemoteDriverAddress() {
+      this(null, -1);
+    }
+
+  }
+
 }

--- a/client-local/src/main/java/com/cloudera/livy/client/local/ContextInfo.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/ContextInfo.java
@@ -26,6 +26,6 @@ interface ContextInfo {
   int getRemotePort();
   String getClientId();
   String getSecret();
-  void dispose();
+  void dispose(boolean forceKill);
 
 }

--- a/client-local/src/main/java/com/cloudera/livy/client/local/ContextInfo.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/ContextInfo.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.client.local;
+
+/**
+ * Information about a running RSC instance.
+ */
+interface ContextInfo {
+
+  String getRemoteAddress();
+  int getRemotePort();
+  String getClientId();
+  String getSecret();
+  void dispose();
+
+}

--- a/client-local/src/main/java/com/cloudera/livy/client/local/ContextLauncher.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/ContextLauncher.java
@@ -134,8 +134,9 @@ class ContextLauncher implements ContextInfo {
     try {
       if (forceKill) {
         child.kill();
+      } else {
+        child.detach();
       }
-      child.detach();
     } finally {
       factory.unref();
     }

--- a/client-local/src/main/java/com/cloudera/livy/client/local/ContextLauncher.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/ContextLauncher.java
@@ -1,0 +1,355 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.client.local;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.attribute.PosixFilePermission.*;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+import io.netty.channel.ChannelHandlerContext;
+import org.apache.spark.launcher.SparkLauncher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.cloudera.livy.client.local.driver.RemoteDriver;
+import com.cloudera.livy.client.local.rpc.Rpc;
+import com.cloudera.livy.client.local.rpc.RpcDispatcher;
+import com.cloudera.livy.client.local.rpc.RpcServer;
+import static com.cloudera.livy.client.local.LocalConf.Entry.*;
+
+/**
+ * Encapsulates code needed to launch a new Spark context and collect information about how
+ * to establish a client connection to it.
+ */
+class ContextLauncher implements ContextInfo {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ContextLauncher.class);
+  private static final AtomicInteger CHILD_IDS = new AtomicInteger();
+  private static final long DEFAULT_SHUTDOWN_TIMEOUT = 10000; // In milliseconds
+
+  private static final String SPARK_JARS_KEY = "spark.jars";
+  private static final String SPARK_HOME_ENV = "SPARK_HOME";
+  private static final String SPARK_HOME_KEY = "spark.home";
+
+  private final String clientId;
+  private final String secret;
+  private final Thread driverThread;
+
+  private BaseProtocol.RemoteDriverAddress driverAddress;
+
+  ContextLauncher(LocalClientFactory factory, LocalConf conf) throws IOException {
+    this.clientId = UUID.randomUUID().toString();
+    this.secret = factory.getServer().createSecret();
+
+    RegistrationHandler handler = new RegistrationHandler();
+    try {
+      factory.getServer().registerClient(clientId, secret, handler);
+      this.driverThread = startDriver(factory.getServer(), conf, clientId, secret);
+
+      // Wait for the handler to receive the driver information.
+      long timeout = conf.getTimeAsMs(RPC_CLIENT_HANDSHAKE_TIMEOUT);
+      long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeout);
+      synchronized (handler) {
+        long now = System.nanoTime();
+        while (handler.driverAddress == null && now < deadline) {
+          handler.wait(TimeUnit.NANOSECONDS.toMillis(deadline - now));
+          now = System.nanoTime();
+        }
+      }
+      Preconditions.checkState(handler.driverAddress != null,
+        "Timed out waiting for driver connection information.");
+      driverAddress = handler.driverAddress;
+    } catch (Exception e) {
+      factory.getServer().unregisterClient(clientId);
+      throw Throwables.propagate(e);
+    } finally {
+      handler.dispose();
+    }
+  }
+
+  @Override
+  public String getRemoteAddress() {
+    return driverAddress.host;
+  }
+
+  @Override
+  public int getRemotePort() {
+    return driverAddress.port;
+  }
+
+  @Override
+  public String getClientId() {
+    return clientId;
+  }
+
+  @Override
+  public String getSecret() {
+    return secret;
+  }
+
+  @Override
+  public void dispose() {
+    try {
+      try {
+        driverThread.join(DEFAULT_SHUTDOWN_TIMEOUT);
+      } catch (InterruptedException ie) {
+        LOG.debug("Interrupted before driver thread was finished.");
+      }
+      if (driverThread.isAlive()) {
+        LOG.warn("Timed out shutting down remote driver, interrupting...");
+        driverThread.interrupt();
+      }
+    } catch (Exception e) {
+      LOG.warn("Exception while waiting for driver thread to finish.", e);
+    }
+  }
+
+  private static Thread startDriver(
+      final RpcServer rpcServer,
+      final LocalConf conf,
+      final String clientId,
+      final String secret) throws IOException {
+    Runnable runnable;
+    final String serverAddress = rpcServer.getAddress();
+    final String serverPort = String.valueOf(rpcServer.getPort());
+    if (conf.get(CLIENT_IN_PROCESS) != null) {
+      // Mostly for testing things quickly. Do not do this in production.
+      LOG.warn("!!!! Running remote driver in-process. !!!!");
+      runnable = new Runnable() {
+        @Override
+        public void run() {
+          List<String> args = new ArrayList<>();
+          args.add("--remote-host");
+          args.add(serverAddress);
+          args.add("--remote-port");
+          args.add(serverPort);
+          args.add("--client-id");
+          args.add(clientId);
+          args.add("--secret");
+          args.add(secret);
+
+          for (Map.Entry<String, String> e : conf) {
+            args.add("--conf");
+            args.add(String.format("%s=%s", e.getKey(), e.getValue()));
+          }
+          try {
+            RemoteDriver.main(args.toArray(new String[args.size()]));
+          } catch (Exception e) {
+            LOG.error("Error running driver.", e);
+          }
+        }
+      };
+    } else {
+      // If a Spark installation is provided, use the spark-submit script. Otherwise, call the
+      // SparkSubmit class directly, which has some caveats (like having to provide a proper
+      // version of Guava on the classpath depending on the deploy mode).
+      final SparkLauncher launcher = new SparkLauncher();
+      String sparkHome = conf.get(SPARK_HOME_KEY);
+      if (sparkHome == null) {
+        sparkHome = System.getenv(SPARK_HOME_ENV);
+      }
+      if (sparkHome == null) {
+        sparkHome = System.getProperty(SPARK_HOME_KEY);
+      }
+      launcher.setSparkHome(sparkHome);
+
+      conf.set(CLIENT_ID, clientId);
+      conf.set(CLIENT_SECRET, secret);
+
+      launcher.setAppResource("spark-internal");
+      String livyJars = conf.get(LIVY_JARS);
+      if (livyJars == null) {
+        String livyHome = System.getenv("LIVY_HOME");
+        Preconditions.checkState(livyHome != null,
+          "Need one of LIVY_HOME or %s set.", LIVY_JARS.key());
+        File clientJars = new File(livyHome, "client-jars");
+        Preconditions.checkState(clientJars.isDirectory(),
+          "Cannot find 'client-jars' directory under LIVY_HOME.");
+        List<String> jars = new ArrayList<>();
+        for (File f : clientJars.listFiles()) {
+           launcher.addJar(f.getAbsolutePath());
+        }
+        livyJars = Joiner.on(",").join(jars);
+      }
+      String userJars = conf.get(SPARK_JARS_KEY);
+      if (userJars != null) {
+        String allJars = Joiner.on(",").join(livyJars, userJars);
+        conf.set(SPARK_JARS_KEY, allJars);
+      }
+
+      // Disable multiple attempts since the RPC server doesn't yet support multiple
+      // connections for the same registered app.
+      conf.set("spark.yarn.maxAppAttempts", "1");
+
+      File confFile = writeConfToFile(conf);
+
+      // Define how to pass options to the child process. If launching in client (or local)
+      // mode, the driver options need to be passed directly on the command line. Otherwise,
+      // SparkSubmit will take care of that for us.
+      String master = conf.get("spark.master");
+      Preconditions.checkArgument(master != null, "spark.master is not defined.");
+      launcher.setMaster(master);
+      launcher.setPropertiesFile(confFile.getAbsolutePath());
+      launcher.setMainClass(RemoteDriver.class.getName());
+      if (conf.get(PROXY_USER) != null) {
+        launcher.addSparkArg("--proxy-user", conf.get(PROXY_USER));
+      }
+      launcher.addAppArgs("--remote-host", serverAddress);
+      launcher.addAppArgs("--remote-port",  serverPort);
+
+      final Process child = launcher.launch();
+      int childId = CHILD_IDS.incrementAndGet();
+      redirect("stdout-redir-" + childId, child.getInputStream());
+      redirect("stderr-redir-" + childId, child.getErrorStream());
+
+      runnable = new Runnable() {
+        @Override
+        public void run() {
+          try {
+            int exitCode = child.waitFor();
+            if (exitCode != 0) {
+              rpcServer.unregisterClient(clientId);
+              LOG.warn("Child process exited with code {}.", exitCode);
+            }
+          } catch (InterruptedException ie) {
+            LOG.warn("Waiting thread interrupted, killing child process.");
+            Thread.interrupted();
+            child.destroy();
+          } catch (Exception e) {
+            LOG.warn("Exception while waiting for child process.", e);
+          }
+        }
+      };
+    }
+
+    Thread thread = new Thread(runnable);
+    thread.setDaemon(true);
+    thread.setName("Driver");
+    thread.start();
+    return thread;
+  }
+
+  private static void redirect(String name, InputStream in) {
+    Thread thread = new Thread(new Redirector(in));
+    thread.setName(name);
+    thread.setDaemon(true);
+    thread.start();
+  }
+
+  /**
+   * Write the configuration to a file readable only by the process's owner. Livy properties
+   * are written with an added prefix so that they can be loaded using SparkConf on the driver
+   * side.
+   */
+  private static File writeConfToFile(LocalConf conf) throws IOException {
+    Properties confView = new Properties();
+    for (Map.Entry<String, String> e : conf) {
+      String key = e.getKey();
+      if (!key.startsWith(LocalConf.SPARK_CONF_PREFIX)) {
+        key = LocalConf.LIVY_SPARK_PREFIX + key;
+      }
+      confView.setProperty(key, e.getValue());
+    }
+
+    File file = File.createTempFile("livyConf", ".properties");
+    Files.setPosixFilePermissions(file.toPath(), EnumSet.of(OWNER_READ, OWNER_WRITE));
+    file.deleteOnExit();
+
+    Writer writer = new OutputStreamWriter(new FileOutputStream(file), UTF_8);
+    try {
+      confView.store(writer, "Livy App Context Configuration");
+    } finally {
+      writer.close();
+    }
+
+    return file;
+  }
+
+  private static class Redirector implements Runnable {
+
+    private final BufferedReader in;
+
+    Redirector(InputStream in) {
+      this.in = new BufferedReader(new InputStreamReader(in));
+    }
+
+    @Override
+    public void run() {
+      try {
+        String line = null;
+        while ((line = in.readLine()) != null) {
+          LOG.info(line);
+        }
+      } catch (Exception e) {
+        LOG.warn("Error in redirector thread.", e);
+      }
+    }
+
+  }
+
+  private static class RegistrationHandler extends BaseProtocol
+    implements RpcServer.ClientCallback {
+
+    volatile RemoteDriverAddress driverAddress;
+
+    private Rpc client;
+
+    @Override
+    public RpcDispatcher onNewClient(Rpc client) {
+      LOG.debug("New RPC client connected from {}.", client.getChannel());
+      this.client = client;
+      return this;
+    }
+
+    void dispose() {
+      if (client != null) {
+        client.close();
+      }
+    }
+
+    private void handle(ChannelHandlerContext ctx, RemoteDriverAddress msg) {
+      LOG.debug("Received driver info for client {}: {}/{}.", client.getChannel(),
+        msg.host, msg.port);
+      synchronized (this) {
+        this.driverAddress = msg;
+        notifyAll();
+      }
+    }
+
+  }
+
+}

--- a/client-local/src/main/java/com/cloudera/livy/client/local/LocalClient.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/LocalClient.java
@@ -17,42 +17,20 @@
 
 package com.cloudera.livy.client.local;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
 import java.net.URI;
-import java.net.URL;
 import java.nio.ByteBuffer;
-import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.EnumSet;
-import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicInteger;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.nio.file.attribute.PosixFilePermission.*;
 
-import com.google.common.base.Charsets;
-import com.google.common.base.Joiner;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.io.Resources;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.Promise;
-import org.apache.spark.launcher.SparkLauncher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,54 +39,37 @@ import com.cloudera.livy.JobContext;
 import com.cloudera.livy.JobHandle;
 import com.cloudera.livy.LivyClient;
 import com.cloudera.livy.client.common.BufferUtils;
-import com.cloudera.livy.client.local.driver.RemoteDriver;
 import com.cloudera.livy.client.local.rpc.Rpc;
-import com.cloudera.livy.client.local.rpc.RpcServer;
 import static com.cloudera.livy.client.local.LocalConf.Entry.*;
 
 public class LocalClient implements LivyClient {
   private static final Logger LOG = LoggerFactory.getLogger(LocalClient.class);
 
-  private static final long DEFAULT_SHUTDOWN_TIMEOUT = 10000; // In milliseconds
-
-  private static final String SPARK_JARS_KEY = "spark.jars";
-  private static final String SPARK_HOME_ENV = "SPARK_HOME";
-  private static final String SPARK_HOME_KEY = "spark.home";
-  private static final String DRIVER_OPTS_KEY = "spark.driver.extraJavaOptions";
-  private static final String EXECUTOR_OPTS_KEY = "spark.executor.extraJavaOptions";
-
+  private final ContextInfo ctx;
   private final LocalClientFactory factory;
   private final LocalConf conf;
-  private final AtomicInteger childIdGenerator;
-  private final Thread driverThread;
   private final Map<String, JobHandleImpl<?>> jobs;
   private final Rpc driverRpc;
   private final ClientProtocol protocol;
   private volatile boolean isAlive;
 
-  LocalClient(LocalClientFactory factory, LocalConf conf) throws IOException {
+  LocalClient(LocalClientFactory factory, LocalConf conf, ContextInfo ctx) throws IOException {
+    this.ctx = ctx;
     this.factory = factory;
     this.conf = conf;
-    this.childIdGenerator = new AtomicInteger();
     this.jobs = Maps.newConcurrentMap();
-
-    String clientId = UUID.randomUUID().toString();
-    String secret = factory.getServer().createSecret();
-    this.driverThread = startDriver(factory.getServer(), clientId, secret);
     this.protocol = new ClientProtocol();
 
     try {
-      // The RPC server will take care of timeouts here.
-      this.driverRpc = factory.getServer().registerClient(clientId, secret, protocol).get();
+      this.driverRpc = Rpc.createClient(conf,
+        factory.getServer().getEventLoopGroup(),
+        ctx.getRemoteAddress(),
+        ctx.getRemotePort(),
+        ctx.getClientId(),
+        ctx.getSecret(),
+        protocol).get();
     } catch (Throwable e) {
-      LOG.warn("Error while waiting for client to connect.", e);
-      driverThread.interrupt();
-      try {
-        driverThread.join();
-      } catch (InterruptedException ie) {
-        // Give up.
-        LOG.debug("Interrupted before driver thread was finished.");
-      }
+      ctx.dispose();
       throw Throwables.propagate(e);
     }
 
@@ -121,6 +82,7 @@ public class LocalClient implements LivyClient {
           }
         }
     });
+
     isAlive = true;
   }
 
@@ -136,26 +98,16 @@ public class LocalClient implements LivyClient {
 
   @Override
   public void stop(boolean shutdownContext) {
-    if (!shutdownContext) {
-      LOG.warn("shutdownContext=false is not supported for local clients.");
-    }
     if (isAlive) {
       isAlive = false;
       try {
-        protocol.endSession();
-
-        try {
-          driverThread.join(DEFAULT_SHUTDOWN_TIMEOUT);
-        } catch (InterruptedException ie) {
-          LOG.debug("Interrupted before driver thread was finished.");
-        }
-        if (driverThread.isAlive()) {
-          LOG.warn("Timed out shutting down remote driver, interrupting...");
-          driverThread.interrupt();
+        if (shutdownContext) {
+          protocol.endSession();
         }
       } catch (Exception e) {
         LOG.warn("Exception while waiting for end session reply.", e);
       } finally {
+        ctx.dispose();
         driverRpc.close();
         factory.unref();
       }
@@ -194,162 +146,9 @@ public class LocalClient implements LivyClient {
     protocol.cancel(jobId);
   }
 
-  private Thread startDriver(final RpcServer rpcServer, final String clientId, final String secret)
-      throws IOException {
-    Runnable runnable;
-    final String serverAddress = rpcServer.getAddress();
-    final String serverPort = String.valueOf(rpcServer.getPort());
-    if (conf.get(CLIENT_IN_PROCESS) != null) {
-      // Mostly for testing things quickly. Do not do this in production.
-      LOG.warn("!!!! Running remote driver in-process. !!!!");
-      runnable = new Runnable() {
-        @Override
-        public void run() {
-          List<String> args = Lists.newArrayList();
-          args.add("--remote-host");
-          args.add(serverAddress);
-          args.add("--remote-port");
-          args.add(serverPort);
-          args.add("--client-id");
-          args.add(clientId);
-          args.add("--secret");
-          args.add(secret);
-
-          for (Map.Entry<String, String> e : conf) {
-            args.add("--conf");
-            args.add(String.format("%s=%s", e.getKey(), e.getValue()));
-          }
-          try {
-            RemoteDriver.main(args.toArray(new String[args.size()]));
-          } catch (Exception e) {
-            LOG.error("Error running driver.", e);
-          }
-        }
-      };
-    } else {
-      // If a Spark installation is provided, use the spark-submit script. Otherwise, call the
-      // SparkSubmit class directly, which has some caveats (like having to provide a proper
-      // version of Guava on the classpath depending on the deploy mode).
-      final SparkLauncher launcher = new SparkLauncher();
-      String sparkHome = conf.get(SPARK_HOME_KEY);
-      if (sparkHome == null) {
-        sparkHome = System.getenv(SPARK_HOME_ENV);
-      }
-      if (sparkHome == null) {
-        sparkHome = System.getProperty(SPARK_HOME_KEY);
-      }
-      launcher.setSparkHome(sparkHome);
-
-      conf.set(CLIENT_ID, clientId);
-      conf.set(CLIENT_SECRET, secret);
-
-      launcher.setAppResource("spark-internal");
-      String livyJars = conf.get(LIVY_JARS);
-      if (livyJars == null) {
-        String livyHome = System.getenv("LIVY_HOME");
-        Preconditions.checkState(livyHome != null,
-                "Need one of LIVY_HOME or %s set.", LIVY_JARS.key());
-        File clientJars = new File(livyHome, "client-jars");
-        Preconditions.checkState(clientJars.isDirectory(),
-                "Cannot find 'client-jars' directory under LIVY_HOME.");
-        List<String> jars = new ArrayList<>();
-        for (File f : clientJars.listFiles()) {
-           launcher.addJar(f.getAbsolutePath());
-        }
-        livyJars = Joiner.on(",").join(jars);
-      }
-      String userJars = conf.get(SPARK_JARS_KEY);
-      if (userJars != null) {
-        String allJars = Joiner.on(",").join(livyJars, userJars);
-        conf.set(SPARK_JARS_KEY, allJars);
-      }
-
-      // Disable multiple attempts since the RPC server doesn't yet support multiple
-      // connections for the same registered app.
-      conf.set("spark.yarn.maxAppAttempts", "1");
-
-      File confFile = writeConfToFile();
-
-      // Define how to pass options to the child process. If launching in client (or local)
-      // mode, the driver options need to be passed directly on the command line. Otherwise,
-      // SparkSubmit will take care of that for us.
-      String master = conf.get("spark.master");
-      Preconditions.checkArgument(master != null, "spark.master is not defined.");
-      launcher.setMaster(master);
-      launcher.setPropertiesFile(confFile.getAbsolutePath());
-      launcher.setMainClass(RemoteDriver.class.getName());
-      if (conf.get(PROXY_USER) != null) {
-        launcher.addSparkArg("--proxy-user", conf.get(PROXY_USER));
-      }
-      launcher.addAppArgs("--remote-host", serverAddress);
-      launcher.addAppArgs("--remote-port",  serverPort);
-
-      final Process child = launcher.launch();
-      int childId = childIdGenerator.incrementAndGet();
-      redirect("stdout-redir-" + childId, child.getInputStream());
-      redirect("stderr-redir-" + childId, child.getErrorStream());
-
-      runnable = new Runnable() {
-        @Override
-        public void run() {
-          try {
-            int exitCode = child.waitFor();
-            if (exitCode != 0) {
-              rpcServer.cancelClient(clientId, "Child process exited before connecting back");
-              LOG.warn("Child process exited with code {}.", exitCode);
-            }
-          } catch (InterruptedException ie) {
-            LOG.warn("Waiting thread interrupted, killing child process.");
-            Thread.interrupted();
-            child.destroy();
-          } catch (Exception e) {
-            LOG.warn("Exception while waiting for child process.", e);
-          }
-        }
-      };
-    }
-
-    Thread thread = new Thread(runnable);
-    thread.setDaemon(true);
-    thread.setName("Driver");
-    thread.start();
-    return thread;
-  }
-
-  private void redirect(String name, InputStream in) {
-    Thread thread = new Thread(new Redirector(in));
-    thread.setName(name);
-    thread.setDaemon(true);
-    thread.start();
-  }
-
-  /**
-   * Write the configuration to a file readable only by the process's owner. Livy properties
-   * are written with an added prefix so that they can be loaded using SparkConf on the driver
-   * side.
-   */
-  private File writeConfToFile() throws IOException {
-    Properties confView = new Properties();
-    for (Map.Entry<String, String> e : conf) {
-      String key = e.getKey();
-      if (!key.startsWith(LocalConf.SPARK_CONF_PREFIX)) {
-        key = LocalConf.LIVY_SPARK_PREFIX + key;
-      }
-      confView.setProperty(key, e.getValue());
-    }
-
-    File file = File.createTempFile("livyConf", ".properties");
-    Files.setPosixFilePermissions(file.toPath(), EnumSet.of(OWNER_READ, OWNER_WRITE));
-    file.deleteOnExit();
-
-    Writer writer = new OutputStreamWriter(new FileOutputStream(file), UTF_8);
-    try {
-      confView.store(writer, "Livy App Context Configuration");
-    } finally {
-      writer.close();
-    }
-
-    return file;
+  @VisibleForTesting
+  ContextInfo getContextInfo() {
+    return ctx;
   }
 
   private class ClientProtocol extends BaseProtocol {
@@ -454,28 +253,6 @@ public class LocalClient implements LivyClient {
         handle.addSparkJobId(msg.sparkJobId);
       } else {
         LOG.warn("Received spark job ID: {} for unknown job {}", msg.sparkJobId, msg.clientJobId);
-      }
-    }
-
-  }
-
-  private class Redirector implements Runnable {
-
-    private final BufferedReader in;
-
-    Redirector(InputStream in) {
-      this.in = new BufferedReader(new InputStreamReader(in));
-    }
-
-    @Override
-    public void run() {
-      try {
-        String line = null;
-        while ((line = in.readLine()) != null) {
-          LOG.info(line);
-        }
-      } catch (Exception e) {
-        LOG.warn("Error in redirector thread.", e);
       }
     }
 

--- a/client-local/src/main/java/com/cloudera/livy/client/local/LocalClientFactory.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/LocalClientFactory.java
@@ -54,22 +54,22 @@ public final class LocalClientFactory implements LivyClientFactory {
     }
 
     LocalConf lconf = new LocalConf(config);
-    try {
-      ref(lconf);
-    } catch (IOException ioe) {
-      throw Throwables.propagate(ioe);
-    }
 
+    boolean needsServer = false;
     try {
       ContextInfo info;
       if (uri.getUserInfo() != null && uri.getHost() != null && uri.getPort() > 0) {
         info = createContextInfo(uri);
       } else {
+        needsServer = true;
+        ref(lconf);
         info = new ContextLauncher(this, lconf);
       }
       return new LocalClient(this, lconf, info);
     } catch (Exception e) {
-      unref();
+      if (needsServer) {
+        unref();
+      }
       throw Throwables.propagate(e);
     }
   }
@@ -128,7 +128,7 @@ public final class LocalClientFactory implements LivyClientFactory {
       }
 
       @Override
-      public void dispose() {
+      public void dispose(boolean forceKill) {
 
       }
 

--- a/client-local/src/main/java/com/cloudera/livy/client/local/LocalConf.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/LocalConf.java
@@ -44,6 +44,7 @@ public class LocalConf extends ClientConf<LocalConf> {
     CLIENT_ID("client.auth.id", null),
     CLIENT_SECRET("client.auth.secret", null),
     CLIENT_IN_PROCESS("client.do_not_use.run_driver_in_process", null),
+    CLIENT_SHUTDOWN_TIMEOUT("client.shutdown_timeout", "10s"),
 
     LIVY_JARS("jars", null),
 

--- a/client-local/src/main/java/com/cloudera/livy/client/local/driver/BypassJobWrapper.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/driver/BypassJobWrapper.java
@@ -33,8 +33,8 @@ class BypassJobWrapper extends JobWrapper<byte[]> {
   private volatile JobHandle.State state;
   private volatile List<Integer> newSparkJobs;
 
-  BypassJobWrapper(RemoteDriver driver, String jobId, byte[] serializedJob) {
-    super(driver, jobId, new BypassJob(driver.serializer, serializedJob));
+  BypassJobWrapper(RemoteDriver driver, DriverProtocol client, String jobId, byte[] serializedJob) {
+    super(driver, client, jobId, new BypassJob(driver.serializer, serializedJob));
     state = JobHandle.State.QUEUED;
   }
 

--- a/client-local/src/main/java/com/cloudera/livy/client/local/driver/JobWrapper.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/driver/JobWrapper.java
@@ -38,14 +38,16 @@ class JobWrapper<T> implements Callable<Void> {
   public final String jobId;
 
   private final RemoteDriver driver;
+  private final DriverProtocol client;
   private final List<JavaFutureAction<?>> sparkJobs;
   private final Job<T> job;
   private final AtomicInteger completed;
 
   private Future<?> future;
 
-  JobWrapper(RemoteDriver driver, String jobId, Job<T> job) {
+  JobWrapper(RemoteDriver driver, DriverProtocol client, String jobId, Job<T> job) {
     this.driver = driver;
+    this.client = client;
     this.jobId = jobId;
     this.job = job;
     this.sparkJobs = Lists.newArrayList();
@@ -122,23 +124,23 @@ class JobWrapper<T> implements Callable<Void> {
   }
 
   void recordNewJob(int sparkJobId) {
-    driver.protocol.jobSubmitted(jobId, sparkJobId);
+    client.jobSubmitted(jobId, sparkJobId);
   }
 
   protected void finished(T result, Throwable error) {
     if (error == null) {
-      driver.protocol.jobFinished(jobId, result, null);
+      client.jobFinished(jobId, result, null);
     } else {
-      driver.protocol.jobFinished(jobId, null, error);
+      client.jobFinished(jobId, null, error);
     }
   }
 
   protected void jobSubmitted(JavaFutureAction<?> job) {
-    driver.protocol.jobSubmitted(jobId, job.jobIds().get(0));
+    client.jobSubmitted(jobId, job.jobIds().get(0));
   }
 
   protected void jobStarted() {
-    driver.protocol.jobStarted(jobId);
+    client.jobStarted(jobId);
   }
 
 }

--- a/client-local/src/main/java/com/cloudera/livy/client/local/driver/RemoteDriver.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/driver/RemoteDriver.java
@@ -148,7 +148,6 @@ public class RemoteDriver {
     server.registerClient(clientId, secret, new RpcServer.ClientCallback() {
       @Override
       public RpcDispatcher onNewClient(Rpc client) {
-        LOG.debug("Incoming connection from {}.", client.getChannel());
         final DriverProtocol dispatcher = new DriverProtocol(RemoteDriver.this, client, jcLock);
         synchronized (clients) {
           clients.add(dispatcher);
@@ -161,6 +160,7 @@ public class RemoteDriver {
             }
           }
         });
+        LOG.debug("Registered new connection from {}.", client.getChannel());
         return dispatcher;
       }
     });

--- a/client-local/src/main/java/com/cloudera/livy/client/local/driver/RemoteDriver.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/driver/RemoteDriver.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import scala.Tuple2;
@@ -37,7 +38,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import io.netty.channel.nio.NioEventLoopGroup;
 import org.apache.commons.io.FileUtils;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkFiles;
@@ -47,8 +47,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.cloudera.livy.client.common.Serializer;
+import com.cloudera.livy.client.local.BaseProtocol;
 import com.cloudera.livy.client.local.LocalConf;
 import com.cloudera.livy.client.local.rpc.Rpc;
+import com.cloudera.livy.client.local.rpc.RpcDispatcher;
+import com.cloudera.livy.client.local.rpc.RpcServer;
 import static com.cloudera.livy.client.local.LocalConf.Entry.*;
 
 /**
@@ -61,16 +64,18 @@ public class RemoteDriver {
   private final Object jcLock;
   private final Object shutdownLock;
   private final ExecutorService executor;
-  private final NioEventLoopGroup egroup;
+  private final RpcServer server;
+
   // a local temp dir specific to this driver
   private final File localTmpDir;
 
   // Used to queue up requests while the SparkContext is being created.
   private final List<JobWrapper<?>> jobQueue = Lists.newLinkedList();
 
+  // Keeps track of connected clients.
+  private final List<DriverProtocol> clients = Lists.newArrayList();
+
   final Map<String, JobWrapper<?>> activeJobs;
-  final DriverProtocol protocol;
-  final Rpc clientRpc;
   final Serializer serializer;
 
   // jc is effectively final, but it has to be volatile since it's accessed by different
@@ -106,7 +111,7 @@ public class RemoteDriver {
       } else if (key.equals("--client-id")) {
         livyConf.set(CLIENT_ID, getArg(args, idx));
       } else if (key.equals("--secret")) {
-        livyConf.set(CLIENT_SECRET.key(), getArg(args, idx));
+        livyConf.set(CLIENT_SECRET, getArg(args, idx));
       } else if (key.equals("--conf")) {
         String[] val = getArg(args, idx).split("[=]", 2);
         if (val[0].startsWith(LocalConf.SPARK_CONF_PREFIX)) {
@@ -129,33 +134,57 @@ public class RemoteDriver {
     String secret = livyConf.get(CLIENT_SECRET);
     Preconditions.checkArgument(secret != null, "No secret provided.");
 
-    this.egroup = new NioEventLoopGroup(
-        livyConf.getInt(RPC_MAX_THREADS),
-        new ThreadFactoryBuilder()
-            .setNameFormat("Driver-RPC-Handler-%d")
-            .setDaemon(true)
-            .build());
     this.serializer = new Serializer();
-    this.protocol = new DriverProtocol(this, jcLock);
 
-    // The RPC library takes care of timing out this.
-    this.clientRpc = Rpc.createClient(livyConf, egroup, serverAddress, serverPort,
-      clientId, secret, protocol).get();
-    this.running = true;
+    // We need to unset this configuration since it doesn't really apply for the driver side.
+    // If the driver runs on a multi-homed machine, this can lead to issues where the Livy
+    // server cannot connect to the auto-detected address, but since the driver can run anywhere
+    // on the cluster, it would be tricky to solve that problem in a generic way.
+    livyConf.set(RPC_SERVER_ADDRESS, null);
 
-    this.clientRpc.addListener(new Rpc.Listener() {
+    // Bring up the RpcServer an register the secret provided by the Livy server as a client.
+    LOG.info("Starting RPC server...");
+    this.server = new RpcServer(livyConf);
+    server.registerClient(clientId, secret, new RpcServer.ClientCallback() {
       @Override
-      public void rpcClosed(Rpc rpc) {
-        LOG.warn("Shutting down driver because RPC channel was closed.");
-        shutdown(null);
+      public RpcDispatcher onNewClient(Rpc client) {
+        LOG.debug("Incoming connection from {}.", client.getChannel());
+        final DriverProtocol dispatcher = new DriverProtocol(RemoteDriver.this, client, jcLock);
+        synchronized (clients) {
+          clients.add(dispatcher);
+        }
+        client.addListener(new Rpc.Listener() {
+          @Override
+          public void rpcClosed(Rpc rpc) {
+            synchronized (clients) {
+              clients.remove(dispatcher);
+            }
+          }
+        });
+        return dispatcher;
       }
     });
 
+    // The RPC library takes care of timing out this.
+    Rpc callbackRpc = Rpc.createClient(livyConf, server.getEventLoopGroup(), serverAddress,
+      serverPort, clientId, secret, new BaseProtocol() { }).get();
     try {
-      long t1 = System.currentTimeMillis();
-      LOG.info("Starting Spark context at {}", t1);
+      // There's no timeout here because we expect the launching side to kill the underlying
+      // application if it takes too long to connect back and send its address.
+      callbackRpc.call(new BaseProtocol.RemoteDriverAddress(server.getAddress(),
+        server.getPort())).get();
+    } finally {
+      callbackRpc.close();
+    }
+
+    this.running = true;
+
+    try {
+      long t1 = System.nanoTime();
+      LOG.info("Starting Spark context...");
       JavaSparkContext sc = new JavaSparkContext(conf);
-      LOG.info("Spark context finished initialization in {}ms", System.currentTimeMillis() - t1);
+      LOG.info("Spark context finished initialization in {}ms",
+        TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t1));
       sc.sc().addSparkListener(new DriverSparkListener(this));
       synchronized (jcLock) {
         jc = new JobContextImpl(sc, localTmpDir);
@@ -225,10 +254,15 @@ public class RemoteDriver {
         jc.stop();
       }
       if (error != null) {
-        protocol.sendError(error);
+        synchronized (clients) {
+          for (DriverProtocol client : clients) {
+            client.sendError(error);
+          }
+        }
       }
-      clientRpc.close();
-      egroup.shutdownGracefully();
+      if (server != null) {
+        server.close();
+      }
     } finally {
       running = false;
       synchronized (shutdownLock) {

--- a/client-local/src/main/java/com/cloudera/livy/client/local/rpc/Rpc.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/rpc/Rpc.java
@@ -47,8 +47,8 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.logging.LogLevel;
@@ -92,7 +92,7 @@ public class Rpc implements Closeable {
    */
   public static Promise<Rpc> createClient(
       final LocalConf config,
-      final NioEventLoopGroup eloop,
+      final EventLoopGroup eloop,
       String host,
       int port,
       final String clientId,
@@ -302,8 +302,7 @@ public class Rpc implements Closeable {
     return egroup.next().newPromise();
   }
 
-  @VisibleForTesting
-  Channel getChannel() {
+  public Channel getChannel() {
     return channel;
   }
 

--- a/client-local/src/main/java/com/cloudera/livy/client/local/rpc/Rpc.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/rpc/Rpc.java
@@ -268,7 +268,7 @@ public class Rpc implements Closeable {
    */
   public <T> Future<T> call(Object msg, Class<T> retType) {
     Preconditions.checkArgument(msg != null);
-    Preconditions.checkState(channel.isActive(), "RPC channel is closed.");
+    Preconditions.checkState(channel.isOpen(), "RPC channel is closed.");
     try {
       final long id = rpcId.getAndIncrement();
       final Promise<T> promise = createPromise();

--- a/client-local/src/main/java/com/cloudera/livy/client/local/rpc/RpcDispatcher.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/rpc/RpcDispatcher.java
@@ -174,6 +174,8 @@ public abstract class RpcDispatcher extends SimpleChannelInboundHandler<Object> 
       for (OutstandingRpc rpc : rpcs) {
         rpc.future.cancel(true);
       }
+    } else {
+      LOG.debug("Channel {} became inactive.", ctx.channel());
     }
     super.channelInactive(ctx);
   }

--- a/client-local/src/test/java/com/cloudera/livy/client/local/TestSparkClient.java
+++ b/client-local/src/test/java/com/cloudera/livy/client/local/TestSparkClient.java
@@ -72,7 +72,6 @@ public class TestSparkClient {
 
   private Properties createConf(boolean local) {
     Properties conf = new Properties();
-    conf.put(RPC_CHANNEL_LOG_LEVEL.key(), "DEBUG");
     if (local) {
       conf.put(CLIENT_IN_PROCESS.key(), "true");
       conf.put(SparkLauncher.SPARK_MASTER, "local");


### PR DESCRIPTION
This change modifies the direction of connections between Livy and the RSC,
so that it's Livy connecting to the RSC instead of the other way around.
This makes the RSC behave sort of like the current REPL code, where the
context will connect back to Livy to tell its listen address so that Livy
can connect to it.

For that to work, the RemoteDriver now runs an RpcServer, and does not
kill itself when client connections go away. It also allows multiple
concurrent client connections to exist, although it should be rare for
that situation to exist in the real world.

The code to launch Spark was refactored into a separate class, since
when connecting to an existing RSC it needs to be bypassed altogether.