### PR TITLE
LIVY-103. Make repl session see user jars, correctly report idle state.

### DIFF
--- a/client-local/src/main/java/com/cloudera/livy/client/local/ContextLauncher.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/ContextLauncher.java
@@ -228,6 +228,21 @@ class ContextLauncher implements ContextInfo {
         conf.set(SPARK_JARS_KEY, livyJars);
       }
 
+      // For testing; propagate jacoco settings so that we also do coverage analysis
+      // on the launched driver. We replace the name of the main file ("main.exec")
+      // so that we don't end up fighting with the main test launcher.
+      String jacocoArgs = System.getProperty("jacoco.args");
+      if (jacocoArgs != null) {
+        jacocoArgs = jacocoArgs.replace("main.exec", "child.exec");
+        String userArgs = conf.get(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS);
+        if (userArgs != null) {
+          userArgs = userArgs + " " + jacocoArgs;
+        } else {
+          userArgs = jacocoArgs;
+        }
+        conf.set(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS, userArgs);
+      }
+
       // Disable multiple attempts since the RPC server doesn't yet support multiple
       // connections for the same registered app.
       conf.set("spark.yarn.maxAppAttempts", "1");

--- a/client-local/src/main/java/com/cloudera/livy/client/local/PingJob.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/PingJob.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.client.local;
+
+import com.cloudera.livy.Job;
+import com.cloudera.livy.JobContext;
+
+/** A job that can be used to check for liveness of the remote context. */
+public class PingJob implements Job<Void> {
+
+  @Override
+  public Void call(JobContext jc) {
+    return null;
+  }
+
+}

--- a/client-local/src/main/java/com/cloudera/livy/client/local/driver/Driver.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/driver/Driver.java
@@ -30,6 +30,7 @@ import org.apache.spark.SparkConf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.cloudera.livy.JobContext;
 import com.cloudera.livy.client.common.Serializer;
 import com.cloudera.livy.client.local.BaseProtocol;
 import com.cloudera.livy.client.local.LocalConf;
@@ -175,6 +176,10 @@ public abstract class Driver {
   public abstract void shutdownDriver();
 
   public abstract DriverProtocol createProtocol(Rpc client);
+
+  public abstract void submit(JobWrapper<?> job);
+
+  public abstract JobContext jobContext();
 
   public void run() throws InterruptedException {
     synchronized (shutdownLock) {

--- a/client-local/src/main/java/com/cloudera/livy/client/local/driver/RemoteDriver.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/driver/RemoteDriver.java
@@ -32,6 +32,7 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.cloudera.livy.JobContext;
 import com.cloudera.livy.client.local.rpc.Rpc;
 
 /**
@@ -83,7 +84,8 @@ public class RemoteDriver extends Driver {
     }
   }
 
-  void submit(JobWrapper<?> job) {
+  @Override
+  public void submit(JobWrapper<?> job) {
     synchronized (jcLock) {
       if (jc != null) {
         job.submit(executor);
@@ -92,6 +94,11 @@ public class RemoteDriver extends Driver {
         jobQueue.add(job);
       }
     }
+  }
+
+  @Override
+  public JobContext jobContext() {
+    return jc;
   }
 
   @Override

--- a/client-local/src/test/java/com/cloudera/livy/client/local/TestSparkClient.java
+++ b/client-local/src/test/java/com/cloudera/livy/client/local/TestSparkClient.java
@@ -106,6 +106,9 @@ public class TestSparkClient {
         verify(listener).onJobQueued(handle);
         verify(listener).onJobStarted(handle);
         verify(listener).onJobSucceeded(same(handle), eq(handle.get()));
+
+        // Try a PingJob, both to make sure it works and also to test "null" results.
+        assertNull(client.submit(new PingJob()).get(TIMEOUT, TimeUnit.SECONDS));
       }
     });
   }

--- a/dev/spark/bin/spark-submit
+++ b/dev/spark/bin/spark-submit
@@ -7,7 +7,9 @@
 
 PROP_FILE=
 DRIVER_CP=
-CONF_KEY="spark.driver.extraClassPath"
+DRIVER_OPTS=
+CP_KEY="spark.driver.extraClassPath"
+OPTS_KEY="spark.driver.extraJavaOptions"
 
 INDEX=1
 ARGS=($@)
@@ -19,8 +21,10 @@ for IDX in $(seq 0 ${#ARGS[@]}); do
     --conf)
       CONF="${ARGS[$NEXT]}"
       IFS='=' read KEY VALUE <<< "$CONF"
-      if [ "$KEY" = "$CONF_KEY" ]; then
+      if [ "$KEY" = "$CP_KEY" ]; then
         DRIVER_CP="$VALUE"
+      elif [ "$KEY" = "$OPTS_KEY" ]; then
+        DRIVER_OPTS="$VALUE"
       fi
       ;;
     --driver-class-path)
@@ -32,12 +36,24 @@ for IDX in $(seq 0 ${#ARGS[@]}); do
   esac
 done
 
-if [ -n "$PROP_FILE" ] && [ -z "$DRIVER_CP" ]; then
-  CONF=$(grep -s "^$CONF_KEY=" "$PROP_FILE" | tail -n 1)
+read_opt() {
+  local FILE="$1"
+  local KEY="$2"
+  CONF=$(grep -s "^$KEY=" "$PROP_FILE" | tail -n 1)
   if [ -n "$CONF" ]; then
     IFS='=' read KEY VALUE <<< "$CONF"
-    DRIVER_CP="$VALUE"
+    echo "$VALUE"
+  fi
+}
+
+if [ -n "$PROP_FILE" ]; then
+  if [ -z "$DRIVER_CP" ]; then
+    DRIVER_CP=$(read_opt "$PROP_FILE" "$CP_KEY")
+  fi
+  if [ -z "$DRIVER_OPTS" ]; then
+    DRIVER_OPTS=$(read_opt "$PROP_FILE" "$OPTS_KEY")
   fi
 fi
 
-exec $JAVA_HOME/bin/java -cp "$DRIVER_CP" org.apache.spark.deploy.SparkSubmit "$@"
+echo "Running Spark: " $JAVA_HOME/bin/java $DRIVER_OPTS org.apache.spark.deploy.SparkSubmit "$@" >&2
+exec $JAVA_HOME/bin/java $DRIVER_OPTS -cp "$DRIVER_CP" org.apache.spark.deploy.SparkSubmit "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -629,6 +629,7 @@
               <java.awt.headless>true</java.awt.headless>
               <java.io.tmpdir>${project.build.directory}/tmp</java.io.tmpdir>
               <livy.environment>development</livy.environment>
+              <jacoco.args>${argLine}</jacoco.args>
             </systemProperties>
             <redirectTestOutputToFile>${test.redirectToFile}</redirectTestOutputToFile>
             <useFile>${test.redirectToFile}</useFile>
@@ -650,6 +651,7 @@
               <java.awt.headless>true</java.awt.headless>
               <java.io.tmpdir>${project.build.directory}/tmp</java.io.tmpdir>
               <livy.environment>development</livy.environment>
+              <jacoco.args>${argLine}</jacoco.args>
             </systemProperties>
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
             <junitxml>.</junitxml>
@@ -890,6 +892,24 @@
             </goals>
             <configuration>
               <append>true</append>
+              <destFile>${project.build.directory}/jacoco/main.exec</destFile>
+            </configuration>
+          </execution>
+          <execution>
+            <id>merge-reports</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>merge</goal>
+            </goals>
+            <configuration>
+              <fileSets>
+                <fileSet>
+                  <directory>${project.build.directory}/jacoco</directory>
+                  <includes>
+                    <include>*.exec</include>
+                  </includes>
+                </fileSet>
+              </fileSets>
             </configuration>
           </execution>
           <execution>

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -97,6 +97,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-hive_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.json4s</groupId>
             <artifactId>json4s-ast_${scala.binary.version}</artifactId>
             <scope>provided</scope>
@@ -136,12 +142,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-hive_${scala.binary.version}</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -139,6 +139,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-hive_${scala.binary.version}</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
             <scope>test</scope>

--- a/repl/src/main/scala/com/cloudera/livy/repl/ReplDriver.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/ReplDriver.scala
@@ -64,7 +64,9 @@ class ReplDriver(args: Array[String]) extends Driver(args) with Logging {
   }
 
   private[repl] val session = Session(interpreter)
-  jcLock.notifyAll()
+  jcLock.synchronized {
+    jcLock.notifyAll()
+  }
 
   override def createProtocol(client: Rpc): DriverProtocol = {
     new ReplProtocol(this, client, jcLock)

--- a/repl/src/main/scala/com/cloudera/livy/repl/Session.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/Session.scala
@@ -54,11 +54,13 @@ class Session(interpreter: Interpreter)
   private var _state: SessionState = SessionState.NotStarted()
   private var _history = IndexedSeq[Statement]()
 
-  Future {
+  val startTask = Future {
     _state = SessionState.Starting()
     interpreter.start()
     _state = SessionState.Idle()
-  }.onFailure { case _ =>
+  }
+
+  startTask.onFailure { case _ =>
     _state = SessionState.Error(System.currentTimeMillis())
   }
 

--- a/repl/src/test/scala/com/cloudera/livy/repl/ReplDriverSuite.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/ReplDriverSuite.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.repl
+
+import java.net.URI
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+import org.apache.spark.launcher.SparkLauncher
+import org.json4s._
+import org.json4s.jackson.JsonMethods._
+import org.scalatest.FunSuite
+import org.scalatest.concurrent.Eventually._
+
+import com.cloudera.livy._
+import com.cloudera.livy.client.local.{LocalClient, LocalConf, PingJob}
+import com.cloudera.livy.sessions.Spark
+
+class ReplDriverSuite extends FunSuite {
+
+  private implicit val formats = DefaultFormats
+
+  test("start a repl session using the rsc") {
+    val client = new LivyClientBuilder()
+      .setConf("spark.master", "local")
+      .setConf(SparkLauncher.DRIVER_EXTRA_CLASSPATH, sys.props("java.class.path"))
+      .setConf(SparkLauncher.EXECUTOR_EXTRA_CLASSPATH, sys.props("java.class.path"))
+      .setConf(LocalConf.Entry.LIVY_JARS.key(), "")
+      .setConf("session.kind", Spark().toString)
+      .setURI(new URI("local:spark"))
+      .setConf(LocalConf.Entry.CLIENT_REPL_MODE.key(), "true")
+      .build()
+      .asInstanceOf[LocalClient]
+
+    try {
+      // This is sort of what InteractiveSession.scala does to detect an idle session.
+      val handle = client.submit(new PingJob()).get(30, TimeUnit.SECONDS)
+
+      assert(client.getReplState().get(10, TimeUnit.SECONDS) === "idle")
+
+      val statementId = client.submitReplCode("1 + 1")
+      eventually(timeout(30 seconds), interval(100 millis)) {
+        val rawResult = client.getReplJobResult(statementId).get(1, TimeUnit.SECONDS)
+        val result = parse(rawResult)
+        assert((result \ Session.STATUS).extract[String] === Session.OK)
+      }
+    } finally {
+      client.stop(true);
+    }
+  }
+
+}

--- a/repl/src/test/scala/com/cloudera/livy/repl/ReplDriverSuite.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/ReplDriverSuite.scala
@@ -58,7 +58,7 @@ class ReplDriverSuite extends FunSuite {
 
       val statementId = client.submitReplCode("1 + 1")
       eventually(timeout(30 seconds), interval(100 millis)) {
-        val rawResult = client.getReplJobResult(statementId).get(1, TimeUnit.SECONDS)
+        val rawResult = client.getReplJobResult(statementId).get(10, TimeUnit.SECONDS)
         val result = parse(rawResult)
         assert((result \ Session.STATUS).extract[String] === Session.OK)
       }

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
@@ -37,7 +37,7 @@ import org.json4s.JsonAST.{JNull, JString}
 import org.json4s.jackson.JsonMethods._
 
 import com.cloudera.livy._
-import com.cloudera.livy.client.local.{LocalClient, LocalConf}
+import com.cloudera.livy.client.local.{LocalClient, LocalConf, PingJob}
 import com.cloudera.livy.sessions._
 import com.cloudera.livy.utils.SparkProcessBuilder
 import com.cloudera.livy.Utils
@@ -121,8 +121,23 @@ class InteractiveSession(
     builder.build()
   }.asInstanceOf[LocalClient]
 
-  // Client is ready to receive commands now.
-  _state = SessionState.Idle()
+  // Send a dummy job that will return once the client is ready to be used, and set the
+  // state to "idle" at that point.
+  client.submit(new PingJob()).addListener(new JobHandle.Listener[Void]() {
+    override def onJobQueued(job: JobHandle[Void]): Unit = { }
+    override def onJobStarted(job: JobHandle[Void]): Unit = { }
+    override def onJobCancelled(job: JobHandle[Void]): Unit = { }
+    override def onSparkJobStarted(job: JobHandle[Void], jobId: Int): Unit = { }
+
+    override def onJobFailed(job: JobHandle[Void], cause: Throwable): Unit = {
+      transition(SessionState.Error())
+      stop()
+    }
+
+    override def onJobSucceeded(job: JobHandle[Void], result: Void): Unit = {
+      transition(SessionState.Idle())
+    }
+  })
 
   private[this] var _executedStatements = 0
   private[this] var _statements = IndexedSeq[Statement]()
@@ -133,9 +148,9 @@ class InteractiveSession(
 
   override def stop(): Future[Unit] = {
     Future {
-      _state = SessionState.ShuttingDown()
+      transition(SessionState.ShuttingDown())
       client.stop(true)
-      _state = SessionState.Dead()
+      transition(SessionState.Dead())
     }
   }
 


### PR DESCRIPTION
Because of how Spark's REPL deals with class loaders, it's necessary to
poke inside of it to make jars distributed by Livy be seen. This fix is
the same as in the patch below:
  https://github.com/hdinsight/livy/commit/f11cdcb5357046fe555a4ee53c85fb1bccf646b5

Aside from that, the REPL sessions were reporting "idle" state too early.
I had to shuffle a little bit of code around so that the REPL can execute
basic RSC commands, so that the client side can know when it's safe to
send commands. This is a little bit hacky at the moment until we can spend
more time working on LIVY-93.

Finally, I included some changes to propagate jacoco configuration to child
processes, so that we can run code coverage analysis when we run the RSC
driver in a child process too.