### PR TITLE
LIVY-100. Make jars uploaded by the user available in RSC's driver.

### DIFF
--- a/client-common/src/main/java/com/cloudera/livy/client/common/Serializer.java
+++ b/client-common/src/main/java/com/cloudera/livy/client/common/Serializer.java
@@ -52,6 +52,7 @@ public class Serializer {
           count++;
         }
         kryo.setInstantiatorStrategy(new StdInstantiatorStrategy());
+        kryo.setClassLoader(Thread.currentThread().getContextClassLoader());
         return kryo;
       }
     };

--- a/client-local/src/main/java/com/cloudera/livy/client/local/LocalClient.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/LocalClient.java
@@ -42,6 +42,7 @@ import com.cloudera.livy.JobContext;
 import com.cloudera.livy.JobHandle;
 import com.cloudera.livy.LivyClient;
 import com.cloudera.livy.client.common.BufferUtils;
+import com.cloudera.livy.client.local.driver.AddJarJob;
 import com.cloudera.livy.client.local.rpc.Rpc;
 import static com.cloudera.livy.client.local.LocalConf.Entry.*;
 
@@ -135,7 +136,7 @@ public class LocalClient implements LivyClient {
 
   @Override
   public Future<?> addJar(URI uri) {
-    return run(new AddJarJob(uri.toString()));
+    return submit(new AddJarJob(uri.toString()));
   }
 
   @Override
@@ -145,7 +146,7 @@ public class LocalClient implements LivyClient {
 
   @Override
   public Future<?> addFile(URI uri) {
-    return run(new AddFileJob(uri.toString()));
+    return submit(new AddFileJob(uri.toString()));
   }
 
   public String bypass(ByteBuffer serializedJob, boolean sync) {
@@ -282,26 +283,6 @@ public class LocalClient implements LivyClient {
       } else {
         LOG.warn("Received spark job ID: {} for unknown job {}", msg.sparkJobId, msg.clientJobId);
       }
-    }
-
-  }
-
-  private static class AddJarJob implements Job<Object> {
-
-    private final String path;
-
-    AddJarJob() {
-      this(null);
-    }
-
-    AddJarJob(String path) {
-      this.path = path;
-    }
-
-    @Override
-    public Object call(JobContext jc) throws Exception {
-      jc.sc().addJar(path);
-      return null;
     }
 
   }

--- a/client-local/src/main/java/com/cloudera/livy/client/local/driver/AddJarJob.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/driver/AddJarJob.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.client.local.driver;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import com.cloudera.livy.Job;
+import com.cloudera.livy.JobContext;
+
+public class AddJarJob implements Job<Object> {
+
+  private final String path;
+
+  // For serialization.
+  private AddJarJob() {
+    this(null);
+  }
+
+  public AddJarJob(String path) {
+    this.path = path;
+  }
+
+  @Override
+  public Object call(JobContext jc) throws Exception {
+    File localCopyDir = new File(jc.getLocalTmpDir(), "__livy__");
+    synchronized (jc) {
+      if (!localCopyDir.isDirectory() && !localCopyDir.mkdir()) {
+        throw new IOException("Failed to create directory for downloaded jars.");
+      }
+    }
+
+    URI uri = new URI(path);
+    String name = uri.getFragment() != null ? uri.getFragment() : uri.getPath();
+    name = new File(name).getName();
+    File localCopy = new File(localCopyDir, name);
+
+    if (localCopy.exists()) {
+      throw new IOException(String.format("A file with name %s has already been uploaded.", name));
+    }
+
+    Configuration conf = jc.sc().sc().hadoopConfiguration();
+    FileSystem fs = FileSystem.get(uri, conf);
+    fs.copyToLocalFile(new Path(uri), new Path(localCopy.toURI()));
+
+    MutableClassLoader cl = (MutableClassLoader) Thread.currentThread().getContextClassLoader();
+    cl.addURL(localCopy.toURI().toURL());
+
+    jc.sc().addJar(path);
+    return null;
+  }
+
+}

--- a/client-local/src/main/java/com/cloudera/livy/client/local/driver/Driver.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/driver/Driver.java
@@ -96,6 +96,12 @@ public abstract class Driver {
       }
     }
 
+    // Set up a class loader that can be modified, so that we can add jars uploaded
+    // by the client to the driver's class path.
+    ClassLoader driverClassLoader = new MutableClassLoader(
+      Thread.currentThread().getContextClassLoader());
+    Thread.currentThread().setContextClassLoader(driverClassLoader);
+
     LOG.info("Connecting to: {}:{}", serverAddress, serverPort);
 
     String clientId = livyConf.get(CLIENT_ID);

--- a/client-local/src/main/java/com/cloudera/livy/client/local/driver/MutableClassLoader.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/driver/MutableClassLoader.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.client.local.driver;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+class MutableClassLoader extends URLClassLoader {
+
+  MutableClassLoader(ClassLoader parent) {
+    super(new URL[] { }, parent);
+  }
+
+  @Override
+  public void addURL(URL url) {
+    super.addURL(url);
+  }
+
+}

--- a/client-local/src/test/java/com/cloudera/livy/client/local/TestSparkClient.java
+++ b/client-local/src/test/java/com/cloudera/livy/client/local/TestSparkClient.java
@@ -534,7 +534,8 @@ public class TestSparkClient {
   private static class JarJob implements Job<String>, Function<Integer, String> {
 
     @Override
-    public String call(JobContext jc) {
+    public String call(JobContext jc) throws Exception {
+      call(0);
       return jc.sc().parallelize(Arrays.asList(1)).map(this).collect().get(0);
     }
 


### PR DESCRIPTION
Spark's "addJar" only applies to executors, so we need more code to get
jars uploaded by users using the RSC API available to the driver. This
change sets up a new class loader that is used by the "add jar" job to
add uploaded files to the driver's class path.