### PR TITLE
LIVY-115. Allow Livy to be run from the build directory.

### DIFF
--- a/client-local/src/main/java/com/cloudera/livy/client/local/ContextLauncher.java
+++ b/client-local/src/main/java/com/cloudera/livy/client/local/ContextLauncher.java
@@ -162,6 +162,9 @@ class ContextLauncher implements ContextInfo {
       Preconditions.checkState(livyHome != null,
         "Need one of LIVY_HOME or %s set.", LIVY_JARS.key());
       File clientJars = new File(livyHome, "client-jars");
+      if (!clientJars.isDirectory()) {
+        clientJars = new File(livyHome, "client-local/target/jars");
+      }
       Preconditions.checkState(clientJars.isDirectory(),
         "Cannot find 'client-jars' directory under LIVY_HOME.");
       List<String> jars = new ArrayList<>();

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
@@ -213,7 +213,7 @@ class InteractiveSession(
       val home = sys.env("LIVY_HOME")
       val jars = Option(new File(home, "repl-jars"))
         .filter(_.isDirectory())
-        .getOrElse(new File(home, "com/cloudera/livy/repl/target/jars"))
+        .getOrElse(new File(home, "repl/target/jars"))
       require(jars.isDirectory(), "Cannot find Livy REPL jars.")
       jars.listFiles().map(_.getAbsolutePath()).toList
     }


### PR DESCRIPTION
Add extra code so that jar files that need to be added to Spark
apps can be retrieved from the build directories when not found
in the expected location.