### PR TITLE
Adding user jars to Scala interpreter's class path.

### DIFF
--- a/integration-test/src/main/scala/com/cloudera/livy/test/framework/BaseIntegrationTestSuite.scala
+++ b/integration-test/src/main/scala/com/cloudera/livy/test/framework/BaseIntegrationTestSuite.scala
@@ -105,9 +105,10 @@ abstract class BaseIntegrationTestSuite extends FunSuite with Matchers {
 
   class LivyRestClient(httpClient: AsyncHttpClient, livyEndpoint: String) {
 
-    def startSession(kind: Kind): Int = {
+    def startSession(kind: Kind, sparkConf: Map[String, String] = Map()): Int = {
       val requestBody = new CreateInteractiveRequest()
       requestBody.kind = kind
+      requestBody.conf = sparkConf
 
       val rep = httpClient.preparePost(s"$livyEndpoint/sessions")
         .setBody(mapper.writeValueAsString(requestBody))


### PR DESCRIPTION
Without this fix, if user imports a package using SparkConf: "spark.jars.packages": "com.databricks:spark-csv_2.10:1.4.0"
Then "import com.databricks.spark.csv._" in the interpreter, it will throw an error because the Scala interpreter cannot see the Spark CSV package.

Also made some small changes in the test framework.