### PR TITLE
LIVY-127. Add integration tests for the public job API.

### DIFF
--- a/api/src/main/java/com/cloudera/livy/LivyClientBuilder.java
+++ b/api/src/main/java/com/cloudera/livy/LivyClientBuilder.java
@@ -26,8 +26,6 @@ import java.net.URL;
 import java.util.Map;
 import java.util.Properties;
 import java.util.ServiceLoader;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
@@ -36,8 +34,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public final class LivyClientBuilder {
 
   public static final String LIVY_URI_KEY = "livy.uri";
-
-  private static final Logger LOG = Logger.getLogger(LivyClientBuilder.class.getName());
 
   private final Properties config;
 
@@ -127,14 +123,11 @@ public final class LivyClientBuilder {
       try {
         client = factory.createClient(uri, config);
       } catch (Exception e) {
-        // Keep the first error and re-throw it if no factories support the URI.
-        if (error == null) {
-          error = e;
+        if (!(e instanceof RuntimeException)) {
+          e = new RuntimeException(e);
         }
-        LOG.log(Level.WARNING,
-          String.format("Factory %s threw an exception.", factory.getClass().getName()), e);
+        throw (RuntimeException) e;
       }
-
       if (client != null) {
         break;
       }
@@ -154,7 +147,7 @@ public final class LivyClientBuilder {
       }
 
       throw new IllegalArgumentException(String.format(
-        "URI '%s' is not supported by any registered client factories.", uri), error);
+        "URI '%s' is not supported by any registered client factories.", uri));
     }
     return client;
   }

--- a/api/src/test/java/com/cloudera/livy/TestLivyClientBuilder.java
+++ b/api/src/test/java/com/cloudera/livy/TestLivyClientBuilder.java
@@ -55,14 +55,9 @@ public class TestLivyClientBuilder {
     assertNull(new LivyClientBuilder(false).setURI(new URI("mismatch")).build());
   }
 
-  @Test
+  @Test(expected=IllegalStateException.class)
   public void testFactoryError() throws Exception {
-    try {
-      assertNull(new LivyClientBuilder(false).setURI(new URI("error")).build());
-    } catch (IllegalArgumentException e) {
-      assertNotNull(e.getCause());
-      assertTrue(e.getCause() instanceof IllegalStateException);
-    }
+    new LivyClientBuilder(false).setURI(new URI("error")).build();
   }
 
   @Test

--- a/client-common/src/main/java/com/cloudera/livy/client/common/HttpMessages.java
+++ b/client-common/src/main/java/com/cloudera/livy/client/common/HttpMessages.java
@@ -39,16 +39,14 @@ public class HttpMessages {
 
   public static class CreateClientRequest implements ClientMessage {
 
-    public final long timeout;
     public final Map<String, String> conf;
 
-    public CreateClientRequest(long timeout, Map<String, String> conf) {
-      this.timeout = timeout;
+    public CreateClientRequest(Map<String, String> conf) {
       this.conf = conf;
     }
 
     private CreateClientRequest() {
-      this(-1, null);
+      this(null);
     }
 
   }

--- a/client-http/src/main/java/com/cloudera/livy/client/http/HttpClient.java
+++ b/client-http/src/main/java/com/cloudera/livy/client/http/HttpClient.java
@@ -72,14 +72,12 @@ class HttpClient implements LivyClient {
         this.sessionId = Integer.parseInt(m.group(2));
         conn.post(null, SessionInfo.class, "/%d/connect", sessionId);
       } else {
-
-        long timeout = config.getTimeAsMs(SESSION_CREATE_TIMEOUT);
         Map<String, String> sessionConf = new HashMap<>();
         for (Map.Entry<String, String> e : config) {
           sessionConf.put(e.getKey(), e.getValue());
         }
 
-        ClientMessage create = new CreateClientRequest(timeout, sessionConf);
+        ClientMessage create = new CreateClientRequest(sessionConf);
         this.conn = new LivyConnection(uri, httpConf);
         this.sessionId = conn.post(create, SessionInfo.class, "/").id;
       }

--- a/client-http/src/main/java/com/cloudera/livy/client/http/HttpConf.java
+++ b/client-http/src/main/java/com/cloudera/livy/client/http/HttpConf.java
@@ -30,9 +30,7 @@ class HttpConf extends ClientConf<HttpConf> {
     SOCKET_TIMEOUT("connection.socket.timeout", "5m"),
 
     JOB_INITIAL_POLL_INTERVAL("job.initial_poll_interval", "100ms"),
-    JOB_MAX_POLL_INTERVAL("job.max_poll_interval", "5s"),
-
-    SESSION_CREATE_TIMEOUT("session.create.timeout", "1m");
+    JOB_MAX_POLL_INTERVAL("job.max_poll_interval", "5s");
 
     private final String key;
     private final Object dflt;

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -63,6 +63,20 @@
     </dependency>
 
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>livy-client-http</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>livy-test-lib</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.decodified</groupId>
       <artifactId>scala-ssh_${scala.binary.version}</artifactId>
       <version>0.7.0</version>

--- a/integration-test/src/test/scala/com/cloudera/livy/test/JobApiIT.scala
+++ b/integration-test/src/test/scala/com/cloudera/livy/test/JobApiIT.scala
@@ -1,0 +1,168 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.test
+
+import java.io.File
+import java.net.URI
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.Files
+import java.util.concurrent.{Future => JFuture, TimeUnit}
+import javax.servlet.http.HttpServletResponse
+
+import scala.util.Try
+
+import org.scalatest.BeforeAndAfterAll
+
+import com.cloudera.livy.{LivyClient, LivyClientBuilder}
+import com.cloudera.livy.client.common.HttpMessages._
+import com.cloudera.livy.sessions.SessionState
+import com.cloudera.livy.test.framework.BaseIntegrationTestSuite
+import com.cloudera.livy.test.jobs._
+
+// Proper type representing the return value of "GET /sessions". At some point we should make
+// SessionServlet use something like this.
+private class SessionList {
+  val from: Int = -1
+  val total: Int = -1
+  val sessions: List[SessionInfo] = Nil
+}
+
+class JobApiIT extends BaseIntegrationTestSuite with BeforeAndAfterAll {
+
+  private var client: LivyClient = _
+  private var sessionId: Int = _
+  private var client2: LivyClient = _
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    Seq(client, client2).foreach { c =>
+      if (c != null) {
+        c.stop(true)
+      }
+    }
+
+    livyClient.stopSession(sessionId)
+  }
+
+  test("create a new session") {
+    client = createClient(livyEndpoint)
+
+    // Figure out the session ID by poking at the REST endpoint. We should probably expose this
+    // in the Java API.
+    val list = sessionList()
+    assert(list.total === 1)
+    sessionId = list.sessions(0).id
+
+    waitTillSessionIdle(sessionId)
+  }
+
+  test("upload jar") {
+    assume(client != null, "Client not active.")
+
+    val testLib = sys.props("java.class.path")
+      .split(File.pathSeparator)
+      .find(new File(_).getName().startsWith("livy-test-lib-"))
+      .get
+
+    waitFor(client.uploadJar(new File(testLib)))
+  }
+
+  test("upload file") {
+    assume(client != null, "Client not active.")
+
+    val file = Files.createTempFile("filetest", ".txt")
+    Files.write(file, "hello".getBytes(UTF_8))
+
+    waitFor(client.uploadFile(file.toFile()))
+
+    val result = waitFor(client.submit(new FileReader(file.toFile().getName(), false)))
+    assert(result === "hello")
+  }
+
+  test("run simple jobs") {
+    assume(client != null, "Client not active.")
+
+    val result = waitFor(client.submit(new Echo("hello")))
+    assert(result === "hello")
+
+    val result2 = waitFor(client.run(new Echo("hello")))
+    assert(result2 === "hello")
+  }
+
+  test("run spark job") {
+    assume(client != null, "Client not active.")
+    val result = waitFor(client.submit(new SmallCount(100)));
+    assert(result === 100)
+  }
+
+  test("run spark sql job") {
+    assume(client != null, "Client not active.")
+    val result = waitFor(client.submit(new SQLGetTweets(false)));
+    assert(result.size() > 0)
+  }
+
+  test("stop a client without destroying the session") {
+    assume(client != null, "Client not active.")
+    client.stop(false)
+    client = null
+  }
+
+  test("connect to an existing session") {
+    assert(livyClient.getSessionStatus(sessionId) === SessionState.Idle().toString)
+    val sessionUri = s"$livyEndpoint/sessions/$sessionId"
+    client2 = createClient(sessionUri)
+  }
+
+  test("submit job using new client") {
+    assume(client2 != null, "Client not active.")
+    val result = waitFor(client2.submit(new Echo("hello")))
+    assert(result === "hello")
+  }
+
+  test("destroy the session") {
+    assume(client2 != null, "Client not active.")
+    client2.stop(true)
+
+    val list = sessionList()
+    assert(list.total === 0)
+
+    val sessionUri = s"$livyEndpoint/sessions/$sessionId"
+    Try(createClient(sessionUri)).foreach { client =>
+      client.stop(true)
+      fail("Should not have been able to connect to destroyed session.")
+    }
+
+    sessionId = -1
+  }
+
+  private def waitFor[T](future: JFuture[T]): T = {
+    future.get(30, TimeUnit.SECONDS)
+  }
+
+  private def sessionList(): SessionList = {
+    val response = httpClient.prepareGet(s"$livyEndpoint/sessions/").execute().get()
+    assert(response.getStatusCode === HttpServletResponse.SC_OK)
+    mapper.readValue(response.getResponseBodyAsStream, classOf[SessionList])
+  }
+
+  private def createClient(uri: String): LivyClient = {
+    new LivyClientBuilder().setURI(new URI(uri)).build()
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,6 @@
     <scala.version>2.10.4</scala.version>
     <scalatest.version>2.2.4</scalatest.version>
     <scalatra.version>2.3.0</scalatra.version>
-    <snappy-java.version>1.1.1.6</snappy-java.version>
     <java.version>1.7</java.version>
     <minJavaVersion>1.7</minJavaVersion>
     <maxJavaVersion>1.8</maxJavaVersion>
@@ -509,12 +508,6 @@
         <groupId>org.scalatra</groupId>
         <artifactId>scalatra-test_${scala.binary.version}</artifactId>
         <version>${scalatra.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.xerial.snappy</groupId>
-        <artifactId>snappy-java</artifactId>
-        <version>${snappy-java.version}</version>
       </dependency>
 
       <dependency>

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -144,12 +144,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.xerial.snappy</groupId>
-            <artifactId>snappy-java</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>net.sf.py4j</groupId>
             <artifactId>py4j</artifactId>
             <scope>provided</scope>

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/CreateInteractiveRequest.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/CreateInteractiveRequest.scala
@@ -18,11 +18,11 @@
 
 package com.cloudera.livy.server.interactive
 
-import com.cloudera.livy.sessions.Kind
+import com.cloudera.livy.sessions.{Kind, Spark}
 
 class CreateInteractiveRequest {
 
-  var kind: Kind = _
+  var kind: Kind = Spark()
   var proxyUser: Option[String] = None
   var jars: List[String] = List()
   var pyFiles: List[String] = List()

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
@@ -72,10 +72,10 @@ class InteractiveSession(
     val builder = new LivyClientBuilder()
       .setConf("spark.app.name", s"livy-session-$id")
       .setConf("spark.master", "yarn-cluster")
-      .setURI(new URI("local:spark"))
       .setAll(Option(request.conf).map(_.asJava).getOrElse(new JHashMap()))
       .setConf("livy.client.sessionId", id.toString)
       .setConf(RSCConf.Entry.DRIVER_CLASS.key(), "com.cloudera.livy.repl.ReplDriver")
+      .setURI(new URI("local:spark"))
 
     kind match {
       case PySpark() =>
@@ -294,14 +294,6 @@ class InteractiveSession(
 
   private def transition(state: SessionState) = synchronized {
     _state = state
-  }
-
-  private def ensureState[A](state: SessionState, f: => A) = synchronized {
-    if (_state == state) {
-      f
-    } else {
-      throw new IllegalStateException("Session is in state %s" format _state)
-    }
   }
 
   private def ensureRunning(): Unit = synchronized {


### PR DESCRIPTION
A few changes in other areas were made:

- Always overwrite the URI used to create the RSC in InteractiveSession,
  otherwise things fail.
- Removed the "timeout" from the session creation structure, because the
  existing interactive session API doesn't have it. We'll add it back
  somehow (probably as a configuration stuck in the "conf" map).
- Removed the logging from LivyClientBuilder and just let exceptions from
  the factories propagate; this removes the logging dependency, which also
  avoids having to install the jul-to-slf4j bridge to avoid ugly log messages
  in test output. As a bonus, it makes the exceptions from the builder less
  cryptic.
- Renamed a few classes and methods to make things cleaner and also to avoid
  a naming clash.
- Removed some dead code and dependencies.