### PR TITLE
LIVY-148. Add explicit whitelist for local files users can read.

### DIFF
--- a/conf/livy.conf
+++ b/conf/livy.conf
@@ -33,3 +33,8 @@
 # Location of the SparkR package. By default Livy will upload the file from SPARK_HOME, but
 # by caching the file in HDFS, startup time of R sessions on YARN can be reduced.
 # livy.sparkr.package =
+
+# List of local directories from where files are allowed to be added to user sessions. By
+# default it's empty, meaning users can only reference remote URIs when starting their
+# sessions.
+# livy.file.local-dir-whitelist =

--- a/conf/spark-blacklist.conf
+++ b/conf/spark-blacklist.conf
@@ -9,3 +9,8 @@
 # Disallow overriding the master and the deploy mode.
 spark.master
 spark.submit.deployMode
+
+# Disallow overriding the location of Spark cached jars.
+spark.yarn.jar
+spark.yarn.jars
+spark.yarn.archive

--- a/server/src/main/scala/com/cloudera/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/SessionServlet.scala
@@ -24,7 +24,7 @@ import scala.concurrent.Future
 
 import org.scalatra._
 
-import com.cloudera.livy.{LivyConf, Logging, Utils}
+import com.cloudera.livy.{LivyConf, Logging}
 import com.cloudera.livy.sessions.{Session, SessionManager}
 
 object SessionServlet extends Logging
@@ -44,11 +44,6 @@ abstract class SessionServlet[S <: Session](livyConf: LivyConf)
 {
 
   private[livy] val sessionManager = new SessionManager[S](livyConf)
-
-  private val configBlackList: Set[String] = {
-    val url = getClass.getResource("/spark-blacklist.conf")
-    if (url != null) Utils.loadProperties(url).keySet else Set()
-  }
 
   /**
    * Creates a new session based on the current request. The implementation is responsible for
@@ -161,17 +156,6 @@ abstract class SessionServlet[S <: Session](livyConf: LivyConf)
    * Returns the remote user for the given request. Separate method so that tests can override it.
    */
   protected def remoteUser(req: HttpServletRequest): String = req.getRemoteUser()
-
-  /**
-   * Validate that the user-provided configuration does not contain anything blacklisted.
-   */
-  protected def validateConf(conf: Map[String, String]): Unit = {
-    val errors = conf.keySet.filter(configBlackList.contains)
-    if (errors.nonEmpty) {
-      throw new IllegalArgumentException(
-        "Blacklisted configuration values in session config: " + errors.mkString(", "))
-    }
-  }
 
   /**
    * Checks that the request's user can impersonate the target user.

--- a/server/src/main/scala/com/cloudera/livy/server/batch/BatchSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/batch/BatchSession.scala
@@ -35,21 +35,19 @@ class BatchSession(
     extends Session(id, owner, livyConf) {
 
   private val process = {
+    val conf = prepareConf(request.conf, request.jars, request.files, request.archives,
+      request.pyFiles)
     require(request.file != null, "File is required.")
 
     val builder = new SparkProcessBuilder(livyConf)
-    builder.conf(request.conf)
+    builder.conf(conf)
     proxyUser.foreach(builder.proxyUser)
     request.className.foreach(builder.className)
-    resolveURIs(request.jars).foreach(builder.jar)
-    resolveURIs(request.pyFiles).foreach(builder.pyFile)
-    resolveURIs(request.files).foreach(builder.file)
     request.driverMemory.foreach(builder.driverMemory)
     request.driverCores.foreach(builder.driverCores)
     request.executorMemory.foreach(builder.executorMemory)
     request.executorCores.foreach(builder.executorCores)
     request.numExecutors.foreach(builder.numExecutors)
-    request.archives.foreach(builder.archive)
     request.queue.foreach(builder.queue)
     request.name.foreach(builder.name)
     builder.redirectOutput(Redirect.PIPE)

--- a/server/src/main/scala/com/cloudera/livy/server/batch/BatchSessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/batch/BatchSessionServlet.scala
@@ -31,7 +31,6 @@ class BatchSessionServlet(livyConf: LivyConf)
 
   override protected def createSession(req: HttpServletRequest): BatchSession = {
     val createRequest = bodyAs[CreateBatchRequest](req)
-    validateConf(createRequest.conf)
     val proxyUser = checkImpersonation(createRequest.proxyUser, req)
     new BatchSession(sessionManager.nextId(), remoteUser(req), proxyUser, livyConf, createRequest)
   }

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSessionServlet.scala
@@ -47,7 +47,6 @@ class InteractiveSessionServlet(livyConf: LivyConf)
 
   override protected def createSession(req: HttpServletRequest): InteractiveSession = {
     val createRequest = bodyAs[CreateInteractiveRequest](req)
-    validateConf(createRequest.conf)
     val proxyUser = checkImpersonation(createRequest.proxyUser, req)
     new InteractiveSession(sessionManager.nextId(), remoteUser(req), proxyUser, livyConf,
       createRequest)

--- a/server/src/main/scala/com/cloudera/livy/utils/SparkProcessBuilder.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/SparkProcessBuilder.scala
@@ -32,16 +32,10 @@ class SparkProcessBuilder(livyConf: LivyConf) extends Logging {
   private[this] var _deployMode: Option[String] = None
   private[this] var _className: Option[String] = None
   private[this] var _name: Option[String] = Some("Livy")
-  private[this] var _jars: ArrayBuffer[String] = ArrayBuffer()
-  private[this] var _pyFiles: ArrayBuffer[String] = ArrayBuffer()
-  private[this] var _files: ArrayBuffer[String] = ArrayBuffer()
   private[this] val _conf = mutable.HashMap[String, String]()
   private[this] var _driverClassPath: ArrayBuffer[String] = ArrayBuffer()
   private[this] var _proxyUser: Option[String] = None
-
   private[this] var _queue: Option[String] = None
-  private[this] var _archives: ArrayBuffer[String] = ArrayBuffer()
-
   private[this] var _env: ArrayBuffer[(String, String)] = ArrayBuffer()
   private[this] var _redirectOutput: Option[ProcessBuilder.Redirect] = None
   private[this] var _redirectError: Option[ProcessBuilder.Redirect] = None
@@ -69,36 +63,6 @@ class SparkProcessBuilder(livyConf: LivyConf) extends Logging {
 
   def name(name: String): SparkProcessBuilder = {
     _name = Some(name)
-    this
-  }
-
-  def jar(jar: String): SparkProcessBuilder = {
-    this._jars += jar
-    this
-  }
-
-  def jars(jars: Traversable[String]): SparkProcessBuilder = {
-    this._jars ++= jars
-    this
-  }
-
-  def pyFile(pyFile: String): SparkProcessBuilder = {
-    this._pyFiles += pyFile
-    this
-  }
-
-  def pyFiles(pyFiles: Traversable[String]): SparkProcessBuilder = {
-    this._pyFiles ++= pyFiles
-    this
-  }
-
-  def file(file: String): SparkProcessBuilder = {
-    this._files += file
-    this
-  }
-
-  def files(files: Traversable[String]): SparkProcessBuilder = {
-    this._files ++= files
     this
   }
 
@@ -172,16 +136,6 @@ class SparkProcessBuilder(livyConf: LivyConf) extends Logging {
     this
   }
 
-  def archive(archive: String): SparkProcessBuilder = {
-    _archives += archive
-    this
-  }
-
-  def archives(archives: Traversable[String]): SparkProcessBuilder = {
-    archives.foreach(archive)
-    this
-  }
-
   def env(key: String, value: String): SparkProcessBuilder = {
     _env += ((key, value))
     this
@@ -222,9 +176,6 @@ class SparkProcessBuilder(livyConf: LivyConf) extends Logging {
     addOpt("--master", _master)
     addOpt("--deploy-mode", _deployMode)
     addOpt("--name", _name)
-    addList("--jars", _jars)
-    addList("--py-files", _pyFiles)
-    addList("--files", _files)
     addOpt("--class", _className)
     _conf.foreach { case (key, value) =>
       arguments += "--conf"
@@ -237,7 +188,6 @@ class SparkProcessBuilder(livyConf: LivyConf) extends Logging {
     }
 
     addOpt("--queue", _queue)
-    addList("--archives", _archives)
 
     arguments += file.getOrElse("spark-internal")
     arguments ++= args

--- a/server/src/test/scala/com/cloudera/livy/server/BaseSessionServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/BaseSessionServletSpec.scala
@@ -54,6 +54,7 @@ abstract class BaseSessionServletSpec[S <: Session]
     new LivyConf()
       .set(LivyConf.IMPERSONATION_ENABLED, true)
       .set(LivyConf.SUPERUSERS, ADMIN)
+      .set(LivyConf.LOCAL_FS_WHITELIST, sys.props("java.io.tmpdir"))
   }
 
   override def afterAll(): Unit = {

--- a/server/src/test/scala/com/cloudera/livy/server/batch/BatchServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/batch/BatchServletSpec.scala
@@ -25,7 +25,7 @@ import javax.servlet.http.HttpServletResponse._
 
 import scala.concurrent.duration.Duration
 
-import com.cloudera.livy.{LivyConf, Utils}
+import com.cloudera.livy.Utils
 import com.cloudera.livy.server.BaseSessionServletSpec
 import com.cloudera.livy.sessions.SessionState
 
@@ -46,7 +46,7 @@ class BatchServletSpec extends BaseSessionServletSpec[BatchSession] {
     script
   }
 
-  override def createServlet(): BatchSessionServlet = new BatchSessionServlet(new LivyConf())
+  override def createServlet(): BatchSessionServlet = new BatchSessionServlet(createConf())
 
   describe("Batch Servlet") {
     it("should create and tear down a batch") {

--- a/server/src/test/scala/com/cloudera/livy/server/batch/BatchSessionSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/batch/BatchSessionSpec.scala
@@ -55,7 +55,8 @@ class BatchSessionSpec
       req.file = script.toString
       req.conf = Map("spark.driver.extraClassPath" -> sys.props("java.class.path"))
 
-      val batch = new BatchSession(0, null, None, new LivyConf(), req)
+      val conf = new LivyConf().set(LivyConf.LOCAL_FS_WHITELIST, sys.props("java.io.tmpdir"))
+      val batch = new BatchSession(0, null, None, conf, req)
 
       Utils.waitUntil({ () => !batch.state.isActive }, Duration(10, TimeUnit.SECONDS))
       (batch.state match {

--- a/server/src/test/scala/com/cloudera/livy/sessions/SessionSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/sessions/SessionSpec.scala
@@ -1,0 +1,105 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.sessions
+
+import java.net.URI
+
+import org.scalatest.FunSuite
+
+import com.cloudera.livy.LivyConf
+
+class SessionSpec extends FunSuite {
+
+  test("use default fs in paths") {
+    val conf = new LivyConf(false)
+    conf.hadoopConf.set("fs.defaultFS", "dummy:///")
+
+    val session = new MockSession(0, null, conf)
+
+    val uris = Seq("http://example.com/foo", "hdfs:/bar", "/baz")
+    val expected = Seq(uris(0), uris(1), "dummy:///baz")
+    assert(session.resolveURIs(uris) === expected)
+
+    intercept[IllegalArgumentException] {
+      session.resolveURI(new URI("relative_path"))
+    }
+  }
+
+  test("local fs whitelist") {
+    val conf = new LivyConf(false)
+    conf.set(LivyConf.LOCAL_FS_WHITELIST, "/allowed/,/also_allowed")
+
+    val session = new MockSession(0, null, conf)
+
+    Seq("/allowed/file", "/also_allowed/file").foreach { path =>
+      assert(session.resolveURI(new URI(path)) === new URI("file://" + path))
+    }
+
+    Seq("/not_allowed", "/allowed_not_really").foreach { path =>
+      intercept[IllegalArgumentException] {
+        session.resolveURI(new URI(path))
+      }
+    }
+  }
+
+  test("conf validation and preparation") {
+    val conf = new LivyConf(false)
+    conf.hadoopConf.set("fs.defaultFS", "dummy:///")
+    conf.set(LivyConf.LOCAL_FS_WHITELIST, "/allowed")
+
+    val session = new MockSession(0, null, conf)
+
+    // Test baseline.
+    assert(session.prepareConf(Map(), Nil, Nil, Nil, Nil) === Map())
+
+    // Test validations.
+    intercept[IllegalArgumentException] {
+      session.prepareConf(Map("spark.do_not_set" -> "1"), Nil, Nil, Nil, Nil)
+    }
+    conf.sparkFileLists.foreach { key =>
+      intercept[IllegalArgumentException] {
+        session.prepareConf(Map(key -> "file:/not_allowed"), Nil, Nil, Nil, Nil)
+      }
+    }
+    intercept[IllegalArgumentException] {
+      session.prepareConf(Map(), Seq("file:/not_allowed"), Nil, Nil, Nil)
+    }
+    intercept[IllegalArgumentException] {
+      session.prepareConf(Map(), Nil, Seq("file:/not_allowed"), Nil, Nil)
+    }
+    intercept[IllegalArgumentException] {
+      session.prepareConf(Map(), Nil, Nil, Seq("file:/not_allowed"), Nil)
+    }
+    intercept[IllegalArgumentException] {
+      session.prepareConf(Map(), Nil, Nil, Nil, Seq("file:/not_allowed"))
+    }
+
+    // Test that file lists are merged and resolved.
+    val base = "/file1.txt"
+    val other = Seq("/file2.txt")
+    val expected = Some(Seq("dummy://" + other(0), "dummy://" + base).mkString(","))
+
+    val userLists = Seq(LivyConf.SPARK_JARS, LivyConf.SPARK_FILES, LivyConf.SPARK_ARCHIVES,
+      LivyConf.SPARK_PY_FILES)
+    val baseConf = userLists.map { key => (key -> base) }.toMap
+    val result = session.prepareConf(baseConf, other, other, other, other)
+    userLists.foreach { key => assert(result.get(key) ===  expected) }
+  }
+
+}


### PR DESCRIPTION
This makes it so by default users cannot provide local URIs as input
to their jobs; this prevents users from using Livy to read arbitrary
files on the Livy server's file system.

It's possible to add explicit directories that users can read, though;
adding "/", for example, would open up the whole file system to users.

There are some extra changes to merge the code that processes file lists
in the Spark configuration into a single shared method used by both
batches and interactive sessions; this makes sure that both modes perform
the appropriate checks and translations before starting Spark. This
new code also looks at all known file lists that Spark processes (as
of the current 2.0 branch) and performs validaton on those.