### PR TITLE
LIVY-149. Add idle timeout to RSC server.

### DIFF
--- a/conf/spark-blacklist.conf
+++ b/conf/spark-blacklist.conf
@@ -14,3 +14,6 @@ spark.submit.deployMode
 spark.yarn.jar
 spark.yarn.jars
 spark.yarn.archive
+
+# Don't allow users to override the RSC timeout.
+livy.rsc.server.idle_timeout

--- a/rsc/src/main/java/com/cloudera/livy/rsc/RSCConf.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/RSCConf.java
@@ -55,11 +55,14 @@ public class RSCConf extends ClientConf<RSCConf> {
     LAUNCHER_ADDRESS("launcher.address", null),
     LAUNCHER_PORT("launcher.port", -1),
 
+    // How long will the RSC wait for a connection for a Livy server before shutting itself down.
+    SERVER_IDLE_TIMEOUT("server.idle_timeout", "10m"),
+
     PROXY_USER("proxy_user", null),
 
     RPC_SERVER_ADDRESS("rpc.server.address", null),
-    RPC_CLIENT_HANDSHAKE_TIMEOUT("server.connect.timeout", "90000ms"),
-    RPC_CLIENT_CONNECT_TIMEOUT("client.connect.timeout", "10000ms"),
+    RPC_CLIENT_HANDSHAKE_TIMEOUT("server.connect.timeout", "90s"),
+    RPC_CLIENT_CONNECT_TIMEOUT("client.connect.timeout", "10s"),
     RPC_CHANNEL_LOG_LEVEL("channel.log.level", null),
     RPC_MAX_MESSAGE_SIZE("rpc.max.size", 50 * 1024 * 1024),
     RPC_MAX_THREADS("rpc.threads", 8),
@@ -72,7 +75,7 @@ public class RSCConf extends ClientConf<RSCConf> {
     private final Object dflt;
 
     private Entry(String key, Object dflt) {
-      this.key = "livy.local." + key;
+      this.key = "livy.rsc." + key;
       this.dflt = dflt;
     }
 

--- a/test-lib/src/main/java/com/cloudera/livy/test/jobs/Sleeper.java
+++ b/test-lib/src/main/java/com/cloudera/livy/test/jobs/Sleeper.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.test.jobs;
+
+import com.cloudera.livy.Job;
+import com.cloudera.livy.JobContext;
+
+public class Sleeper implements Job<Void> {
+
+  private final long millis;
+
+  public Sleeper(long millis) {
+    this.millis = millis;
+  }
+
+  @Override
+  public Void call(JobContext jc) throws Exception {
+    Thread.sleep(millis);
+    return null;
+  }
+
+}


### PR DESCRIPTION
The RSC server currently listens indefinitely waiting for a Livy server
to connect to it. That can result in sessions that never go away and need
to be manually cleaned up when the Livy server crashes or is otherwise
uncleanly shut down.

So add a timeout, default 10 minutes, that allows sessions to shut themselves
down if the Livy server goes away and doesn't come back.