### PR TITLE
LIVY-130. Run pyspark and sparkr tests if a real Spark is available.

### DIFF
--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -204,6 +204,7 @@
         <configuration>
           <environmentVariables>
             <LIVY_HOME>${execution.root}</LIVY_HOME>
+            <LIVY_TEST>false</LIVY_TEST>
           </environmentVariables>
           <systemProperties>
             <cluster.spec>${cluster.spec}</cluster.spec>
@@ -213,5 +214,19 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>real-spark-home</id>
+      <activation>
+        <property>
+          <name>real.spark.home</name>
+        </property>
+      </activation>
+      <properties>
+        <spark.home>${real.spark.home}</spark.home>
+      </properties>
+    </profile>
+  </profiles>
 
 </project>

--- a/integration-test/src/main/scala/com/cloudera/livy/test/framework/Cluster.scala
+++ b/integration-test/src/main/scala/com/cloudera/livy/test/framework/Cluster.scala
@@ -29,6 +29,7 @@ trait Cluster {
   def getYarnRmEndpoint: String
   def upload(srcPath: String, destPath: String): Unit
   def configDir(): File
+  def isRealSpark(): Boolean
 
   def runLivy(): Unit
   def stopLivy(): Unit

--- a/integration-test/src/main/scala/com/cloudera/livy/test/framework/MiniCluster.scala
+++ b/integration-test/src/main/scala/com/cloudera/livy/test/framework/MiniCluster.scala
@@ -53,8 +53,8 @@ sealed trait MiniClusterUtils {
 
   protected def saveConfig(conf: Configuration, dest: File): Unit = {
     val redacted = new Configuration(conf)
-    // This setting references a test class is not available when using a real Spark installation,
-    // so remove it from client configs.
+    // This setting references a test class that is not available when using a real Spark
+    // installation, so remove it from client configs.
     redacted.unset("net.topology.node.switch.mapping.impl")
 
     val out = new FileOutputStream(dest)

--- a/integration-test/src/main/scala/com/cloudera/livy/test/framework/MiniCluster.scala
+++ b/integration-test/src/main/scala/com/cloudera/livy/test/framework/MiniCluster.scala
@@ -52,9 +52,14 @@ private class MiniClusterConfig(val config: Map[String, String]) {
 sealed trait MiniClusterUtils {
 
   protected def saveConfig(conf: Configuration, dest: File): Unit = {
+    val redacted = new Configuration(conf)
+    // This setting references a test class is not available when using a real Spark installation,
+    // so remove it from client configs.
+    redacted.unset("net.topology.node.switch.mapping.impl")
+
     val out = new FileOutputStream(dest)
     try {
-      conf.writeXml(out)
+      redacted.writeXml(out)
     } finally {
       out.close()
     }
@@ -189,6 +194,10 @@ class MiniCluster(config: Map[String, String]) extends Cluster with MiniClusterU
 
   override def configDir(): File = _configDir
 
+  override def isRealSpark(): Boolean = {
+    new File(sys.env("SPARK_HOME") + File.separator + "RELEASE").isFile()
+  }
+
   // Explicitly remove the "test-lib" dependency from the classpath of child processes. We
   // want tests to explicitly upload this jar when necessary, to test those code paths.
   private val childClasspath = {
@@ -201,15 +210,22 @@ class MiniCluster(config: Map[String, String]) extends Cluster with MiniClusterU
   override def deploy(): Unit = {
     sparkConfDir = mkdir("spark-conf")
 
-    val sparkConf = Map(
+    // When running a real Spark cluster, don't set the classpath.
+    val extraCp = if (!isRealSpark()) {
+      Map(
+        SparkLauncher.DRIVER_EXTRA_CLASSPATH -> childClasspath,
+        SparkLauncher.EXECUTOR_EXTRA_CLASSPATH -> childClasspath)
+    } else {
+      Map()
+    }
+
+    val sparkConf = extraCp ++ Map(
       SparkLauncher.SPARK_MASTER -> "yarn-cluster",
       "spark.executor.instances" -> "1",
       "spark.scheduler.minRegisteredResourcesRatio" -> "0.0",
       "spark.ui.enabled" -> "false",
       SparkLauncher.DRIVER_MEMORY -> "512m",
       SparkLauncher.EXECUTOR_MEMORY -> "512m",
-      SparkLauncher.DRIVER_EXTRA_CLASSPATH -> childClasspath,
-      SparkLauncher.EXECUTOR_EXTRA_CLASSPATH -> childClasspath,
       SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS -> "-Dtest.appender=console",
       SparkLauncher.EXECUTOR_EXTRA_JAVA_OPTIONS -> "-Dtest.appender=console"
     )

--- a/integration-test/src/main/scala/com/cloudera/livy/test/framework/RealCluster.scala
+++ b/integration-test/src/main/scala/com/cloudera/livy/test/framework/RealCluster.scala
@@ -52,6 +52,8 @@ class RealCluster(
   private var livyHomePath: Option[String] = Some("/usr/bin/livy")
   private var pathsToCleanUp = ListBuffer.empty[String]
 
+  override def isRealSpark(): Boolean = true
+
   override def configDir(): File = throw new UnsupportedOperationException()
 
   def sshClient[T](body: SshClient => SSH.Result[T]): Validated[T] = {

--- a/integration-test/src/test/resources/log4j.properties
+++ b/integration-test/src/test/resources/log4j.properties
@@ -18,7 +18,7 @@
 
 # Set everything to be logged to the file target/unit-tests.log
 test.appender=file
-log4j.rootCategory=INFO, ${test.appender}
+log4j.rootCategory=DEBUG, ${test.appender}
 log4j.appender.file=org.apache.log4j.FileAppender
 log4j.appender.file.append=true
 log4j.appender.file.file=target/unit-tests.log
@@ -34,5 +34,4 @@ log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS} %t: %m%n
 
 # Ignore messages below warning level from Jetty, because it's a bit verbose
-log4j.logger.org.spark-project.jetty=WARN
-org.spark-project.jetty.LEVEL=WARN
+log4j.logger.org.eclipse.jetty=WARN

--- a/integration-test/src/test/resources/pytest.py
+++ b/integration-test/src/test/resources/pytest.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env /python
+#
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import sys
+from pyspark import SparkContext
+
+output = sys.argv[1]
+sc = SparkContext(appName="PySpark Test")
+try:
+  sc.parallelize(range(100), 10).map(lambda x: (x, x * 2)).saveAsTextFile(output)
+finally:
+  sc.stop()

--- a/integration-test/src/test/resources/rtest.R
+++ b/integration-test/src/test/resources/rtest.R
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+library(SparkR)
+
+# Initialize SparkContext and SQLContext
+sc <- sparkR.init(appName="SparkR-DataFrame-example")
+sqlContext <- sparkRSQL.init(sc)
+
+# Create a simple local data.frame
+localDF <- data.frame(name=c("John", "Smith", "Sarah"), age=c(19, 23, 18))
+
+# Convert local data frame to a SparkDataFrame
+df <- createDataFrame(sqlContext, localDF)
+
+# Print its schema
+printSchema(df)
+
+# Stop the SparkContext now
+sparkR.stop()

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,8 @@
     <maxJavaVersion>1.8</maxJavaVersion>
     <test.redirectToFile>true</test.redirectToFile>
     <execution.root>${user.dir}</execution.root>
+    <spark.home>${execution.root}/dev/spark</spark.home>
+
     <!--
       Properties for the copyright header style checks. Modules that use the ASF header
       should override the "copyright.header" property.
@@ -638,7 +640,7 @@
           <configuration>
             <environmentVariables>
               <LIVY_TEST>true</LIVY_TEST>
-              <SPARK_HOME>${execution.root}/dev/spark</SPARK_HOME>
+              <SPARK_HOME>${spark.home}</SPARK_HOME>
             </environmentVariables>
             <systemProperties>
               <java.awt.headless>true</java.awt.headless>
@@ -661,7 +663,7 @@
           <configuration>
             <environmentVariables>
               <LIVY_TEST>true</LIVY_TEST>
-              <SPARK_HOME>${execution.root}/dev/spark</SPARK_HOME>
+              <SPARK_HOME>${spark.home}</SPARK_HOME>
             </environmentVariables>
             <systemProperties>
               <java.awt.headless>true</java.awt.headless>

--- a/server/src/main/scala/com/cloudera/livy/utils/SparkProcessBuilder.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/SparkProcessBuilder.scala
@@ -255,8 +255,6 @@ class SparkProcessBuilder(livyConf: LivyConf) extends Logging {
       env.put(key, value)
     }
 
-    env.asScala.foreach { case (k, v) => info(s"  env: $k = $v") }
-
     _redirectOutput.foreach(pb.redirectOutput)
     _redirectError.foreach(pb.redirectError)
     _redirectErrorStream.foreach(pb.redirectErrorStream)


### PR DESCRIPTION
A new setting was added to allow a real Spark installation to be used
for integration tests. When set, this allows pyspark and sparkr to run;
this also allows testing different versions of Spark than the one
referenced in the pom easily. I tested this with 1.6.1.