### PR TITLE
LIVY-102. Set the config to dispose of the yarn-cluster launcher.

### DIFF
--- a/client-local/src/main/java/com/cloudera/livy/client/local/ContextLauncher.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/ContextLauncher.java
@@ -180,6 +180,10 @@ class ContextLauncher implements ContextInfo {
     // connections for the same registered app.
     conf.set("spark.yarn.maxAppAttempts", "1");
 
+    // Let the launcher go away when launcher in yarn cluster mode. This avoids keeping lots
+    // of "small" Java processes lingering on the Livy server node.
+    conf.set("spark.yarn.submit.waitAppCompletion", "false");
+
     // For testing; propagate jacoco settings so that we also do coverage analysis
     // on the launched driver. We replace the name of the main file ("main.exec")
     // so that we don't end up fighting with the main test launcher.


### PR DESCRIPTION
This saves resources on the Livy server by not keeping the launcher
process around; Livy is already connected to the driver so it knows
how to monitor its status.