### PR TITLE
LIVY-31. Close sessions when server shuts down.

### DIFF
--- a/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
@@ -115,6 +115,13 @@ class LivyServer extends Logging {
 
     server.start()
 
+    Runtime.getRuntime().addShutdownHook(new Thread("Livy Server Shutdown") {
+      override def run(): Unit = {
+        info("Shutting down Livy server.")
+        server.stop()
+      }
+    })
+
     _serverUrl = Some(s"http://${server.host}:${server.port}")
     sys.props("livy.server.serverUrl") = _serverUrl.get
   }

--- a/server/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
+++ b/server/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
@@ -22,7 +22,8 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.mutable
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration.Duration
 
 import com.cloudera.livy.{LivyConf, Logging}
 
@@ -71,7 +72,10 @@ class SessionManager[S <: Session](val livyConf: LivyConf) extends Logging {
   }
 
   def shutdown(): Unit = {
-    // TODO: shut down open sessions?
+    // TODO: if recovery or HA is available, sessions should not be stopped.
+    sessions.values.map(_.stop).foreach { future =>
+      Await.ready(future, Duration.Inf)
+    }
   }
 
   def collectGarbage(): Future[Iterable[Unit]] = {


### PR DESCRIPTION
Without HA or recovery, not doing this means leaving orphan sessions
that will just hog resources and cannot be used, requiring people to
use YARN's (or other) tools to shut them down.

This change adds a shutdown hook that stops all the active sessions
when the server shuts down. This requires doing more work in a shutdown
hook than is generally palatable, but the alternative is to have some
explicit command (via REST API? monitoring local file? something else?)
to shut down the server, which we don't have.