### PR TITLE
LIVY-164. Fixed and cleaned up stack trace return from SparkInterpreter.

### DIFF
--- a/repl/src/main/scala/com/cloudera/livy/repl/SparkInterpreter.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/SparkInterpreter.scala
@@ -39,6 +39,7 @@ object SparkInterpreter {
   private val EXCEPTION_STACK_TRACE_REGEX = """(.+?)\n((?:\tat .+?\n?)*)""".r
   private val KEEP_NEWLINE_REGEX = """(?=\n)""".r
   private val MAGIC_REGEX = "^%(\\w+)\\W*(.*)".r
+  val USER_CODE_FRAME_NAME = "<user code>"
 }
 
 /**
@@ -311,7 +312,7 @@ class SparkInterpreter(conf: SparkConf) extends Interpreter with Logging {
                         // Remove Interpreter frames
                         .take(interpreterFrameIdx)
                         // Replace weird internal class name
-                        .map(_.replace("$iwC$$iwC", "UserCode"))
+                        .map(_.replace("$iwC$$iwC", "<user code>"))
                       // TODO Proper translate line number in stack trace for $iwC$$iwC.
                     }
                     (ename.trim, traceback)

--- a/repl/src/main/scala/com/cloudera/livy/repl/SparkInterpreter.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/SparkInterpreter.scala
@@ -36,6 +36,8 @@ import org.json4s.JsonDSL._
 import com.cloudera.livy.Logging
 
 object SparkInterpreter {
+  private val EXCEPTION_STACK_TRACE_REGEX = """(.+?)\n((?:\tat .+?\n?)*)""".r
+  private val KEEP_NEWLINE_REGEX = """(?=\n)""".r
   private val MAGIC_REGEX = "^%(\\w+)\\W*(.*)".r
 }
 
@@ -298,7 +300,26 @@ class SparkInterpreter(conf: SparkConf) extends Interpreter with Logging {
                 TEXT_PLAIN -> readStdout()
               )
             case Results.Incomplete => Interpreter.ExecuteIncomplete()
-            case Results.Error => Interpreter.ExecuteError("Error", readStdout())
+            case Results.Error =>
+              def parseStdout(stdout: String): (String, Seq[String]) = {
+                stdout match {
+                  case EXCEPTION_STACK_TRACE_REGEX(ename, tracebackLines) =>
+                    var traceback = KEEP_NEWLINE_REGEX.pattern.split(tracebackLines)
+                    val interpreterFrameIdx = traceback.indexWhere(_.contains("$iwC$$iwC.<init>"))
+                    if (interpreterFrameIdx >= 0) {
+                      traceback = traceback
+                        // Remove Interpreter frames
+                        .take(interpreterFrameIdx)
+                        // Replace weird internal class name
+                        .map(_.replace("$iwC$$iwC", "UserCode"))
+                      // TODO Proper translate line number in stack trace for $iwC$$iwC.
+                    }
+                    (ename.trim, traceback)
+                  case _ => (stdout, Seq.empty)
+                }
+              }
+              val (ename, traceback) = parseStdout(readStdout())
+              Interpreter.ExecuteError("Error", ename, traceback)
           }
         }
     }

--- a/repl/src/test/scala/com/cloudera/livy/repl/SparkSessionSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/SparkSessionSpec.scala
@@ -135,7 +135,9 @@ class SparkSessionSpec extends BaseSessionSpec {
 
     val traceback = resultMap("traceback").extract[Seq[String]]
     traceback should have length 1
-    traceback(0) should fullyMatch regex """\tat UserCode.func1\(<console>:\d+\)"""
+    val frameRegex = """\tat """ + SparkInterpreter.USER_CODE_FRAME_NAME +
+      """\.func1\(<console>:\d+\)"""
+    traceback(0) should fullyMatch regex frameRegex
   }
 
   it should "access the spark context" in withSession { session =>
@@ -177,7 +179,6 @@ class SparkSessionSpec extends BaseSessionSpec {
     statement.id should equal (0)
 
     val result = statement.result
-
 
     val expectedResult = Extraction.decompose(Map(
       "status" -> "ok",


### PR DESCRIPTION
- Moved stack trace from "evalue" to "traceback".
- Filtered out internal frames from stack trace.