### PR TITLE
LIVY-147. Prepend default FS to user-provided paths when needed.

### DIFF
--- a/api/src/main/java/com/cloudera/livy/LivyClient.java
+++ b/api/src/main/java/com/cloudera/livy/LivyClient.java
@@ -71,10 +71,13 @@ public interface LivyClient {
 
   /**
    * Adds a jar file to the running remote context.
-   *
+   * <p>
    * Note that the URL should be reachable by the Spark driver process. If running the driver
    * in cluster mode, it may reside on a different host, meaning "file:" URLs have to exist
    * on that node (and not on the client machine).
+   * <p>
+   * If the provided URI has no scheme, it's considered to be relative to the default file system
+   * configured in the Livy server.
    *
    * @param uri The location of the jar file.
    * @return A future that can be used to monitor the operation.
@@ -90,10 +93,13 @@ public interface LivyClient {
 
   /**
    * Adds a file to the running remote context.
-   *
+   * <p>
    * Note that the URL should be reachable by the Spark driver process. If running the driver
    * in cluster mode, it may reside on a different host, meaning "file:" URLs have to exist
    * on that node (and not on the client machine).
+   * <p>
+   * If the provided URI has no scheme, it's considered to be relative to the default file system
+   * configured in the Livy server.
    *
    * @param uri The location of the file.
    * @return A future that can be used to monitor the operation.

--- a/client-http/src/main/java/com/cloudera/livy/client/http/HttpClient.java
+++ b/client-http/src/main/java/com/cloudera/livy/client/http/HttpClient.java
@@ -160,10 +160,6 @@ class HttpClient implements LivyClient {
   }
 
   private Future<?> addResource(final String command, final URI resource) {
-    if (resource.getScheme() == null || resource.getScheme() == "file") {
-      throw new IllegalArgumentException("Local resources are not yet supported: " + resource);
-    }
-
     Callable<Void> task = new Callable<Void>() {
       @Override
       public Void call() throws Exception {

--- a/integration-test/src/main/scala/com/cloudera/livy/test/framework/BaseIntegrationTestSuite.scala
+++ b/integration-test/src/main/scala/com/cloudera/livy/test/framework/BaseIntegrationTestSuite.scala
@@ -19,6 +19,7 @@
 package com.cloudera.livy.test.framework
 
 import java.io.File
+import java.util.UUID
 import javax.servlet.http.HttpServletResponse
 
 import scala.concurrent.duration._
@@ -29,6 +30,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.ning.http.client.AsyncHttpClient
+import org.apache.hadoop.fs.Path
 import org.scalatest._
 import org.scalatest.concurrent.Eventually._
 
@@ -67,6 +69,14 @@ abstract class BaseIntegrationTestSuite extends FunSuite with Matchers {
       val curState = livyClient.getSessionStatus(sessionId)
       assert(curState === SessionState.Idle().toString)
     }
+  }
+
+  /** Uploads a file to HDFS and returns just its path. */
+  protected def uploadToHdfs(file: File): String = {
+    val hdfsPath = new Path(cluster.hdfsScratchDir(),
+      UUID.randomUUID().toString() + "-" + file.getName())
+    cluster.fs.copyFromLocalFile(new Path(file.toURI()), hdfsPath)
+    hdfsPath.toUri().getPath()
   }
 
   /** Wrapper around test() to be used by pyspark tests. */

--- a/rsc/src/main/java/com/cloudera/livy/rsc/RSCClient.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/RSCClient.java
@@ -219,8 +219,10 @@ public class RSCClient implements LivyClient {
 
         eventLoopGroup.shutdownGracefully();
       }
-      LOG.debug("Disconnected from context {}, shutdown = {}.", contextInfo.clientId,
-        shutdownContext);
+      if (contextInfo != null) {
+        LOG.debug("Disconnected from context {}, shutdown = {}.", contextInfo.clientId,
+          shutdownContext);
+      }
     }
   }
 

--- a/server/src/main/scala/com/cloudera/livy/LivyConf.scala
+++ b/server/src/main/scala/com/cloudera/livy/LivyConf.scala
@@ -22,6 +22,8 @@ import java.io.File
 import java.lang.{Boolean => JBoolean, Long => JLong}
 import java.nio.file.Files
 
+import org.apache.hadoop.conf.Configuration
+
 import com.cloudera.livy.client.common.ClientConf
 import com.cloudera.livy.client.common.ClientConf.ConfEntry
 
@@ -56,6 +58,8 @@ class LivyConf(loadDefaults: Boolean) extends ClientConf[LivyConf](null) {
   import LivyConf._
 
   private lazy val _superusers = Option(get(SUPERUSERS)).map(_.split("[, ]+").toSeq).getOrElse(Nil)
+
+  lazy val hadoopConf = new Configuration()
 
   /**
    * Create a LivyConf that loads defaults from the system properties and the classpath.

--- a/server/src/main/scala/com/cloudera/livy/server/batch/BatchSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/batch/BatchSession.scala
@@ -41,9 +41,9 @@ class BatchSession(
     builder.conf(request.conf)
     proxyUser.foreach(builder.proxyUser)
     request.className.foreach(builder.className)
-    request.jars.foreach(builder.jar)
-    request.pyFiles.foreach(builder.pyFile)
-    request.files.foreach(builder.file)
+    resolveURIs(request.jars).foreach(builder.jar)
+    resolveURIs(request.pyFiles).foreach(builder.pyFile)
+    resolveURIs(request.files).foreach(builder.file)
     request.driverMemory.foreach(builder.driverMemory)
     request.driverCores.foreach(builder.driverCores)
     request.executorMemory.foreach(builder.executorMemory)
@@ -55,7 +55,8 @@ class BatchSession(
     builder.redirectOutput(Redirect.PIPE)
     builder.redirectErrorStream(true)
 
-    builder.start(Some(request.file), request.args)
+    val file = resolveURIs(Seq(request.file))(0)
+    builder.start(Some(file), request.args)
   }
 
   protected implicit def executor: ExecutionContextExecutor = ExecutionContext.global

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSessionServlet.scala
@@ -18,7 +18,7 @@
 
 package com.cloudera.livy.server.interactive
 
-import java.net.{URI, URL}
+import java.net.URI
 import java.util.concurrent.TimeUnit
 import javax.servlet.http.HttpServletRequest
 
@@ -28,7 +28,7 @@ import scala.concurrent.duration._
 
 import org.json4s.jackson.Json4sScalaModule
 import org.scalatra._
-import org.scalatra.servlet.{FileUploadSupport, MultipartConfig}
+import org.scalatra.servlet.FileUploadSupport
 
 import com.cloudera.livy.{ExecuteRequest, JobHandle, LivyConf, Logging}
 import com.cloudera.livy.client.common.HttpMessages._

--- a/test-lib/src/main/java/com/cloudera/livy/test/jobs/FileReader.java
+++ b/test-lib/src/main/java/com/cloudera/livy/test/jobs/FileReader.java
@@ -21,6 +21,7 @@ package com.cloudera.livy.test.jobs;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -53,7 +54,10 @@ public class FileReader implements Job<String> {
       InputStream in;
       if (isResource) {
         ClassLoader ccl = Thread.currentThread().getContextClassLoader();
-        in = ccl.getResourceAsStream("test.resource");
+        in = ccl.getResourceAsStream(fileName);
+        if (in == null) {
+          throw new IOException("Resource not found: " + fileName);
+        }
       } else {
         in = new FileInputStream(SparkFiles.get(fileName));
       }


### PR DESCRIPTION
Spark's default behavior is to treat schema-less URIs as local, which
doesn't make a whole lot of sense for Livy (since clients most probably
don't share Livy's local filesystem).

So, instead, prepend Hadoop's default FS to paths when they don't already
have a scheme, so that users don't have to figure that out by themselves.
This should also make session requests more backwards compatible with v0.1,
since a similar functionality existed there in certain cases.