### PR TITLE
LIVY-136. Put tests on a memory diet.

### DIFF
--- a/integration-test/src/main/scala/com/cloudera/livy/test/framework/MiniCluster.scala
+++ b/integration-test/src/main/scala/com/cloudera/livy/test/framework/MiniCluster.scala
@@ -205,6 +205,8 @@ class MiniCluster(config: Map[String, String]) extends Cluster with MiniClusterU
       "spark.executor.instances" -> "1",
       "spark.scheduler.minRegisteredResourcesRatio" -> "0.0",
       "spark.ui.enabled" -> "false",
+      SparkLauncher.DRIVER_MEMORY -> "512m",
+      SparkLauncher.EXECUTOR_MEMORY -> "512m",
       SparkLauncher.DRIVER_EXTRA_CLASSPATH -> childClasspath,
       SparkLauncher.EXECUTOR_EXTRA_CLASSPATH -> childClasspath,
       SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS -> "-Dtest.appender=console",
@@ -282,7 +284,7 @@ class MiniCluster(config: Map[String, String]) extends Cluster with MiniClusterU
       "-Dtest.appender=console",
       "-Djava.io.tmpdir=" + procTmp.getAbsolutePath(),
       "-cp", childClasspath + File.pathSeparator + configDir.getAbsolutePath(),
-      "-Xmx2g",
+      "-Xmx1g",
       klass.getName().stripSuffix("$"),
       configDir.getAbsolutePath())
 

--- a/pom.xml
+++ b/pom.xml
@@ -649,7 +649,7 @@
             </systemProperties>
             <redirectTestOutputToFile>${test.redirectToFile}</redirectTestOutputToFile>
             <useFile>${test.redirectToFile}</useFile>
-            <argLine>${argLine} -Xmx4096m -XX:MaxPermSize=512m</argLine>
+            <argLine>${argLine} -Xmx1g -XX:MaxPermSize=256m</argLine>
             <failIfNoTests>false</failIfNoTests>
           </configuration>
         </plugin>
@@ -674,7 +674,7 @@
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
             <junitxml>.</junitxml>
             <filereports>WDF TestSuite.txt</filereports>
-            <argLine>${argLine} -Xmx4096m -XX:MaxPermSize=512m</argLine>
+            <argLine>${argLine} -Xmx1g -XX:MaxPermSize=256m</argLine>
           </configuration>
           <executions>
             <execution>

--- a/repl/src/test/scala/com/cloudera/livy/repl/ReplDriverSuite.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/ReplDriverSuite.scala
@@ -40,7 +40,8 @@ class ReplDriverSuite extends FunSuite {
 
   test("start a repl session using the rsc") {
     val client = new LivyClientBuilder()
-      .setConf("spark.master", "local")
+      .setConf(SparkLauncher.SPARK_MASTER, "local")
+      .setConf(SparkLauncher.DRIVER_MEMORY, "512m")
       .setConf(SparkLauncher.DRIVER_EXTRA_CLASSPATH, sys.props("java.class.path"))
       .setConf(SparkLauncher.EXECUTOR_EXTRA_CLASSPATH, sys.props("java.class.path"))
       .setConf(RSCConf.Entry.LIVY_JARS.key(), "")

--- a/rsc/src/test/java/com/cloudera/livy/rsc/TestSparkClient.java
+++ b/rsc/src/test/java/com/cloudera/livy/rsc/TestSparkClient.java
@@ -79,6 +79,7 @@ public class TestSparkClient {
       String classpath = System.getProperty("java.class.path");
       conf.put(SparkLauncher.SPARK_MASTER, "local");
       conf.put("spark.app.name", "SparkClientSuite Remote App");
+      conf.put(SparkLauncher.DRIVER_MEMORY, "512m");
       conf.put(SparkLauncher.DRIVER_EXTRA_CLASSPATH, classpath);
       conf.put(SparkLauncher.EXECUTOR_EXTRA_CLASSPATH, classpath);
     }


### PR DESCRIPTION
Reduce the amount of memory requested by tests so that they
don't put too much pressure on the machines used by CI builds,
and avoid triggering the kernel's OOM killer.