### PR TITLE
LIVY-101. Remove message about unsupported Spark versions.

### DIFF
--- a/dev/spark/bin/spark-submit
+++ b/dev/spark/bin/spark-submit
@@ -55,5 +55,9 @@ if [ -n "$PROP_FILE" ]; then
   fi
 fi
 
+if [ -n "$LIVY_TEST_CLASSPATH" ]; then
+  DRIVER_CP="$DRIVER_CP:$LIVY_TEST_CLASSPATH"
+fi
+
 echo "Running Spark: " $JAVA_HOME/bin/java $DRIVER_OPTS org.apache.spark.deploy.SparkSubmit "$@" >&2
 exec $JAVA_HOME/bin/java $DRIVER_OPTS -cp "$DRIVER_CP" org.apache.spark.deploy.SparkSubmit "$@"

--- a/server/src/test/scala/com/cloudera/livy/server/MainSuite.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/MainSuite.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.server
+
+import org.scalatest.FunSuite
+
+import com.cloudera.livy.LivyConf
+
+class MainSuite extends FunSuite {
+
+  private val livyConf = new LivyConf()
+
+  test("check for SPARK_HOME") {
+    Main.testSparkHome(livyConf)
+  }
+
+  test("check spark-submit version") {
+    Main.testSparkSubmit(livyConf)
+  }
+
+}


### PR DESCRIPTION
We've actually tested on 1.6; instead of a white list, let's just
print the found Spark version in the code. Also added a couple of
small tests just to exercise that code during the build.