### PR TITLE
LIVY-157. Specifying Spark master and Spark deploy mode for Livy sess…

### DIFF
--- a/conf/livy.conf
+++ b/conf/livy.conf
@@ -10,6 +10,12 @@
 # What port to start the server on.
 ## livy.server.port = 8998
 
+# What spark master Livy sessions should use.
+## livy.spark.master = local
+
+# What spark deploy mode Livy sessions should use.
+## livy.spark.deployMode =
+
 # Time in milliseconds on how long Livy will wait before timing out an idle session.
 ## livy.server.session.timeout = 1h
 

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -38,7 +38,6 @@
       system.
     -->
     <cluster.spec>default</cluster.spec>
-    <skipITs>${skipTests}</skipITs>
   </properties>
 
   <dependencies>
@@ -101,6 +100,12 @@
       <groupId>com.ning</groupId>
       <artifactId>async-http-client</artifactId>
       <version>1.9.38</version>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.5</version>
     </dependency>
 
     <dependency>
@@ -201,6 +206,20 @@
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
+        <executions>
+          <!-- Unbind integration test from test phase and bind it to integration-test phase -->
+          <execution>
+            <id>test</id>
+            <phase>none</phase>
+          </execution>
+          <execution>
+            <id>integration-test</id>
+            <phase>integration-test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
         <configuration>
           <environmentVariables>
             <LIVY_HOME>${execution.root}</LIVY_HOME>

--- a/integration-test/src/main/scala/com/cloudera/livy/test/framework/BaseIntegrationTestSuite.scala
+++ b/integration-test/src/main/scala/com/cloudera/livy/test/framework/BaseIntegrationTestSuite.scala
@@ -46,7 +46,7 @@ object BaseIntegrationTestSuite {
   val ERROR = "error"
 }
 
-abstract class BaseIntegrationTestSuite extends FunSuite with Matchers {
+abstract class BaseIntegrationTestSuite extends FunSuite with Matchers with BeforeAndAfter {
   import BaseIntegrationTestSuite._
 
   var cluster: Cluster = _
@@ -62,7 +62,7 @@ abstract class BaseIntegrationTestSuite extends FunSuite with Matchers {
   protected val testLib = sys.props("java.class.path")
     .split(File.pathSeparator)
     .find(new File(_).getName().startsWith("livy-test-lib-"))
-    .get
+    .getOrElse(throw new Exception(s"Cannot find test lib in ${sys.props("java.class.path")}"))
 
   protected def waitTillSessionIdle(sessionId: Int): Unit = {
     eventually(timeout(1 minute), interval(100 millis)) {
@@ -97,10 +97,15 @@ abstract class BaseIntegrationTestSuite extends FunSuite with Matchers {
     }
   }
 
-  test("initialize test cluster") {
+  before {
     cluster = Cluster.get()
     httpClient = new AsyncHttpClient()
     livyClient = new LivyRestClient(httpClient, livyEndpoint)
+  }
+
+  test("initialize test cluster") {
+    // Empty test case to separate time spent on creating cluster in before() and executing actual
+    // test cases.
   }
 
   class LivyRestClient(httpClient: AsyncHttpClient, livyEndpoint: String) {

--- a/rsc/src/main/java/com/cloudera/livy/rsc/ContextLauncher.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/ContextLauncher.java
@@ -63,6 +63,7 @@ class ContextLauncher {
   private static final Logger LOG = LoggerFactory.getLogger(ContextLauncher.class);
   private static final AtomicInteger CHILD_IDS = new AtomicInteger();
 
+  private static final String SPARK_DEPLOY_MODE = "spark.submit.deployMode";
   private static final String SPARK_JARS_KEY = "spark.jars";
   private static final String SPARK_ARCHIVES_KEY = "spark.yarn.dist.archives";
   private static final String SPARK_HOME_ENV = "SPARK_HOME";
@@ -199,6 +200,13 @@ class ContextLauncher {
       return new ChildProcess(conf, promise, child, confFile);
     } else {
       final SparkLauncher launcher = new SparkLauncher();
+
+      // Spark 1.x does not support specifying deploy mode in conf and needs special handling.
+      String deployMode = conf.get(SPARK_DEPLOY_MODE);
+      if (deployMode != null) {
+        launcher.setDeployMode(deployMode);
+      }
+
       launcher.setSparkHome(System.getenv(SPARK_HOME_ENV));
       launcher.setAppResource("spark-internal");
       launcher.setPropertiesFile(confFile.getAbsolutePath());

--- a/server/src/main/scala/com/cloudera/livy/LivyConf.scala
+++ b/server/src/main/scala/com/cloudera/livy/LivyConf.scala
@@ -20,7 +20,6 @@ package com.cloudera.livy
 
 import java.io.File
 import java.lang.{Boolean => JBoolean, Long => JLong}
-import java.nio.file.Files
 
 import org.apache.hadoop.conf.Configuration
 
@@ -39,15 +38,17 @@ object LivyConf {
 
   val TEST_MODE = ClientConf.TEST_MODE
 
-  val SESSION_FACTORY = Entry("livy.server.session.factory", "process")
   val SPARK_HOME = Entry("livy.server.spark-home", null)
+  val LIVY_SPARK_MASTER = Entry("livy.spark.master", "local")
+  val LIVY_SPARK_DEPLOY_MODE = Entry("livy.spark.deployMode", null)
   val IMPERSONATION_ENABLED = Entry("livy.impersonation.enabled", false)
   val FILE_UPLOAD_MAX_SIZE = Entry("livy.file.upload.max.size", 100L * 1024 * 1024)
   val SUPERUSERS = Entry("livy.superusers", null)
-  val SPARKR_PACKAGE = Entry("livy.repl.sparkr.package", null)
   val SESSION_STAGING_DIR = Entry("livy.session.staging-dir", null)
   val LOCAL_FS_WHITELIST = Entry("livy.file.local-dir-whitelist", null)
 
+  val SPARK_MASTER = "spark.master"
+  val SPARK_DEPLOY_MODE = "spark.submit.deployMode"
   val SPARK_JARS = "spark.jars"
   val SPARK_FILES = "spark.files"
   val SPARK_ARCHIVES = "spark.yarn.dist.archives"
@@ -113,8 +114,14 @@ class LivyConf(loadDefaults: Boolean) extends ClientConf[LivyConf](null) {
     this
   }
 
+  /** Return the spark deploy mode Livy sessions should use. */
+  def sparkDeployMode(): Option[String] = Option(get(LIVY_SPARK_DEPLOY_MODE)).filterNot(_.isEmpty)
+
   /** Return the location of the spark home directory */
   def sparkHome(): Option[String] = Option(get(SPARK_HOME)).orElse(sys.env.get("SPARK_HOME"))
+
+  /** Return the spark master Livy sessions should use. */
+  def sparkMaster(): String = get(LIVY_SPARK_MASTER)
 
   /** Return the path to the spark-submit executable. */
   def sparkSubmit(): String = {

--- a/server/src/main/scala/com/cloudera/livy/server/batch/BatchSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/batch/BatchSession.scala
@@ -41,6 +41,7 @@ class BatchSession(
 
     val builder = new SparkProcessBuilder(livyConf)
     builder.conf(conf)
+
     proxyUser.foreach(builder.proxyUser)
     request.className.foreach(builder.className)
     request.driverMemory.foreach(builder.driverMemory)
@@ -50,6 +51,10 @@ class BatchSession(
     request.numExecutors.foreach(builder.numExecutors)
     request.queue.foreach(builder.queue)
     request.name.foreach(builder.name)
+
+    // Spark 1.x does not support specifying deploy mode in conf and needs special handling.
+    livyConf.sparkDeployMode().foreach(builder.deployMode)
+
     builder.redirectOutput(Redirect.PIPE)
     builder.redirectErrorStream(true)
 

--- a/server/src/main/scala/com/cloudera/livy/sessions/Session.scala
+++ b/server/src/main/scala/com/cloudera/livy/sessions/Session.scala
@@ -222,7 +222,10 @@ abstract class Session(val id: Int, val owner: String, val livyConf: LivyConf) e
       }
     }
 
-    conf ++ merged
+    val masterConfList = Map(LivyConf.SPARK_MASTER -> livyConf.sparkMaster()) ++
+      livyConf.sparkDeployMode().map(LivyConf.SPARK_DEPLOY_MODE -> _).toMap
+
+    conf ++ masterConfList ++ merged
   }
 
   private def getStagingDir(fs: FileSystem): Path = synchronized {

--- a/server/src/test/scala/com/cloudera/livy/sessions/SessionSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/sessions/SessionSpec.scala
@@ -66,7 +66,7 @@ class SessionSpec extends FunSuite {
     val session = new MockSession(0, null, conf)
 
     // Test baseline.
-    assert(session.prepareConf(Map(), Nil, Nil, Nil, Nil) === Map())
+    assert(session.prepareConf(Map(), Nil, Nil, Nil, Nil) === Map("spark.master" -> "local"))
 
     // Test validations.
     intercept[IllegalArgumentException] {


### PR DESCRIPTION
…ion recovery.

Added 2 new Livy configs to specify master and deploy mode for Livy sessions:
- livy.spark.master (Default is local)
- livy.spark.deployMode (Default left empty)

Session.prepareConf() add them to SparkConf as spark.master and spark.submit.deployMode. Spark 2.0- does not support spark.submit.deployMode. ContextLauncher and BatchSession will map it back to spark-submit argument.

Also fixed issues in integration test framework:
- Moved integration test from maven test phase to maven integration test phase.
- Cleanup files and processes from previous test run before running the test.
- Added ability to set LivyConf.
- Write MiniLivyServer's endpoint to new file serverUrl.conf instead of livy.conf.