### PR TITLE
Add property to skip R tests in the whole build.

### DIFF
--- a/integration-test/src/main/scala/com/cloudera/livy/test/framework/BaseIntegrationTestSuite.scala
+++ b/integration-test/src/main/scala/com/cloudera/livy/test/framework/BaseIntegrationTestSuite.scala
@@ -90,6 +90,7 @@ abstract class BaseIntegrationTestSuite extends FunSuite with Matchers {
   /** Wrapper around test() to be used by SparkR tests. */
   protected def rtest(desc: String)(testFn: => Unit): Unit = {
     test(desc) {
+      assume(!sys.props.getOrElse("skipRTests", "false").toBoolean, "Skipping R tests.")
       assume(cluster.isRealSpark(), "SparkR tests require a real Spark installation.")
       assume(cluster.hasSparkR(), "Spark under test does not support R.")
       testFn

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,9 @@
     <execution.root>${user.dir}</execution.root>
     <spark.home>${execution.root}/dev/spark</spark.home>
 
+    <!-- Set this to "true" to skip R tests. -->
+    <skipRTests>false</skipRTests>
+
     <!--
       Properties for the copyright header style checks. Modules that use the ASF header
       should override the "copyright.header" property.
@@ -649,6 +652,7 @@
               <jacoco.args>${argLine}</jacoco.args>
               <spark.ui.enabled>false</spark.ui.enabled>
               <project.version>${project.version}</project.version>
+              <skipRTests>${skipRTests}</skipRTests>
             </systemProperties>
             <redirectTestOutputToFile>${test.redirectToFile}</redirectTestOutputToFile>
             <useFile>${test.redirectToFile}</useFile>
@@ -673,6 +677,7 @@
               <jacoco.args>${argLine}</jacoco.args>
               <spark.ui.enabled>false</spark.ui.enabled>
               <project.version>${project.version}</project.version>
+              <skipRTests>${skipRTests}</skipRTests>
             </systemProperties>
             <stdout>D</stdout>
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>

--- a/repl/src/test/scala/com/cloudera/livy/repl/SparkRInterpreterSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/SparkRInterpreterSpec.scala
@@ -21,10 +21,16 @@ package com.cloudera.livy.repl
 import org.apache.spark.SparkConf
 import org.json4s.{DefaultFormats, JValue}
 import org.json4s.JsonDSL._
+import org.scalatest._
 
 class SparkRInterpreterSpec extends BaseInterpreterSpec {
 
   implicit val formats = DefaultFormats
+
+  override protected def withFixture(test: NoArgTest): Outcome = {
+    assume(!sys.props.getOrElse("skipRTests", "false").toBoolean, "Skipping R tests.")
+    test()
+  }
 
   override def createInterpreter(): Interpreter = SparkRInterpreter(new SparkConf())
 

--- a/repl/src/test/scala/com/cloudera/livy/repl/SparkRSessionSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/SparkRSessionSpec.scala
@@ -24,8 +24,14 @@ import scala.concurrent.duration.Duration
 import org.apache.spark.SparkConf
 import org.json4s.Extraction
 import org.json4s.JsonAST.JValue
+import org.scalatest._
 
 class SparkRSessionSpec extends BaseSessionSpec {
+
+  override protected def withFixture(test: NoArgTest) = {
+    assume(!sys.props.getOrElse("skipRTests", "false").toBoolean, "Skipping R tests.")
+    test()
+  }
 
   override def createInterpreter(): Interpreter = SparkRInterpreter(new SparkConf())
 


### PR DESCRIPTION
Our internal build machines don't have R, so we need a way to disable
those tests in our CI jobs.