### PR TITLE
LIVY-183. Deploy livy-main pom to maven repo.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -30,7 +30,6 @@
 
   <properties>
     <copyright.header>${asf.copyright.header}</copyright.header>
-    <skipDeploy>false</skipDeploy>
   </properties>
 
   <dependencies>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -32,6 +32,7 @@
   <properties>
     <assembly.name>livy-server-${project.version}</assembly.name>
     <assembly.format>zip</assembly.format>
+    <skipDeploy>true</skipDeploy>
   </properties>
 
   <profiles>

--- a/client-common/pom.xml
+++ b/client-common/pom.xml
@@ -29,10 +29,6 @@
   <version>0.3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
-  <properties>
-    <skipDeploy>false</skipDeploy>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>com.cloudera.livy</groupId>

--- a/client-http/pom.xml
+++ b/client-http/pom.xml
@@ -29,10 +29,6 @@
   <version>0.3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
-  <properties>
-    <skipDeploy>false</skipDeploy>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>com.cloudera.livy</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -31,6 +31,10 @@
   <version>0.3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
+  <properties>
+    <skipDeploy>true</skipDeploy>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.cloudera.livy</groupId>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -38,6 +38,7 @@
       system.
     -->
     <cluster.spec>default</cluster.spec>
+    <skipDeploy>true</skipDeploy>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -78,10 +78,10 @@
     -->
 
     <!--
-      By default artifacts are not deployed. Artifacts that should be deployed to a maven
-      repo should override the "skipDeploy" property in their pom.
+      Artifacts that should not be deployed to a maven repo should override the "skipDeploy"
+      property in their pom.
     -->
-    <skipDeploy>true</skipDeploy>
+    <skipDeploy>false</skipDeploy>
 
     <asf.copyright.header><![CDATA[/*
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -31,6 +31,10 @@
     <version>0.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
+    <properties>
+        <skipDeploy>true</skipDeploy>
+    </properties>
+
     <dependencies>
 
         <dependency>

--- a/rsc/pom.xml
+++ b/rsc/pom.xml
@@ -31,7 +31,6 @@
 
   <properties>
     <copyright.header>${asf.copyright.header}</copyright.header>
-    <skipDeploy>false</skipDeploy>
   </properties>
 
   <dependencies>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -31,6 +31,10 @@
     <version>0.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
+    <properties>
+        <skipDeploy>true</skipDeploy>
+    </properties>
+
     <dependencies>
 
         <dependency>

--- a/test-lib/pom.xml
+++ b/test-lib/pom.xml
@@ -29,6 +29,10 @@
   <version>0.3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
+  <properties>
+    <skipDeploy>true</skipDeploy>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.cloudera.livy</groupId>


### PR DESCRIPTION
This requires changing the default value of "skipDeploy" since it
cannot be overridden just for the root pom. Ah, maven.