### PR TITLE
LIVY-185. Update jacoco and generate aggregate reports.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ before_install:
   - pip install --user codecov
 
 after_success:
-  - codecov
+  - bash <(curl -s https://codecov.io/bash)

--- a/client-common/src/main/java/com/cloudera/livy/client/common/TestUtils.java
+++ b/client-common/src/main/java/com/cloudera/livy/client/common/TestUtils.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.client.common;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.cloudera.livy.annotations.Private;
+
+/**
+ * Utility methods used by Livy tests.
+ */
+@Private
+public class TestUtils {
+
+  /**
+   * Returns JVM arguments that enable jacoco on a process to be run. The returned arguments
+   * create a new, unique output file in the same directory referenced by the "jacoco.args"
+   * system property.
+   *
+   * @return JVM arguments, or null.
+   */
+  public static String getJacocoArgs() {
+    String jacocoArgs = System.getProperty("jacoco.args");
+    if (jacocoArgs == null) {
+      return null;
+    }
+
+    Pattern p = Pattern.compile("(.+?destfile=)(.+?)(,.+)?");
+    Matcher m = p.matcher(jacocoArgs);
+    if (!m.matches()) {
+      return null;
+    }
+
+    String fileName = new File(m.group(2)).getName();
+    File outputDir = new File(m.group(2)).getParentFile();
+
+    File newFile;
+    while (true) {
+      int newId = outputDir.list().length;
+      newFile = new File(outputDir, "jacoco-" + newId + ".exec");
+      try {
+        Files.newOutputStream(newFile.toPath(), StandardOpenOption.CREATE_NEW).close();
+        break;
+      } catch (IOException ioe) {
+        // Try again.
+      }
+    }
+
+    StringBuilder newArgs = new StringBuilder();
+    newArgs.append(m.group(1));
+    newArgs.append(newFile.getAbsolutePath());
+    if (m.group(3) != null) {
+      newArgs.append(m.group(3));
+    }
+
+    return newArgs.toString();
+  }
+
+}

--- a/client-common/src/test/java/com/cloudera/livy/client/common/TestTestUtils.java
+++ b/client-common/src/test/java/com/cloudera/livy/client/common/TestTestUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.client.common;
+
+import java.nio.ByteBuffer;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class TestTestUtils {
+
+  @Test
+  public void testJacocoArgs() {
+    String args1 = TestUtils.getJacocoArgs();
+    String expected1 = System.getProperty("jacoco.args").replace("main.exec", "jacoco-1.exec");
+    assertEquals(expected1, args1);
+
+    String args2 = TestUtils.getJacocoArgs();
+    String expected2 = System.getProperty("jacoco.args").replace("main.exec", "jacoco-2.exec");
+    assertEquals(expected2, args2);
+  }
+
+}

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to Cloudera, Inc. under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  Cloudera, Inc. licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.cloudera.livy</groupId>
+    <artifactId>livy-main</artifactId>
+    <relativePath>../pom.xml</relativePath>
+    <version>0.3.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>livy-coverage-report</artifactId>
+  <version>0.3.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>livy-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>livy-client-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>livy-client-http</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>livy-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>livy-repl</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>livy-rsc</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>livy-server</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>livy-scala-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>livy-integration-test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>livy-test-lib</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>jacoco-report</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>report-aggregate</goal>
+            </goals>
+            <configuration>
+              <dataFileIncludes>
+                <dataFileInclude>target/jacoco/*.exec</dataFileInclude>
+              </dataFileIncludes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/integration-test/src/main/scala/com/cloudera/livy/test/framework/BaseIntegrationTestSuite.scala
+++ b/integration-test/src/main/scala/com/cloudera/livy/test/framework/BaseIntegrationTestSuite.scala
@@ -65,7 +65,7 @@ abstract class BaseIntegrationTestSuite extends FunSuite with Matchers with Befo
     .getOrElse(throw new Exception(s"Cannot find test lib in ${sys.props("java.class.path")}"))
 
   protected def waitTillSessionIdle(sessionId: Int): Unit = {
-    eventually(timeout(1 minute), interval(100 millis)) {
+    eventually(timeout(2 minutes), interval(100 millis)) {
       val curState = livyClient.getSessionStatus(sessionId)
       assert(curState === SessionState.Idle().toString)
     }

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,6 @@
         <enabled>false</enabled>
       </snapshots>
     </repository>
-
   </repositories>
 
   <modules>
@@ -174,6 +173,7 @@
     <module>client-common</module>
     <module>client-http</module>
     <module>core</module>
+    <module>coverage</module>
     <module>repl</module>
     <module>rsc</module>
     <module>scala-api</module>
@@ -785,7 +785,7 @@
             <configuration>
               <target>
                 <delete file="${project.build.directory}/unit-tests.log" quiet="true" />
-                <delete file="${project.build.directory}/jacoco.exec" quiet="true" />
+                <delete dir="${project.build.directory}/jacoco" quiet="true" />
                 <delete dir="${project.build.directory}/tmp" quiet="true" />
               </target>
             </configuration>
@@ -918,7 +918,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.7.5.201505241946</version>
+        <version>0.7.7.201606060606</version>
         <executions>
           <execution>
             <goals>
@@ -928,30 +928,6 @@
               <append>true</append>
               <destFile>${project.build.directory}/jacoco/main.exec</destFile>
             </configuration>
-          </execution>
-          <execution>
-            <id>merge-reports</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>merge</goal>
-            </goals>
-            <configuration>
-              <fileSets>
-                <fileSet>
-                  <directory>${project.build.directory}/jacoco</directory>
-                  <includes>
-                    <include>*.exec</include>
-                  </includes>
-                </fileSet>
-              </fileSets>
-            </configuration>
-          </execution>
-          <execution>
-            <id>report</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>report</goal>
-            </goals>
           </execution>
         </executions>
       </plugin>

--- a/rsc/src/main/java/com/cloudera/livy/rsc/ContextLauncher.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/ContextLauncher.java
@@ -48,6 +48,7 @@ import org.apache.spark.launcher.SparkLauncher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.cloudera.livy.client.common.TestUtils;
 import com.cloudera.livy.rsc.driver.RSCDriverBootstrapper;
 import com.cloudera.livy.rsc.rpc.Rpc;
 import com.cloudera.livy.rsc.rpc.RpcDispatcher;
@@ -173,13 +174,14 @@ class ContextLauncher {
     // of "small" Java processes lingering on the Livy server node.
     conf.set("spark.yarn.submit.waitAppCompletion", "false");
 
-    // For testing; propagate jacoco settings so that we also do coverage analysis
-    // on the launched driver. We replace the name of the main file ("main.exec")
-    // so that we don't end up fighting with the main test launcher.
-    String jacocoArgs = System.getProperty("jacoco.args");
-    if (jacocoArgs != null) {
-      jacocoArgs = jacocoArgs.replace("main.exec", "child.exec");
-      merge(conf, SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS, jacocoArgs, " ");
+    if (!conf.getBoolean(CLIENT_IN_PROCESS)) {
+      // For testing; propagate jacoco settings so that we also do coverage analysis
+      // on the launched driver. We replace the name of the main file ("main.exec")
+      // so that we don't end up fighting with the main test launcher.
+      String jacocoArgs = TestUtils.getJacocoArgs();
+      if (jacocoArgs != null) {
+        merge(conf, SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS, jacocoArgs, " ");
+      }
     }
 
     final File confFile = writeConfToFile(conf);


### PR DESCRIPTION
To account for coverage added by integration tests, generate aggregate reports,
and hook up the jacoco command line arguments to the Livy server run as part of
the integration tests.