### PR TITLE
LIVY-177. Added unicode support output for PySpark session.

### DIFF
--- a/repl/src/test/scala/com/cloudera/livy/repl/PythonInterpreterSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/PythonInterpreterSpec.scala
@@ -200,4 +200,18 @@ class PythonInterpreterSpec extends BaseInterpreterSpec {
     ))
   }
 
+  // Scalastyle is treating unicode escape as non ascii characters. Turn off the check.
+  // scalastyle:off non.ascii.character.disallowed
+  it should "print unicode correctly" in withInterpreter { intp =>
+    intp.execute("print(u\"\u263A\")") should equal(Interpreter.ExecuteSuccess(
+      TEXT_PLAIN -> "\u263A"
+    ))
+    intp.execute("""print(u"\u263A")""") should equal(Interpreter.ExecuteSuccess(
+      TEXT_PLAIN -> "\u263A"
+    ))
+    intp.execute("""print("\xE2\x98\xBA")""") should equal(Interpreter.ExecuteSuccess(
+      TEXT_PLAIN -> "\u263A"
+    ))
+  }
+  // scalastyle:on non.ascii.character.disallowed
 }


### PR DESCRIPTION
fake_shell is using cStringIO to capture stdout and stderr.
cStringIO doesn't support unicode. Replacing it with io.StringIO.
io.StringIO supports unicode only, convert every output to utf8.