### PR TITLE
Fix integration tests on real clusters.

### DIFF
--- a/integration-test/src/main/scala/com/cloudera/livy/test/framework/MiniCluster.scala
+++ b/integration-test/src/main/scala/com/cloudera/livy/test/framework/MiniCluster.scala
@@ -34,7 +34,7 @@ import org.apache.hadoop.yarn.server.MiniYARNCluster
 import org.apache.spark.launcher.SparkLauncher
 import org.scalatest.concurrent.Eventually._
 
-import com.cloudera.livy.Logging
+import com.cloudera.livy.{LivyConf, Logging}
 import com.cloudera.livy.server.LivyServer
 
 private class MiniClusterConfig(val config: Map[String, String]) {
@@ -144,8 +144,8 @@ object MiniLivyMain extends MiniClusterBase {
 
   def start(config: MiniClusterConfig, configPath: String): Unit = {
     val livyConf = Map(
-      "livy.spark.master" -> "yarn",
-      "livy.spark.deployMode" -> "cluster")
+      LivyConf.LIVY_SPARK_MASTER.key -> "yarn",
+      LivyConf.LIVY_SPARK_DEPLOY_MODE.key -> "cluster")
     saveProperties(livyConf, new File(configPath + "/livy.conf"))
 
     val server = new LivyServer()

--- a/integration-test/src/main/scala/com/cloudera/livy/test/framework/RealCluster.scala
+++ b/integration-test/src/main/scala/com/cloudera/livy/test/framework/RealCluster.scala
@@ -36,14 +36,14 @@ import org.apache.hadoop.fs.permission.FsPermission
 import org.apache.hadoop.security.UserGroupInformation
 import org.scalatest.concurrent.Eventually._
 
-import com.cloudera.livy.Logging
+import com.cloudera.livy.{LivyConf, Logging}
 
 private class RealClusterConfig(config: Map[String, String]) {
   val ip = config("ip")
 
   val sshLogin = config("ssh.login")
   val sshPubKey = config("ssh.pubkey")
-  val livyPort = config.getOrElse("livy.port", "8998").toInt
+  val livyPort = config.getOrElse(LivyConf.SERVER_PORT.key, "8998").toInt
   val livyClasspath = config.getOrElse("livy.classpath", "")
 
   val deployLivy = config.getOrElse("deploy-livy", "true").toBoolean
@@ -215,8 +215,9 @@ class RealCluster(_config: Map[String, String])
     val livyConf = Map(
       "livy.server.port" -> config.livyPort.toString,
       // "livy.server.recovery.mode=local",
-      "livy.environment" -> "development"
-    )
+      "livy.environment" -> "development",
+      LivyConf.LIVY_SPARK_MASTER.key -> "yarn",
+      LivyConf.LIVY_SPARK_DEPLOY_MODE.key -> "cluster")
     val livyConfFile = File.createTempFile("livy.", ".properties")
     saveProperties(livyConf, livyConfFile)
     upload(livyConfFile.getAbsolutePath(), s"$livyHomePath/conf/livy.conf")

--- a/server/src/main/scala/com/cloudera/livy/LivyConf.scala
+++ b/server/src/main/scala/com/cloudera/livy/LivyConf.scala
@@ -41,11 +41,24 @@ object LivyConf {
   val SPARK_HOME = Entry("livy.server.spark-home", null)
   val LIVY_SPARK_MASTER = Entry("livy.spark.master", "local")
   val LIVY_SPARK_DEPLOY_MODE = Entry("livy.spark.deployMode", null)
-  val IMPERSONATION_ENABLED = Entry("livy.impersonation.enabled", false)
-  val FILE_UPLOAD_MAX_SIZE = Entry("livy.file.upload.max.size", 100L * 1024 * 1024)
-  val SUPERUSERS = Entry("livy.superusers", null)
+
   val SESSION_STAGING_DIR = Entry("livy.session.staging-dir", null)
+  val FILE_UPLOAD_MAX_SIZE = Entry("livy.file.upload.max.size", 100L * 1024 * 1024)
   val LOCAL_FS_WHITELIST = Entry("livy.file.local-dir-whitelist", null)
+
+  val ENVIRONMENT = Entry("livy.environment", "production")
+
+  val SERVER_HOST = Entry("livy.server.host", "0.0.0.0")
+  val SERVER_PORT = Entry("livy.server.port", 8998)
+  val CSRF_PROTECTION = LivyConf.Entry("livy.server.csrf_protection.enabled", false)
+
+  val IMPERSONATION_ENABLED = Entry("livy.impersonation.enabled", false)
+  val SUPERUSERS = Entry("livy.superusers", null)
+
+  val AUTH_TYPE = Entry("livy.server.auth.type", null)
+  val KERBEROS_PRINCIPAL = Entry("livy.server.auth.kerberos.principal", null)
+  val KERBEROS_KEYTAB = Entry("livy.server.auth.kerberos.keytab", null)
+  val KERBEROS_NAME_RULES = Entry("livy.server.auth.kerberos.name_rules", "DEFAULT")
 
   val SPARK_MASTER = "spark.master"
   val SPARK_DEPLOY_MODE = "spark.submit.deployMode"

--- a/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
@@ -36,15 +36,7 @@ import com.cloudera.livy.util.LineBufferedProcess
 
 class LivyServer extends Logging {
 
-  private val ENVIRONMENT = LivyConf.Entry("livy.environment", "production")
-  private val SERVER_HOST = LivyConf.Entry("livy.server.host", "0.0.0.0")
-  private val SERVER_PORT = LivyConf.Entry("livy.server.port", 8998)
-  private val AUTH_TYPE = LivyConf.Entry("livy.server.auth.type", null)
-  private val KERBEROS_PRINCIPAL = LivyConf.Entry("livy.server.auth.kerberos.principal", null)
-  private val KERBEROS_KEYTAB = LivyConf.Entry("livy.server.auth.kerberos.keytab", null)
-  private val KERBEROS_NAME_RULES = LivyConf.Entry("livy.server.auth.kerberos.name_rules",
-    "DEFAULT")
-  private val CSRF_PROTECTION = LivyConf.Entry("livy.server.csrf_protection.enabled", false)
+  import LivyConf._
 
   private var server: WebServer = _
   private var _serverUrl: Option[String] = None


### PR DESCRIPTION
Spark was being run in local mode after recent changes, which made a few
tests fail. So update things to run in yarn-cluster mode, and also reuse
existing constants in a few places.