### PR TITLE
LIVY-107. Add config blacklist file.

### DIFF
--- a/conf/spark-blacklist.properties
+++ b/conf/spark-blacklist.properties
@@ -1,0 +1,11 @@
+#
+# Configuration override / blacklist. Defines a list of properties that users are not allowed
+# to override when starting Spark sessions.
+#
+# This file takes a list of property names (one per line). Empty lines and lines starting with "#"
+# are ignored.
+#
+
+# Disallow overriding the master and the deploy mode.
+spark.master
+spark.submit.deployMode

--- a/core/src/main/scala/com/cloudera/livy/Utils.scala
+++ b/core/src/main/scala/com/cloudera/livy/Utils.scala
@@ -19,6 +19,8 @@
 package com.cloudera.livy
 
 import java.io.{Closeable, File, FileInputStream, InputStreamReader}
+import java.net.URL
+import java.nio.charset.StandardCharsets.UTF_8
 import java.util.Properties
 
 import scala.annotation.tailrec
@@ -28,7 +30,11 @@ import scala.concurrent.duration.Duration
 
 object Utils {
   def getPropertiesFromFile(file: File): Map[String, String] = {
-    val inReader = new InputStreamReader(new FileInputStream(file), "UTF-8")
+    loadProperties(file.toURL())
+  }
+
+  def loadProperties(url: URL): Map[String, String] = {
+    val inReader = new InputStreamReader(url.openStream(), UTF_8)
     try {
       val properties = new Properties()
       properties.load(inReader)

--- a/server/src/main/scala/com/cloudera/livy/server/batch/BatchSessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/batch/BatchSessionServlet.scala
@@ -31,6 +31,7 @@ class BatchSessionServlet(livyConf: LivyConf)
 
   override protected def createSession(req: HttpServletRequest): BatchSession = {
     val createRequest = bodyAs[CreateBatchRequest](req)
+    validateConf(createRequest.conf)
     val proxyUser = checkImpersonation(createRequest.proxyUser, req)
     new BatchSession(sessionManager.nextId(), remoteUser(req), proxyUser, livyConf, createRequest)
   }

--- a/server/src/main/scala/com/cloudera/livy/server/client/ClientSessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/client/ClientSessionServlet.scala
@@ -21,6 +21,8 @@ package com.cloudera.livy.server.client
 import java.net.URI
 import javax.servlet.http.HttpServletRequest
 
+import scala.collection.JavaConverters._
+
 import org.scalatra._
 import org.scalatra.servlet.{FileUploadSupport, MultipartConfig}
 
@@ -40,6 +42,7 @@ class ClientSessionServlet(livyConf: LivyConf)
   override protected def createSession(req: HttpServletRequest): ClientSession = {
     val id = sessionManager.nextId()
     val createRequest = bodyAs[CreateClientRequest](req)
+    validateConf(createRequest.conf.asScala.toMap)
     val user = remoteUser(req)
     val requestedProxy =
       if (createRequest.conf != null) {

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSessionServlet.scala
@@ -43,6 +43,7 @@ class InteractiveSessionServlet(livyConf: LivyConf)
 
   override protected def createSession(req: HttpServletRequest): InteractiveSession = {
     val createRequest = bodyAs[CreateInteractiveRequest](req)
+    validateConf(createRequest.conf)
     val proxyUser = checkImpersonation(createRequest.proxyUser, req)
     new InteractiveSession(sessionManager.nextId(), remoteUser(req), proxyUser, livyConf,
       createRequest)

--- a/server/src/test/resources/spark-blacklist.properties
+++ b/server/src/test/resources/spark-blacklist.properties
@@ -1,0 +1,1 @@
+spark.do_not_set

--- a/server/src/test/scala/com/cloudera/livy/server/BaseSessionServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/BaseSessionServletSpec.scala
@@ -36,6 +36,9 @@ abstract class BaseSessionServletSpec[S <: Session]
   extends BaseJsonServletSpec
   with BeforeAndAfterAll {
 
+  /** Config map containing option that is blacklisted. */
+  protected val BLACKLISTED_CONFIG = Map("spark.do_not_set" -> "true")
+
   /** Name of the admin user. */
   protected val ADMIN = "__admin__"
 

--- a/server/src/test/scala/com/cloudera/livy/server/batch/BatchServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/batch/BatchServletSpec.scala
@@ -21,6 +21,7 @@ package com.cloudera.livy.server.batch
 import java.io.FileWriter
 import java.nio.file.{Files, Path}
 import java.util.concurrent.TimeUnit
+import javax.servlet.http.HttpServletResponse._
 
 import scala.concurrent.duration.Duration
 
@@ -98,6 +99,14 @@ class BatchServletSpec extends BaseSessionServletSpec[BatchSession] {
         batch should not be defined
       }
     }
+
+    it("should respect config black list") {
+      val createRequest = new CreateBatchRequest()
+      createRequest.file = script.toString
+      createRequest.conf = BLACKLISTED_CONFIG
+      jpost[Map[String, Any]]("/", createRequest, expectedStatus = SC_BAD_REQUEST) { _ => }
+    }
+
   }
 
 }

--- a/server/src/test/scala/com/cloudera/livy/server/client/ClientServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/client/ClientServletSpec.scala
@@ -181,13 +181,21 @@ class ClientServletSpec
         }
       }
     }
+
+    it("should respect config black list") {
+      jpost[SessionInfo]("/", createRequest(extraConf = BLACKLISTED_CONFIG),
+        expectedStatus = SC_BAD_REQUEST) { _ => }
+    }
+
   }
 
   private def deleteSession(id: Int): Unit = {
     jdelete[Map[String, Any]](s"/$id", headers = adminHeaders) { _ => }
   }
 
-  private def createRequest(inProcess: Boolean = true): CreateClientRequest = {
+  private def createRequest(
+      inProcess: Boolean = true,
+      extraConf: Map[String, String] = Map()): CreateClientRequest = {
     val classpath = sys.props("java.class.path")
     val conf = new HashMap[String, String]
     conf.put("spark.master", "local")
@@ -197,6 +205,7 @@ class ClientServletSpec
     if (inProcess) {
       conf.put(LocalConf.Entry.CLIENT_IN_PROCESS.key(), "true")
     }
+    extraConf.foreach { case (k, v) => conf.put(k, v) }
     new CreateClientRequest(10000L, conf)
   }
 


### PR DESCRIPTION
This file lists Spark (and Livy) settings that cannot be set by users,
to avoid security issues (and possibly other runtime issues). For example,
Livy can only start sessions really securely in YARN cluster mode, so admins
should blacklist options that would allow users to override that.