### PR TITLE
Specify java version in maven-compiler-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -696,6 +696,10 @@
             <phase>none</phase>
           </execution>
         </executions>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+        </configuration>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
The purpose is that it can help intellij recognize the java version and set the language level correctly in intellij. Otherwise intellij always use java 5 which is very annoying. 