### PR TITLE
LIVY-163. Fixed missing Python traceback in interactive mode.

### DIFF
--- a/repl/src/main/resources/fake_shell.py
+++ b/repl/src/main/resources/fake_shell.py
@@ -25,12 +25,14 @@ import traceback
 import StringIO
 import base64
 import os
+import re
 
 logging.basicConfig()
 LOG = logging.getLogger('fake_shell')
 
 global_dict = {}
 
+TOP_FRAME_REGEX = re.compile(r'\s*File "<stdin>".*in <module>')
 
 def execute_reply(status, content):
     return {
@@ -50,8 +52,12 @@ def execute_reply_ok(data):
 
 def execute_reply_error(exc_type, exc_value, tb):
     LOG.error('execute_reply', exc_info=True)
-    formatted_tb = filter(lambda t: __file__ not in t,
-                          traceback.format_exception(exc_type, exc_value, tb))
+    formatted_tb = traceback.format_exception(exc_type, exc_value, tb)
+    for i in range(len(formatted_tb)):
+        if TOP_FRAME_REGEX.match(formatted_tb[i]):
+            formatted_tb = formatted_tb[:1] + formatted_tb[i + 1:]
+            break
+
     return execute_reply('error', {
         'ename': unicode(exc_type.__name__),
         'evalue': unicode(exc_value),

--- a/repl/src/main/resources/fake_shell.py
+++ b/repl/src/main/resources/fake_shell.py
@@ -50,10 +50,12 @@ def execute_reply_ok(data):
 
 def execute_reply_error(exc_type, exc_value, tb):
     LOG.error('execute_reply', exc_info=True)
+    formatted_tb = filter(lambda t: __file__ not in t,
+                          traceback.format_exception(exc_type, exc_value, tb))
     return execute_reply('error', {
         'ename': unicode(exc_type.__name__),
         'evalue': unicode(exc_value),
-        'traceback': traceback.format_exception(exc_type, exc_value, tb, -1),
+        'traceback': formatted_tb,
     })
 
 

--- a/repl/src/test/scala/com/cloudera/livy/repl/PythonInterpreterSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/PythonInterpreterSpec.scala
@@ -21,7 +21,6 @@ package com.cloudera.livy.repl
 import org.apache.spark.SparkConf
 import org.json4s.{DefaultFormats, JValue}
 import org.json4s.JsonDSL._
-import org.scalatest.Outcome
 
 class PythonInterpreterSpec extends BaseInterpreterSpec {
 
@@ -150,6 +149,7 @@ class PythonInterpreterSpec extends BaseInterpreterSpec {
       "name 'x' is not defined",
       List(
         "Traceback (most recent call last):\n",
+        "  File \"<stdin>\", line 1, in <module>\n",
         "NameError: name 'x' is not defined\n"
       )
     ))
@@ -196,6 +196,7 @@ class PythonInterpreterSpec extends BaseInterpreterSpec {
       "name 'x' is not defined",
       List(
         "Traceback (most recent call last):\n",
+        "  File \"<stdin>\", line 1, in <module>\n",
         "NameError: name 'x' is not defined\n"
       )
     ))

--- a/repl/src/test/scala/com/cloudera/livy/repl/PythonInterpreterSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/PythonInterpreterSpec.scala
@@ -149,7 +149,6 @@ class PythonInterpreterSpec extends BaseInterpreterSpec {
       "name 'x' is not defined",
       List(
         "Traceback (most recent call last):\n",
-        "  File \"<stdin>\", line 1, in <module>\n",
         "NameError: name 'x' is not defined\n"
       )
     ))
@@ -196,7 +195,6 @@ class PythonInterpreterSpec extends BaseInterpreterSpec {
       "name 'x' is not defined",
       List(
         "Traceback (most recent call last):\n",
-        "  File \"<stdin>\", line 1, in <module>\n",
         "NameError: name 'x' is not defined\n"
       )
     ))

--- a/repl/src/test/scala/com/cloudera/livy/repl/PythonSessionSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/PythonSessionSpec.scala
@@ -18,9 +18,6 @@
 
 package com.cloudera.livy.repl
 
-import scala.concurrent.Await
-import scala.concurrent.duration.Duration
-
 import org.apache.spark.SparkConf
 import org.json4s.Extraction
 
@@ -135,6 +132,7 @@ class PythonSessionSpec extends BaseSessionSpec {
       "execution_count" -> 0,
       "traceback" -> List(
         "Traceback (most recent call last):\n",
+        "  File \"<stdin>\", line 1, in <module>\n",
         "NameError: name 'x' is not defined\n"
       ),
       "ename" -> "NameError",
@@ -158,6 +156,8 @@ class PythonSessionSpec extends BaseSessionSpec {
       "execution_count" -> 0,
       "traceback" -> List(
         "Traceback (most recent call last):\n",
+        "  File \"<stdin>\", line 3, in <module>\n",
+        "  File \"<stdin>\", line 2, in foo\n",
         "Exception\n"
       ),
       "ename" -> "Exception",

--- a/repl/src/test/scala/com/cloudera/livy/repl/PythonSessionSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/PythonSessionSpec.scala
@@ -132,7 +132,6 @@ class PythonSessionSpec extends BaseSessionSpec {
       "execution_count" -> 0,
       "traceback" -> List(
         "Traceback (most recent call last):\n",
-        "  File \"<stdin>\", line 1, in <module>\n",
         "NameError: name 'x' is not defined\n"
       ),
       "ename" -> "NameError",
@@ -144,10 +143,12 @@ class PythonSessionSpec extends BaseSessionSpec {
 
   it should "report an error if exception is thrown" in withSession { session =>
     val statement = session.execute(
-      """def foo():
-        |    raise Exception()
-        |foo()
-        |""".stripMargin)
+      """def func1():
+        |  raise Exception("message")
+        |def func2():
+        |  func1()
+        |func2()
+      """.stripMargin)
     statement.id should equal (0)
 
     val result = statement.result
@@ -156,12 +157,12 @@ class PythonSessionSpec extends BaseSessionSpec {
       "execution_count" -> 0,
       "traceback" -> List(
         "Traceback (most recent call last):\n",
-        "  File \"<stdin>\", line 3, in <module>\n",
-        "  File \"<stdin>\", line 2, in foo\n",
-        "Exception\n"
+        "  File \"<stdin>\", line 4, in func2\n",
+        "  File \"<stdin>\", line 2, in func1\n",
+        "Exception: message\n"
       ),
       "ename" -> "Exception",
-      "evalue" -> ""
+      "evalue" -> "message"
     ))
 
     result should equal (expectedResult)

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionSpec.scala
@@ -106,7 +106,6 @@ class InteractiveSessionSpec extends FunSpec with Matchers with BeforeAndAfterAl
         "evalue" -> "name 'x' is not defined",
         "traceback" -> List(
           "Traceback (most recent call last):\n",
-          "  File \"<stdin>\", line 1, in <module>\n",
           "NameError: name 'x' is not defined\n"
         )
       ))

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionSpec.scala
@@ -18,8 +18,6 @@
 
 package com.cloudera.livy.server.interactive
 
-import java.util.concurrent.TimeUnit
-
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.language.postfixOps
@@ -108,6 +106,7 @@ class InteractiveSessionSpec extends FunSpec with Matchers with BeforeAndAfterAl
         "evalue" -> "name 'x' is not defined",
         "traceback" -> List(
           "Traceback (most recent call last):\n",
+          "  File \"<stdin>\", line 1, in <module>\n",
           "NameError: name 'x' is not defined\n"
         )
       ))


### PR DESCRIPTION
- Also stripped the frame of fake_shell in the traceback. It should be transparent to users.