### PR TITLE
LIVY-189. Rest api for getting all sessions should order sessions by id

### DIFF
--- a/server/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
+++ b/server/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
@@ -36,7 +36,7 @@ class SessionManager[S <: Session](val livyConf: LivyConf) extends Logging {
   private implicit def executor: ExecutionContext = ExecutionContext.global
 
   private[this] final val idCounter = new AtomicInteger()
-  private[this] final val sessions = mutable.Map[Int, S]()
+  private[this] final val sessions = mutable.LinkedHashMap[Int, S]()
 
   private[this] final val sessionTimeout =
     TimeUnit.MILLISECONDS.toNanos(livyConf.getTimeAsMs(SessionManager.SESSION_TIMEOUT))


### PR DESCRIPTION
Change default HashMap to LinkedHashMap to make the sessions ordered. 