### PR TITLE
LIVY-81. Monitor start of remote context asynchronously.

### DIFF
--- a/api/src/main/java/com/cloudera/livy/JobHandle.java
+++ b/api/src/main/java/com/cloudera/livy/JobHandle.java
@@ -56,6 +56,11 @@ public interface JobHandle<T> extends Future<T> {
    */
   static interface Listener<T> {
 
+    /**
+     * Notifies when a job has been queued for execution on the remote context. Note that it is
+     * possible for jobs to bypass this state and got directly from the SENT state to the STARTED
+     * state.
+     */
     void onJobQueued(JobHandle<T> job);
 
     void onJobStarted(JobHandle<T> job);

--- a/rsc/src/main/java/com/cloudera/livy/rsc/FutureListener.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/FutureListener.java
@@ -17,21 +17,11 @@
 
 package com.cloudera.livy.rsc;
 
-/**
- * Information about a running RSC instance.
- */
-class ContextInfo {
+/** A simplified future listener for netty futures. See Utils.addListener(). */
+public abstract class FutureListener<T> {
 
-  final String remoteAddress;
-  final int remotePort;
-  final String clientId;
-  final String secret;
+  public void onSuccess(T result) throws Exception { }
 
-  ContextInfo(String remoteAddress, int remotePort, String clientId, String secret) {
-    this.remoteAddress = remoteAddress;
-    this.remotePort = remotePort;
-    this.clientId = clientId;
-    this.secret = secret;
-  }
+  public void onFailure(Throwable error) throws Exception { }
 
 }

--- a/rsc/src/main/java/com/cloudera/livy/rsc/RSCClient.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/RSCClient.java
@@ -25,11 +25,15 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,51 +50,124 @@ import static com.cloudera.livy.rsc.RSCConf.Entry.*;
 
 public class RSCClient implements LivyClient {
   private static final Logger LOG = LoggerFactory.getLogger(RSCClient.class);
+  private static final AtomicInteger EXECUTOR_GROUP_ID = new AtomicInteger();
 
-  private final ContextInfo ctx;
-  private final RSCClientFactory factory;
   private final RSCConf conf;
   private final Map<String, JobHandleImpl<?>> jobs;
-  public final Rpc driverRpc;
   private final ClientProtocol protocol;
+  private final Promise<Rpc> driverRpc;
+  private final int executorGroupId;
   private final EventLoopGroup eventLoopGroup;
+
+  private ContextInfo contextInfo;
   private volatile boolean isAlive;
 
-  RSCClient(RSCClientFactory factory, RSCConf conf, ContextInfo ctx) throws IOException {
-    this.ctx = ctx;
-    this.factory = factory;
+  RSCClient(RSCConf conf, Promise<ContextInfo> ctx) throws IOException {
     this.conf = conf;
     this.jobs = new ConcurrentHashMap<>();
     this.protocol = new ClientProtocol();
+    this.driverRpc = ImmediateEventExecutor.INSTANCE.newPromise();
+    this.executorGroupId = EXECUTOR_GROUP_ID.incrementAndGet();
     this.eventLoopGroup = new NioEventLoopGroup(
         conf.getInt(RPC_MAX_THREADS),
-        Utils.newDaemonThreadFactory("Client-RPC-Handler-" + ctx.getClientId() + "-%d"));
+        Utils.newDaemonThreadFactory("RSCClient-" + executorGroupId + "-%d"));
 
-    try {
-      this.driverRpc = Rpc.createClient(conf,
-        eventLoopGroup,
-        ctx.getRemoteAddress(),
-        ctx.getRemotePort(),
-        ctx.getClientId(),
-        ctx.getSecret(),
-        protocol).get();
-    } catch (Throwable e) {
-      ctx.dispose(true);
-      throw Utils.propagate(e);
-    }
+    Utils.addListener(ctx, new FutureListener<ContextInfo>() {
+      @Override
+      public void onSuccess(ContextInfo info) throws Exception {
+        connectToContext(info);
+      }
 
-    driverRpc.addListener(new Rpc.Listener() {
-        @Override
-        public void rpcClosed(Rpc rpc) {
-          if (isAlive) {
-            LOG.warn("Client RPC channel closed unexpectedly.");
-            isAlive = false;
-          }
-        }
+      @Override
+      public void onFailure(Throwable error) {
+        connectionError(error);
+      }
     });
 
     isAlive = true;
-    LOG.debug("Connected to context {} ({}).", ctx.getClientId(), driverRpc.getChannel());
+  }
+
+  private synchronized void connectToContext(final ContextInfo info) throws Exception {
+    this.contextInfo = info;
+
+    try {
+      Promise<Rpc> promise = Rpc.createClient(conf,
+        eventLoopGroup,
+        info.remoteAddress,
+        info.remotePort,
+        info.clientId,
+        info.secret,
+        protocol);
+      Utils.addListener(promise, new FutureListener<Rpc>() {
+        @Override
+        public void onSuccess(Rpc rpc) throws Exception {
+          driverRpc.setSuccess(rpc);
+          Utils.addListener(rpc.getChannel().closeFuture(), new FutureListener<Void>() {
+            @Override
+            public void onSuccess(Void unused) {
+              if (isAlive) {
+                LOG.warn("Client RPC channel closed unexpectedly.");
+                isAlive = false;
+              }
+            }
+          });
+          LOG.debug("Connected to context {} ({}, {}).", info.clientId,
+            rpc.getChannel(), executorGroupId);
+        }
+
+        @Override
+        public void onFailure(Throwable error) throws Exception {
+          driverRpc.setFailure(error);
+          connectionError(error);
+        }
+      });
+    } catch (Exception e) {
+      connectionError(e);
+    }
+  }
+
+  private void connectionError(Throwable error) {
+    LOG.error("Failed to connect to context.", error);
+    stop(false);
+  }
+
+  private <T> io.netty.util.concurrent.Future<T> deferredCall(final Object msg,
+      final Class<T> retType) {
+    if (driverRpc.isSuccess()) {
+      try {
+        return driverRpc.get().call(msg, retType);
+      } catch (Exception ie) {
+        throw Utils.propagate(ie);
+      }
+    }
+
+    // No driver RPC yet, so install a listener and return a promise that will be ready when
+    // the driver is up and the message is actually delivered.
+    final Promise<T> promise = eventLoopGroup.next().newPromise();
+    final FutureListener<T> callListener = new FutureListener<T>() {
+      @Override
+      public void onSuccess(T value) throws Exception {
+        promise.setSuccess(value);
+      }
+
+      @Override
+      public void onFailure(Throwable error) throws Exception {
+        promise.setFailure(error);
+      }
+    };
+
+    Utils.addListener(driverRpc, new FutureListener<Rpc>() {
+      @Override
+      public void onSuccess(Rpc rpc) throws Exception {
+        Utils.addListener(rpc.call(msg, retType), callListener);
+      }
+
+      @Override
+      public void onFailure(Throwable error) throws Exception {
+        promise.setFailure(error);
+      }
+    });
+    return promise;
   }
 
   @Override
@@ -108,18 +185,40 @@ public class RSCClient implements LivyClient {
     if (isAlive) {
       isAlive = false;
       try {
-        if (shutdownContext) {
+        if (shutdownContext && driverRpc.isSuccess()) {
           protocol.endSession();
-          ctx.dispose(false);
+
+          // Because the remote context won't really reply to the end session message -
+          // since it closes the channel while handling it, we wait for the RPC's channel
+          // to close instead.
+          long stopTimeout = conf.getTimeAsMs(CLIENT_SHUTDOWN_TIMEOUT);
+          try {
+            driverRpc.get().getChannel().closeFuture().get(stopTimeout,
+              TimeUnit.MILLISECONDS);
+          } catch (Exception e) {
+            LOG.warn("Error waiting for context to shut down: {} ({}).",
+              e.getClass().getSimpleName(), e.getMessage());
+          }
         }
       } catch (Exception e) {
         LOG.warn("Exception while waiting for end session reply.", e);
-        ctx.dispose(true);
       } finally {
-        driverRpc.close();
+        if (driverRpc.isSuccess()) {
+          try {
+            driverRpc.get().close();
+          } catch (Exception e) {
+            LOG.warn("Error stopping RPC.", e);
+          }
+        }
+
+        // Report failure for all pending jobs, so that clients can react.
+        for (JobHandleImpl<?> job : jobs.values()) {
+          job.setFailure(new IOException("RSCClient instance stopped."));
+        }
+
         eventLoopGroup.shutdownGracefully();
       }
-      LOG.debug("Disconnected from context {}, shutdown = {}.", ctx.getClientId(),
+      LOG.debug("Disconnected from context {}, shutdown = {}.", contextInfo.clientId,
         shutdownContext);
     }
   }
@@ -157,21 +256,21 @@ public class RSCClient implements LivyClient {
   }
 
   ContextInfo getContextInfo() {
-    return ctx;
+    return contextInfo;
   }
 
   public String submitReplCode(String code) throws Exception {
     String id = UUID.randomUUID().toString();
-    driverRpc.call(new BaseProtocol.ReplJobRequest(code, id));
+    deferredCall(new BaseProtocol.ReplJobRequest(code, id), Void.class);
     return id;
   }
 
   public Future<String> getReplJobResult(String id) throws Exception {
-    return driverRpc.call(new BaseProtocol.GetReplJobResult(id), String.class);
+    return deferredCall(new BaseProtocol.GetReplJobResult(id), String.class);
   }
 
   public Future<String> getReplState() {
-    return driverRpc.call(new BaseProtocol.GetReplState(), String.class);
+    return deferredCall(new BaseProtocol.GetReplState(), String.class);
   }
 
   private class ClientProtocol extends BaseProtocol {
@@ -180,24 +279,24 @@ public class RSCClient implements LivyClient {
       final String jobId = UUID.randomUUID().toString();
       Object msg = new JobRequest<T>(jobId, job);
 
-      final Promise<T> promise = driverRpc.createPromise();
+      final Promise<T> promise = eventLoopGroup.next().newPromise();
       final JobHandleImpl<T> handle = new JobHandleImpl<T>(RSCClient.this,
         promise, jobId);
       jobs.put(jobId, handle);
 
-      final io.netty.util.concurrent.Future<Void> rpc = driverRpc.call(msg);
-      LOG.debug("Send JobRequest[{}].", jobId);
+      final io.netty.util.concurrent.Future<Void> rpc = deferredCall(msg, Void.class);
+      LOG.debug("Sending JobRequest[{}].", jobId);
 
-      // Link the RPC and the promise so that events from one are propagated to the other as
-      // needed.
-      rpc.addListener(new GenericFutureListener<io.netty.util.concurrent.Future<Void>>() {
+      Utils.addListener(rpc, new FutureListener<Void>() {
         @Override
-        public void operationComplete(io.netty.util.concurrent.Future<Void> f) {
-          if (f.isSuccess()) {
-            handle.changeState(JobHandle.State.QUEUED);
-          } else if (!promise.isDone()) {
-            promise.setFailure(f.cause());
-          }
+        public void onSuccess(Void unused) throws Exception {
+          handle.changeState(JobHandle.State.QUEUED);
+        }
+
+        @Override
+        public void onFailure(Throwable error) throws Exception {
+          error.printStackTrace();
+          promise.tryFailure(error);
         }
       });
       promise.addListener(new GenericFutureListener<Promise<T>>() {
@@ -214,30 +313,28 @@ public class RSCClient implements LivyClient {
       return handle;
     }
 
+    @SuppressWarnings("unchecked")
     <T> Future<T> run(Job<T> job) {
-      @SuppressWarnings("unchecked")
-      final io.netty.util.concurrent.Future<T> rpc = (io.netty.util.concurrent.Future<T>)
-        driverRpc.call(new SyncJobRequest(job), Object.class);
-      return rpc;
+      return (Future<T>) deferredCall(new SyncJobRequest(job), Object.class);
     }
 
     String bypass(ByteBuffer serializedJob, boolean sync) {
       String jobId = UUID.randomUUID().toString();
       Object msg = new BypassJobRequest(jobId, BufferUtils.toByteArray(serializedJob), sync);
-      driverRpc.call(msg);
+      deferredCall(msg, Void.class);
       return jobId;
     }
 
     Future<BypassJobStatus> getBypassJobStatus(String id) {
-      return driverRpc.call(new GetBypassJobStatus(id), BypassJobStatus.class);
+      return deferredCall(new GetBypassJobStatus(id), BypassJobStatus.class);
     }
 
     void cancel(String jobId) {
-      driverRpc.call(new CancelJob(jobId));
+      deferredCall(new CancelJob(jobId), Void.class);
     }
 
     Future<?> endSession() {
-      return driverRpc.call(new EndSession());
+      return deferredCall(new EndSession(), Void.class);
     }
 
     private void handle(ChannelHandlerContext ctx, InitializationError msg) {

--- a/rsc/src/main/java/com/cloudera/livy/rsc/Utils.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/Utils.java
@@ -20,6 +20,9 @@ package com.cloudera.livy.rsc;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
+
 /**
  * A few simple utility functions used by the code, mostly to avoid a direct dependency
  * on Guava.
@@ -95,6 +98,19 @@ public class Utils {
       sb.append(e.toString());
     }
     return sb.toString();
+  }
+
+  public static <T> void addListener(Future<T> future, final FutureListener<T> lsnr) {
+    future.addListener(new GenericFutureListener<Future<T>>() {
+      @Override
+      public void operationComplete(Future<T> f) throws Exception {
+        if (f.isSuccess()) {
+          lsnr.onSuccess(f.get());
+        } else {
+          lsnr.onFailure(f.cause());
+        }
+      }
+    });
   }
 
   private Utils() { }

--- a/rsc/src/main/java/com/cloudera/livy/rsc/rpc/Rpc.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/rpc/Rpc.java
@@ -215,7 +215,6 @@ public class Rpc implements Closeable {
   private final AtomicBoolean rpcClosed;
   private final AtomicLong rpcId;
   private final Channel channel;
-  private final Collection<Listener> listeners;
   private final EventExecutorGroup egroup;
   private final Object channelLock;
   private volatile RpcDispatcher dispatcher;
@@ -228,7 +227,6 @@ public class Rpc implements Closeable {
     this.channelLock = new Object();
     this.dispatcher = null;
     this.egroup = egroup;
-    this.listeners = new LinkedList<>();
     this.rpcClosed = new AtomicBoolean();
     this.rpcId = new AtomicLong();
 
@@ -239,12 +237,6 @@ public class Rpc implements Closeable {
           close();
         }
     });
-  }
-
-  public void addListener(Listener l) {
-    synchronized (listeners) {
-      listeners.add(l);
-    }
   }
 
   /**
@@ -268,7 +260,7 @@ public class Rpc implements Closeable {
     Utils.checkState(channel.isOpen(), "RPC channel is closed.");
     try {
       final long id = rpcId.getAndIncrement();
-      final Promise<T> promise = createPromise();
+      final Promise<T> promise = egroup.next().newPromise();
       ChannelFutureListener listener = new ChannelFutureListener() {
           @Override
           public void operationComplete(ChannelFuture cf) {
@@ -292,13 +284,6 @@ public class Rpc implements Closeable {
     }
   }
 
-  /**
-   * Creates a promise backed by this RPC's event loop.
-   */
-  public <T> Promise<T> createPromise() {
-    return egroup.next().newPromise();
-  }
-
   public Channel getChannel() {
     return channel;
   }
@@ -319,23 +304,7 @@ public class Rpc implements Closeable {
       channel.close().sync();
     } catch (InterruptedException ie) {
       Thread.interrupted();
-    } finally {
-      synchronized (listeners) {
-        for (Listener l : listeners) {
-          try {
-            l.rpcClosed(this);
-          } catch (Exception e) {
-            LOG.warn("Error caught in Rpc.Listener invocation.", e);
-          }
-        }
-      }
     }
-  }
-
-  public interface Listener {
-
-    void rpcClosed(Rpc rpc);
-
   }
 
   static enum MessageType {

--- a/rsc/src/test/java/com/cloudera/livy/rsc/TestSparkClient.java
+++ b/rsc/src/test/java/com/cloudera/livy/rsc/TestSparkClient.java
@@ -102,12 +102,8 @@ public class TestSparkClient {
         // state changes.
         assertFalse(((JobHandleImpl<String>)handle).changeState(JobHandle.State.SENT));
 
-        verify(listener).onJobQueued(handle);
         verify(listener).onJobStarted(handle);
         verify(listener).onJobSucceeded(same(handle), eq(handle.get()));
-
-        // Try a PingJob, both to make sure it works and also to test "null" results.
-        assertNull(client.submit(new PingJob()).get(TIMEOUT, TimeUnit.SECONDS));
       }
     });
   }
@@ -144,7 +140,6 @@ public class TestSparkClient {
         // state changes.
         assertFalse(((JobHandleImpl<Void>)handle).changeState(JobHandle.State.SENT));
 
-        verify(listener).onJobQueued(handle);
         verify(listener).onJobStarted(handle);
         verify(listener).onJobFailed(same(handle), any(Throwable.class));
       }
@@ -293,8 +288,8 @@ public class TestSparkClient {
       @Override
       void call(LivyClient client) throws Exception {
         ContextInfo ctx = ((RSCClient) client).getContextInfo();
-        URI uri = new URI(String.format("local://%s:%s@%s:%d", ctx.getClientId(), ctx.getSecret(),
-          ctx.getRemoteAddress(), ctx.getRemotePort()));
+        URI uri = new URI(String.format("local://%s:%s@%s:%d", ctx.clientId, ctx.secret,
+          ctx.remoteAddress, ctx.remotePort));
 
         // Close the old client to make sure the driver doesn't go away when it disconnects.
         client.stop(false);
@@ -314,7 +309,7 @@ public class TestSparkClient {
 
           // Make sure the underlying ContextLauncher is cleaned up properly, since we did
           // a "stop(false)" above.
-          ((RSCClient) client).getContextInfo().dispose(true);
+          // ((RSCClient) client).getContextInfo().dispose(true);
         }
       }
     });
@@ -392,6 +387,10 @@ public class TestSparkClient {
       client = new LivyClientBuilder(false).setURI(new URI("local:spark"))
         .setAll(conf)
         .build();
+
+      // Wait for the context to be up before running the test.
+      assertNull(client.submit(new PingJob()).get(TIMEOUT, TimeUnit.SECONDS));
+
       test.call(client);
     } catch (Exception e) {
       // JUnit prints not so useful backtraces in test summary reports, and we don't see the

--- a/rsc/src/test/java/com/cloudera/livy/rsc/rpc/TestRpc.java
+++ b/rsc/src/test/java/com/cloudera/livy/rsc/rpc/TestRpc.java
@@ -37,7 +37,9 @@ import org.slf4j.LoggerFactory;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import com.cloudera.livy.rsc.FutureListener;
 import com.cloudera.livy.rsc.RSCConf;
+import com.cloudera.livy.rsc.Utils;
 import static com.cloudera.livy.rsc.RSCConf.Entry.*;
 
 public class TestRpc {
@@ -141,11 +143,11 @@ public class TestRpc {
     Rpc client = rpcs[1];
 
     final AtomicInteger closeCount = new AtomicInteger();
-    client.addListener(new Rpc.Listener() {
-        @Override
-        public void rpcClosed(Rpc rpc) {
-          closeCount.incrementAndGet();
-        }
+    Utils.addListener(client.getChannel().closeFuture(), new FutureListener<Void>() {
+      @Override
+      public void onSuccess(Void unused) {
+        closeCount.incrementAndGet();
+      }
     });
 
     client.close();

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
@@ -131,7 +131,11 @@ class InteractiveSession(
   client.submit(new PingJob()).addListener(new JobHandle.Listener[Void]() {
     override def onJobQueued(job: JobHandle[Void]): Unit = { }
     override def onJobStarted(job: JobHandle[Void]): Unit = { }
-    override def onJobCancelled(job: JobHandle[Void]): Unit = { }
+
+    override def onJobCancelled(job: JobHandle[Void]): Unit = {
+      transition(SessionState.Error())
+      stop()
+    }
 
     override def onJobFailed(job: JobHandle[Void], cause: Throwable): Unit = {
       transition(SessionState.Error())


### PR DESCRIPTION
The remote context can take a while to start, and doing it
synchronously in the builder call makes it possible, even
likely, that you'll get ugly timeouts from the Livy server,
and cause contexts to stay around and be lost while still
consuming resources.

Instead, just start the submission process synchronously, but
wait for the context to connect back asynchronously. This makes
the client create call return much more quickly, but, as with
anything done asynchronously, requires a lot of code to be moved
around and placed in listeners, and to use promises instead of
actual instances in a few places.

The first tricky change was to support submitting jobs before
the context was up. This was done by chaining listeners so that
the actual submission only happens when the context's RPC channel
is actually created; for clients of the API, nothing changes.

The trickier part was monitoring context shut down; this mostly
affected unit tests, since you can't run two Spark contexts in
the same VM (so tests need to make sure the contexts are really
stopped when the stop call returns). That is now done by waiting
for the RPC socket to close, instead of explicitly waiting for
the context thread or process to go away.

As part of the above change I also removed Rpc.Listener since it
can be implemented by adding a listener to the channel's close
future.

Another unrelated thing I ran into while testing was that jobs
can jump directly from SENT to STARTED, and tests were expecting
them to go through QUEUED first. I fixed the test and wrote a
clarification in the API docs.