### PR TITLE
LIVY-119. Move LivyConf to the server module.

### DIFF
--- a/client-common/src/main/java/com/cloudera/livy/client/common/ClientConf.java
+++ b/client-common/src/main/java/com/cloudera/livy/client/common/ClientConf.java
@@ -52,6 +52,8 @@ public abstract class ClientConf<T extends ClientConf>
 
   private static final Map<String, TimeUnit> TIME_SUFFIXES;
 
+  public static final boolean TEST_MODE = Boolean.parseBoolean(System.getenv("livy.test"));
+
   static {
     TIME_SUFFIXES = new HashMap<>();
     TIME_SUFFIXES.put("us", TimeUnit.MICROSECONDS);

--- a/core/src/main/scala/com/cloudera/livy/Utils.scala
+++ b/core/src/main/scala/com/cloudera/livy/Utils.scala
@@ -46,17 +46,6 @@ object Utils {
     }
   }
 
-  def getLivyConfDir(env: Map[String, String] = sys.env): Option[File] = {
-    env.get("LIVY_CONF_DIR")
-      .orElse(env.get("LIVY_HOME").map(path => s"$path${File.separator}conf"))
-      .map(new File(_))
-      .filter(_.exists())
-  }
-
-  def getLivyConfigFile(name: String): Option[File] = {
-    getLivyConfDir().map(new File(_, name)).filter(_.exists())
-  }
-
   /**
    * Checks if event has occurred during some time period. This performs an exponential backoff
    * to limit the poll calls.

--- a/repl/src/main/scala/com/cloudera/livy/repl/python/PythonInterpreter.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/python/PythonInterpreter.scala
@@ -32,7 +32,7 @@ import org.json4s.jackson.JsonMethods._
 import org.json4s.jackson.Serialization.write
 import py4j.GatewayServer
 
-import com.cloudera.livy.LivyConf
+import com.cloudera.livy.client.common.ClientConf
 import com.cloudera.livy.repl.Interpreter
 import com.cloudera.livy.repl.process.ProcessInterpreter
 
@@ -50,8 +50,8 @@ object PythonInterpreter extends Logging {
 
     val pythonPath = sys.env.getOrElse("PYTHONPATH", "")
       .split(File.pathSeparator)
-      .++(if (!LivyConf.TEST_MODE) findPySparkArchives() else Nil)
-      .++(if (!LivyConf.TEST_MODE) findPyFiles() else Nil)
+      .++(if (!ClientConf.TEST_MODE) findPySparkArchives() else Nil)
+      .++(if (!ClientConf.TEST_MODE) findPyFiles() else Nil)
 
     env.put("PYTHONPATH", pythonPath.mkString(File.pathSeparator))
     env.put("PYTHONUNBUFFERED", "YES")

--- a/repl/src/main/scala/com/cloudera/livy/repl/sparkr/SparkRInterpreter.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/sparkr/SparkRInterpreter.scala
@@ -33,7 +33,7 @@ import org.apache.spark.util.{ChildFirstURLClassLoader, MutableURLClassLoader, U
 import org.json4s._
 import org.json4s.JsonDSL._
 
-import com.cloudera.livy.LivyConf
+import com.cloudera.livy.client.common.ClientConf
 import com.cloudera.livy.repl
 import com.cloudera.livy.repl.Interpreter
 import com.cloudera.livy.repl.process.ProcessInterpreter
@@ -98,7 +98,7 @@ object SparkRInterpreter {
         // local mode
         val rLibPath = new File(sys.env.getOrElse("SPARKR_PACKAGE_DIR",
           Seq(sys.env.getOrElse("SPARK_HOME", "."), "R", "lib").mkString(File.separator)))
-        if (!LivyConf.TEST_MODE) {
+        if (!ClientConf.TEST_MODE) {
           require(rLibPath.exists(), "Cannot find sparkr package directory.")
           packageDir = rLibPath.getAbsolutePath()
         }
@@ -139,7 +139,7 @@ class SparkRInterpreter(process: Process)
   final override protected def waitUntilReady(): Unit = {
     // Set the option to catch and ignore errors instead of halting.
     sendRequest("options(error = dump.frames)")
-    if (!LivyConf.TEST_MODE) {
+    if (!ClientConf.TEST_MODE) {
       sendRequest("library(SparkR)")
       sendRequest("sc <- sparkR.init()")
     }


### PR DESCRIPTION
The core module is small and, after some other adjustments to dependencies,
can probably be removed. LivyConf is only used in the server module (except
for a single static field, now moved to ClientConf), so move it there.