### PR TITLE
LIVY-154. Don't reuse connections in client-http.

### DIFF
--- a/client-http/pom.xml
+++ b/client-http/pom.xml
@@ -146,8 +146,12 @@
                   <shadedPattern>com.cloudera.livy.shaded.jackson</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>org.apache</pattern>
-                  <shadedPattern>com.cloudera.livy.shaded.apache</shadedPattern>
+                  <pattern>org.apache.commons</pattern>
+                  <shadedPattern>com.cloudera.livy.shaded.apache.commons</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.http</pattern>
+                  <shadedPattern>com.cloudera.livy.shaded.apache.http</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/client-http/src/main/java/com/cloudera/livy/client/http/LivyConnection.java
+++ b/client-http/src/main/java/com/cloudera/livy/client/http/LivyConnection.java
@@ -42,7 +42,7 @@ import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.entity.mime.content.FileBody;
-import org.apache.http.impl.DefaultConnectionReuseStrategy;
+import org.apache.http.impl.NoConnectionReuseStrategy;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -113,7 +113,7 @@ class LivyConnection {
       .evictExpiredConnections()
       .evictIdleConnections(config.getTimeAsMs(CONNECTION_IDLE_TIMEOUT), TimeUnit.MILLISECONDS)
       .setConnectionManager(new BasicHttpClientConnectionManager())
-      .setConnectionReuseStrategy(new DefaultConnectionReuseStrategy())
+      .setConnectionReuseStrategy(new NoConnectionReuseStrategy())
       .setDefaultRequestConfig(reqConfig)
       .setMaxConnTotal(1)
       .setDefaultCredentialsProvider(credsProvider)
@@ -178,8 +178,6 @@ class LivyConnection {
       Class<V> retType,
       String uri,
       Object... uriParams) throws Exception {
-    req.setURI(new URI(server.getScheme(), null, server.getHost(), server.getPort(),
-      uriRoot + String.format(uri, uriParams), null, null));
     req.setURI(new URI(server.getScheme(), null, server.getHost(), server.getPort(),
       uriRoot + String.format(uri, uriParams), null, null));
 

--- a/client-http/src/test/resources/log4j.properties
+++ b/client-http/src/test/resources/log4j.properties
@@ -33,5 +33,5 @@ log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%t: %m%n
 
 # Ignore messages below warning level from Jetty, because it's a bit verbose
-log4j.logger.org.spark-project.jetty=WARN
-org.spark-project.jetty.LEVEL=WARN
+log4j.logger.com.cloudera.livy.shaded=INFO
+log4j.logger.org.eclipse.jetty=WARN

--- a/integration-test/src/test/resources/log4j.properties
+++ b/integration-test/src/test/resources/log4j.properties
@@ -35,6 +35,7 @@ log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS} %t: %m
 
 # Silence 3rd party libraries.
 log4j.logger.com.cloudera.livy.rsc=INFO
+log4j.logger.com.cloudera.livy.shaded=INFO
 log4j.logger.com.decodified=WARN
 log4j.logger.com.ning.http=WARN
 log4j.logger.org.apache.hadoop=WARN

--- a/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
@@ -28,7 +28,7 @@ import org.apache.hadoop.security.SecurityUtil
 import org.eclipse.jetty.servlet.FilterHolder
 import org.scalatra.metrics.MetricsBootstrap
 import org.scalatra.metrics.MetricsSupportExtensions._
-import org.scalatra.servlet.ServletApiImplicits
+import org.scalatra.servlet.{MultipartConfig, ServletApiImplicits}
 
 import com.cloudera.livy._
 import com.cloudera.livy.server.batch.BatchSessionServlet
@@ -53,6 +53,9 @@ class LivyServer extends Logging {
     val livyConf = new LivyConf().loadFromFile("livy.conf")
     val host = livyConf.get(SERVER_HOST)
     val port = livyConf.getInt(SERVER_PORT)
+    val multipartConfig = MultipartConfig(
+        maxFileSize = Some(livyConf.getLong(LivyConf.FILE_UPLOAD_MAX_SIZE))
+      ).toMultipartConfigElement
 
     // Make sure the `spark-submit` program exists, otherwise much of livy won't work.
     testSparkHome(livyConf)
@@ -63,6 +66,12 @@ class LivyServer extends Logging {
     server.context.addEventListener(
       new ServletContextListener() with MetricsBootstrap with ServletApiImplicits {
 
+        private def mount(sc: ServletContext, servlet: Servlet, mappings: String*): Unit = {
+          val registration = sc.addServlet(servlet.getClass().getName(), servlet)
+          registration.addMapping(mappings: _*)
+          registration.setMultipartConfig(multipartConfig)
+        }
+
         override def contextDestroyed(sce: ServletContextEvent): Unit = {
 
         }
@@ -71,8 +80,8 @@ class LivyServer extends Logging {
           try {
             val context = sce.getServletContext()
             context.initParameters(org.scalatra.EnvironmentKey) = livyConf.get(ENVIRONMENT)
-            context.mount(new InteractiveSessionServlet(livyConf), "/sessions/*")
-            context.mount(new BatchSessionServlet(livyConf), "/batches/*")
+            mount(context, new InteractiveSessionServlet(livyConf), "/sessions/*")
+            mount(context, new BatchSessionServlet(livyConf), "/batches/*")
             context.mountMetricsAdminServlet("/")
           } catch {
             case e: Throwable =>

--- a/server/src/main/scala/com/cloudera/livy/server/WebServer.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/WebServer.scala
@@ -27,7 +27,6 @@ import org.eclipse.jetty.server._
 import org.eclipse.jetty.server.handler.{HandlerCollection, RequestLogHandler}
 import org.eclipse.jetty.servlet.{DefaultServlet, ServletContextHandler}
 import org.eclipse.jetty.util.ssl.SslContextFactory
-import org.scalatra.servlet.AsyncSupport
 
 import com.cloudera.livy.{LivyConf, Logging}
 
@@ -71,7 +70,6 @@ class WebServer(livyConf: LivyConf, var host: String, var port: Int) extends Log
 
   context.setContextPath("/")
   context.addServlet(classOf[DefaultServlet], "/")
-  context.setAttribute(AsyncSupport.ExecutionContextKey, ExecutionContext.global)
 
   val handlers = new HandlerCollection
   handlers.addHandler(context)


### PR DESCRIPTION
Either the current client code is doing something wrong when setting
up the http client, or there's a bug in the http client library, but
the result is that a connection ends up being closed while still in
use, causing errors when the client is talking to Livy.

While investigating that I found a couple of other issues that I also
fixed here:

- the client-http packaging was relocating too much stuff, which broke
  logging for the relocated classes, making it hard to debug things.

- the server wasn't configuring multipart request handling for servlets;
  fixing that means that we can't use asynchronous tasks, since Jetty
  (at least the version we use) does not allow that. Async tasks weren't
  really needed anyway, since they're either pretty quick or, otherwise,
  would block a thread in another shared thread pool anyway, so there
  wasn't really any gain.