### PR TITLE
LIVY-174. CSRF protection in livy rest api

### DIFF
--- a/client-http/src/main/java/com/cloudera/livy/client/http/LivyConnection.java
+++ b/client-http/src/main/java/com/cloudera/livy/client/http/LivyConnection.java
@@ -33,11 +33,7 @@ import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.methods.*;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
@@ -180,7 +176,11 @@ class LivyConnection {
       Object... uriParams) throws Exception {
     req.setURI(new URI(server.getScheme(), null, server.getHost(), server.getPort(),
       uriRoot + String.format(uri, uriParams), null, null));
-
+    // It is no harm to set X-Requested-By when csrf protection is disabled.
+    if (req instanceof HttpPost || req instanceof HttpDelete || req instanceof HttpPut
+            || req instanceof  HttpPatch) {
+      req.addHeader("X-Requested-By", "livy");
+    }
     try (CloseableHttpResponse res = client.execute(req)) {
       int status = (res.getStatusLine().getStatusCode() / 100) * 100;
       HttpEntity entity = res.getEntity();

--- a/conf/livy.conf
+++ b/conf/livy.conf
@@ -38,3 +38,7 @@
 # default it's empty, meaning users can only reference remote URIs when starting their
 # sessions.
 # livy.file.local-dir-whitelist =
+
+# Whether to enable csrf protection, by default it is false. If it is enabled, client should add
+# http-header "X-Requested-By" in request if the http method is POST/DELETE/PATCH.
+# livy.server.csrf_protection.enabled =

--- a/conf/livy.conf
+++ b/conf/livy.conf
@@ -40,5 +40,5 @@
 # livy.file.local-dir-whitelist =
 
 # Whether to enable csrf protection, by default it is false. If it is enabled, client should add
-# http-header "X-Requested-By" in request if the http method is POST/DELETE/PATCH.
+# http-header "X-Requested-By" in request if the http method is POST/DELETE/PUT/PATCH.
 # livy.server.csrf_protection.enabled =

--- a/server/src/main/scala/com/cloudera/livy/server/CsrfFilter.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/CsrfFilter.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.cloudera.livy.server
+
+import javax.servlet._
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
+
+
+class CsrfFilter extends Filter {
+
+  val METHODS_TO_IGNORE = Set("GET", "OPTIONS", "HEAD");
+
+  val HEADER_NAME = "X-Requested-By";
+
+  override def init(filterConfig: FilterConfig): Unit = {}
+
+  override def doFilter(request: ServletRequest,
+                        response: ServletResponse,
+                        chain: FilterChain): Unit = {
+    val httpRequest = request.asInstanceOf[HttpServletRequest]
+
+    if (!METHODS_TO_IGNORE.contains(httpRequest.getMethod)
+      && httpRequest.getHeader(HEADER_NAME) == null) {
+      response.asInstanceOf[HttpServletResponse].sendError(HttpServletResponse.SC_BAD_REQUEST,
+        "Missing Required Header for CSRF protection.")
+    } else {
+      chain.doFilter(request, response)
+    }
+  }
+
+  override def destroy(): Unit = {}
+}
+


### PR DESCRIPTION
Add CSRFFilter in livy server. By default it is false, so it won't bring incomptability and break the existing application. 