### PR TITLE
LIVY-71. Write session files to HDFS as the correct user.

### DIFF
--- a/bin/livy-server
+++ b/bin/livy-server
@@ -32,9 +32,20 @@ if [ ! -d "$LIBDIR" ]; then
   exit 1
 fi
 
-CLASSPATH="$LIBDIR/*:$LIVY_HOME/conf:$CLASSPATH"
+
+LIVY_CLASSPATH="$LIBDIR/*:$LIVY_HOME/conf"
+
+if [ -n "$SPARK_CONF_DIR" ]; then
+  LIVY_CLASSPATH="$LIVY_CLASSPATH:$SPARK_CONF_DIR"
+fi
+if [ -n "$HADOOP_CONF_DIR" ]; then
+  LIVY_CLASSPATH="$LIVY_CLASSPATH:$HADOOP_CONF_DIR"
+fi
+if [ -n "$YARN_CONF_DIR" ]; then
+  LIVY_CLASSPATH="$LIVY_CLASSPATH:$YARN_CONF_DIR"
+fi
 
 exec java \
 	$LIVY_SERVER_JAVA_OPTS \
-	-cp "$CLASSPATH" \
+	-cp "$LIVY_CLASSPATH:$CLASSPATH" \
 	com.cloudera.livy.server.Main

--- a/client-http/pom.xml
+++ b/client-http/pom.xml
@@ -117,7 +117,6 @@
                 </includes>
                 <excludes>
                   <exclude>com.cloudera.livy:livy-api</exclude>
-                  <exclude>com.cloudera.livy:livy-client-common</exclude>
                 </excludes>
               </artifactSet>
               <filters>

--- a/core/src/main/scala/com/cloudera/livy/LivyConf.scala
+++ b/core/src/main/scala/com/cloudera/livy/LivyConf.scala
@@ -41,11 +41,9 @@ object LivyConf {
   val SPARK_HOME = Entry("livy.server.spark-home", null)
   val SPARK_SUBMIT_KEY = Entry("livy.server.spark-submit", null)
   val IMPERSONATION_ENABLED = Entry("livy.impersonation.enabled", false)
-  val LIVY_HOME = Entry("livy.home", null)
   val FILE_UPLOAD_MAX_SIZE = Entry("livy.file.upload.max.size", 100L * 1024 * 1024)
   val SUPERUSERS = Entry("livy.superusers", null)
-
-  lazy val TEST_LIVY_HOME = Files.createTempDirectory("livyTemp").toUri.toString
+  val SESSION_STAGING_DIR = Entry("livy.session.staging-dir", null)
 }
 
 /**
@@ -77,16 +75,6 @@ class LivyConf(loadDefaults: Boolean) extends ClientConf[LivyConf](null) {
 
   /** Return the location of the spark home directory */
   def sparkHome(): Option[String] = Option(get(SPARK_HOME)).orElse(sys.env.get("SPARK_HOME"))
-
-  def livyHome(): String = {
-    Option(get(LIVY_HOME)).orElse(sys.env.get("LIVY_HOME")).getOrElse {
-      if (LivyConf.TEST_MODE) {
-        LivyConf.TEST_LIVY_HOME
-      } else {
-        throw new IllegalStateException("livy.home must be specified!")
-      }
-    }
-  }
 
   /** Return the path to the spark-submit executable. */
   def sparkSubmit(): String = {

--- a/server/src/main/scala/com/cloudera/livy/server/client/ClientSessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/client/ClientSessionServlet.scala
@@ -48,7 +48,7 @@ class ClientSessionServlet(livyConf: LivyConf)
         None
       }
     val proxyUser = checkImpersonation(requestedProxy, req)
-    new ClientSession(id, user, proxyUser, createRequest, livyConf.livyHome)
+    new ClientSession(id, user, proxyUser, createRequest, livyConf)
   }
 
   // This endpoint is used by the client-http module to "connect" to an existing session and

--- a/server/src/test/resources/log4j.properties
+++ b/server/src/test/resources/log4j.properties
@@ -33,6 +33,8 @@ log4j.appender.console.target=System.err
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%t: %m%n
 
-# Ignore messages below warning level from Jetty, because it's a bit verbose
+# Silence some noisy libraries.
+log4j.logger.org.apache.http=WARN
+log4j.logger.org.apache.spark=INFO
+log4j.logger.org.eclipse.jetty=WARN
 log4j.logger.org.spark-project.jetty=WARN
-org.spark-project.jetty.LEVEL=WARN

--- a/server/src/test/scala/com/cloudera/livy/server/BaseJsonServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/BaseJsonServletSpec.scala
@@ -98,7 +98,11 @@ abstract class BaseJsonServletSpec extends ScalatraSuite with FunSpecLike {
 
   private def doTest[R: ClassTag](expectedStatus: Int, fn: R => Unit)
       (implicit klass: ClassTag[R]): Unit = {
-    status should be (expectedStatus)
+    if (status != expectedStatus) {
+      // Yeah this is weird, but we don't want to evaluate "response.body" if there's no error.
+      assert(status === expectedStatus,
+        s"Unexpected response status: $status != $expectedStatus (${response.body})")
+    }
     // Only try to parse the body if response is in the "OK" range (20x).
     if ((status / 100) * 100 == SC_OK) {
       val result =

--- a/server/src/test/scala/com/cloudera/livy/server/client/ClientServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/client/ClientServletSpec.scala
@@ -31,6 +31,7 @@ import scala.concurrent.duration._
 import scala.io.Source
 import scala.language.postfixOps
 
+import org.apache.commons.io.FileUtils
 import org.apache.hadoop.security.UserGroupInformation
 import org.apache.spark.api.java.function.VoidFunction
 import org.scalatest.concurrent.Eventually._
@@ -45,6 +46,23 @@ class ClientServletSpec
   extends BaseSessionServletSpec[ClientSession] {
 
   private val PROXY = "__proxy__"
+
+  private var tempDir: File = _
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    if (tempDir != null) {
+      scala.util.Try(FileUtils.deleteDirectory(tempDir))
+      tempDir = null
+    }
+  }
+
+  override protected def createConf(): LivyConf = synchronized {
+    if (tempDir == null) {
+      tempDir = Files.createTempDirectory("client-test").toFile()
+    }
+    super.createConf().set(LivyConf.SESSION_STAGING_DIR, tempDir.toURI().toString())
+  }
 
   override def createServlet(): ClientSessionServlet = {
     new ClientSessionServlet(createConf()) with RemoteUserOverride
@@ -185,12 +203,17 @@ class ClientServletSpec
 
   private def testResourceUpload(cmd: String, sessionId: Int): Unit = {
     val f = File.createTempFile("uploadTestFile", cmd)
-    val conf = new LivyConf()
+    val conf = createConf()
 
     Files.write(Paths.get(f.getAbsolutePath), "Test data".getBytes())
 
     jupload[Unit](s"/$sessionId/upload-$cmd", Map(cmd -> f), expectedStatus = SC_OK) { _ =>
-      val resultFile = new File(new URI(s"${conf.livyHome()}/$sessionId/${f.getName}"))
+      // There should be a single directory under the staging dir.
+      val subdirs = tempDir.listFiles()
+      assert(subdirs.length === 1)
+      val stagingDir = subdirs(0).toURI().toString()
+
+      val resultFile = new File(new URI(s"$stagingDir/${f.getName}"))
       resultFile.deleteOnExit()
       resultFile.exists() should be(true)
       Source.fromFile(resultFile).mkString should be("Test data")

--- a/server/src/test/scala/com/cloudera/livy/server/client/ClientServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/client/ClientServletSpec.scala
@@ -152,6 +152,9 @@ class ClientServletSpec
           case _ => fail("Response is not an array.")
         }
       }
+
+      // Make sure the session's staging directory was cleaned up.
+      assert(tempDir.listFiles().length === 0)
     }
 
     it("should support user impersonation") {
@@ -177,8 +180,13 @@ class ClientServletSpec
           data.proxyUser should be (PROXY)
           val user = runJob(data.id, new GetUserJob(), headers = adminHeaders)
           user should be (PROXY)
+
+          // Test that files are uploaded to a new session directory.
+          assert(tempDir.listFiles().length === 0)
+          testResourceUpload("file", data.id)
         } finally {
           deleteSession(data.id)
+          assert(tempDir.listFiles().length === 0)
         }
       }
     }


### PR DESCRIPTION
When uploading files using `LivyClient.uploadJar` (or `uploadFile`),
the user files should not be readable by other users. Since we know
who the session is running as, impersonate that user before uploading
the file to HDFS. The file is stored in a session-specific staging
directory, which is deleted when the session is stopped.

The staging directory, by default, is under the user's home directory
(under the ".livy-sessions" subdirectory); the location can be modified
in the config file. When setting a custom location, the directory needs
to be world-writable, so that all users can create directories, since
Livy cannot change ownership of directories it creates as its own user.

Two other minor changes are included (found during testing):

- bin/livy-server now adds config directories (Spark and Hadoop) do Livy's
  classpath, so that Livy can read the correct Hadoop configuration (and
  Spark's, if needed later).
- client-http/pom.xml now shades livy-client-common since we need to relocate
  kryo classes in that artifact too.