### PR TITLE
The README file doesn't reflect the actual endpoint implemented to GE…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -485,7 +485,7 @@ Response Body
 +---------+---------------+------+
 | name    | description   | type |
 +=========+===============+======+
-| batches | `batch`_ list | list |
+|sessions | `batch`_ list | list |
 +---------+---------------+------+
 
 
@@ -572,7 +572,7 @@ DELETE /batches/{batchId}
 Kill the `Batch`_ job.
 
 
-GET /batches/{batchId}/logs
+GET /batches/{batchId}/log
 ---------------------------
 
 Get the log lines from this batch.


### PR DESCRIPTION
…T the Batch Logs as well as the response to GET all Batches.

The current documentation has the following mistakes:
1. Points to `GET /batches/{batchId}/logs` when in fact is `GET /batches/{batchId}/log`.
2. The `GET /batches` refers to a response that contains `batches` when in fact returns `sessions`.