### PR TITLE
Batch submit to support setting python 2 or 3

### DIFF
--- a/server/src/main/scala/com/cloudera/livy/server/batch/BatchSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/batch/BatchSession.scala
@@ -55,7 +55,7 @@ class BatchSession(
     request.queue.foreach(builder.queue)
     request.name.foreach(builder.name)
     request.pyspark_python.foreach(builder.pysparkPython)
-    request.pyspark_python.foreach(builder.pysparkDriverPython) // Always set Driver also to cancel current setting.
+    request.pyspark_python.foreach(builder.pysparkDriverPython) // Always set to replace current.
     request.pyspark_driver_python.foreach(builder.pysparkDriverPython)
     builder.redirectOutput(Redirect.PIPE)
     builder.redirectErrorStream(true)

--- a/server/src/main/scala/com/cloudera/livy/server/batch/BatchSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/batch/BatchSession.scala
@@ -38,6 +38,10 @@ class BatchSession(
     val conf = prepareConf(request.conf, request.jars, request.files, request.archives,
       request.pyFiles)
     require(request.file != null, "File is required.")
+    require(!request.pyspark_python.exists(s => s != "python2" && s != "python3"),
+      "pyspark_python can only be set to python2 or python3.")
+    require(!request.pyspark_driver_python.exists(s => s != "python2" && s != "python3"),
+      "pyspark_driver_python can only be set to python2 or python3.")
 
     val builder = new SparkProcessBuilder(livyConf)
     builder.conf(conf)
@@ -50,6 +54,9 @@ class BatchSession(
     request.numExecutors.foreach(builder.numExecutors)
     request.queue.foreach(builder.queue)
     request.name.foreach(builder.name)
+    request.pyspark_python.foreach(builder.pysparkPython)
+    request.pyspark_python.foreach(builder.pysparkDriverPython) // Always set Driver also to cancel current setting.
+    request.pyspark_driver_python.foreach(builder.pysparkDriverPython)
     builder.redirectOutput(Redirect.PIPE)
     builder.redirectErrorStream(true)
 

--- a/server/src/main/scala/com/cloudera/livy/server/batch/CreateBatchRequest.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/batch/CreateBatchRequest.scala
@@ -36,5 +36,6 @@ class CreateBatchRequest {
   var queue: Option[String] = None
   var name: Option[String] = None
   var conf: Map[String, String] = Map()
-
+  var pyspark_python: Option[String] = None
+  var pyspark_driver_python: Option[String] = None
 }

--- a/server/src/main/scala/com/cloudera/livy/utils/SparkProcessBuilder.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/SparkProcessBuilder.scala
@@ -126,6 +126,14 @@ class SparkProcessBuilder(livyConf: LivyConf) extends Logging {
     this.conf("spark.executor.instances", numExecutors)
   }
 
+  def pysparkPython(pysparkPython: String): SparkProcessBuilder = {
+    this.env("PYSPARK_PYTHON", pysparkPython)
+  }
+
+  def pysparkDriverPython(pysparkDriverPython: String): SparkProcessBuilder = {
+    this.env("PYSPARK_DRIVER_PYTHON", pysparkDriverPython)
+  }
+
   def proxyUser(proxyUser: String): SparkProcessBuilder = {
     _proxyUser = Some(proxyUser)
     this
@@ -203,6 +211,7 @@ class SparkProcessBuilder(livyConf: LivyConf) extends Logging {
 
     for ((key, value) <- _env) {
       env.put(key, value)
+      info(s"with environment $key = $value")
     }
 
     _redirectOutput.foreach(pb.redirectOutput)

--- a/server/src/test/scala/com/cloudera/livy/server/batch/BatchSessionSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/batch/BatchSessionSpec.scala
@@ -43,7 +43,8 @@ class BatchSessionSpec
         """
           |print("hello world")
           |import os
-          |print("PYSPARK_PYTHON=" + (os.environ["PYSPARK_PYTHON"] if "PYSPARK_PYTHON" in os.environ else "not set."))
+          |print("PYSPARK_PYTHON=" +
+          |      (os.environ["PYSPARK_PYTHON"] if "PYSPARK_PYTHON" in os.environ else "not set."))
         """.stripMargin)
     } finally {
       writer.close()

--- a/server/src/test/scala/com/cloudera/livy/server/batch/CreateBatchRequestSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/batch/CreateBatchRequestSpec.scala
@@ -47,6 +47,8 @@ class CreateBatchRequestSpec extends FunSpec {
       assert(req.queue === None)
       assert(req.name === None)
       assert(req.conf === Map())
+      assert(req.pyspark_python === None)
+      assert(req.pyspark_driver_python === None)
     }
 
   }


### PR DESCRIPTION
Add ability to set Python version for batch submit. See: [https://issues.cloudera.org/browse/LIVY-159](https://issues.cloudera.org/browse/LIVY-159)

Added new fields to batch submit that echo the environment variables that are accepted by spark-submit; PYSPARK_PYTHON and PYSPARK_DRIVER_PYTHON. To prevent ability to execute arbitrary code via these, only "python2" and "python3" are permitted.