### PR TITLE
LIVY-184. Better YARN integration for Batch Session.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ MacOS:
 
 
 To run Livy, you will also need a Spark installation. You can get Spark releases at
-https://spark.apache.org/downloads.html. Livy requires at least Spark 1.4 and currently
+https://spark.apache.org/downloads.html. Livy requires at least Spark 1.6 and currently
 only supports Scala 2.10 builds of Spark.
 
 

--- a/client-common/src/main/java/com/cloudera/livy/client/common/HttpMessages.java
+++ b/client-common/src/main/java/com/cloudera/livy/client/common/HttpMessages.java
@@ -62,7 +62,7 @@ public class HttpMessages {
     public final List<String> log;
 
     public SessionInfo(int id, String appId, String owner, String proxyUser, String state,
-                       String kind, List<String> log) {
+        String kind, List<String> log) {
       this.id = id;
       this.appId = appId;
       this.owner = owner;

--- a/client-common/src/main/java/com/cloudera/livy/client/common/HttpMessages.java
+++ b/client-common/src/main/java/com/cloudera/livy/client/common/HttpMessages.java
@@ -54,15 +54,17 @@ public class HttpMessages {
   public static class SessionInfo implements ClientMessage {
 
     public final int id;
+    public final String appId;
     public final String owner;
     public final String proxyUser;
     public final String state;
     public final String kind;
     public final List<String> log;
 
-    public SessionInfo(int id, String owner, String proxyUser, String state, String kind,
-        List<String> log) {
+    public SessionInfo(int id, String appId, String owner, String proxyUser, String state,
+                       String kind, List<String> log) {
       this.id = id;
+      this.appId = appId;
       this.owner = owner;
       this.proxyUser = proxyUser;
       this.state = state;
@@ -71,7 +73,7 @@ public class HttpMessages {
     }
 
     private SessionInfo() {
-      this(-1, null, null, null, null, null);
+      this(-1, null, null, null, null, null, null);
     }
 
   }

--- a/conf/livy.conf
+++ b/conf/livy.conf
@@ -52,3 +52,9 @@
 # Whether to enable HiveContext in livy interpreter, if it is true hive-site.xml will be detected
 # on user request and then livy server classpath automatically.
 # livy.repl.enableHiveContext =
+
+# If Livy can't find the yarn app within this time, consider it lost.
+livy.server.yarn.app-lookup-timeout = 30s
+
+# How often Livy polls YARN to refresh YARN app state.
+# livy.server.yarn.poll-interval = 1s

--- a/core/src/main/scala/com/cloudera/livy/Utils.scala
+++ b/core/src/main/scala/com/cloudera/livy/Utils.scala
@@ -90,6 +90,15 @@ object Utils {
     }
   }
 
+  def startDaemonThread(name: String)(f: => Unit): Thread = {
+    val thread = new Thread(name) {
+      override def run(): Unit = f
+    }
+    thread.setDaemon(true)
+    thread.start()
+    thread
+  }
+
   def usingResource[A <: Closeable, B](resource: A)(f: A => B): B = {
     try {
       f(resource)

--- a/integration-test/src/main/scala/com/cloudera/livy/test/framework/BaseIntegrationTestSuite.scala
+++ b/integration-test/src/main/scala/com/cloudera/livy/test/framework/BaseIntegrationTestSuite.scala
@@ -105,11 +105,6 @@ abstract class BaseIntegrationTestSuite extends FunSuite with Matchers with Befo
     livyClient = new LivyRestClient(httpClient, livyEndpoint)
   }
 
-  test("initialize test cluster") {
-    // Empty test case to separate time spent on creating cluster in beforeAll() and
-    // executing actual test cases.
-  }
-
   class LivyRestClient(httpClient: AsyncHttpClient, livyEndpoint: String) {
 
     def startSession(kind: Kind, sparkConf: Map[String, String] = Map()): Int = {

--- a/integration-test/src/main/scala/com/cloudera/livy/test/framework/BaseIntegrationTestSuite.scala
+++ b/integration-test/src/main/scala/com/cloudera/livy/test/framework/BaseIntegrationTestSuite.scala
@@ -46,7 +46,7 @@ object BaseIntegrationTestSuite {
   val ERROR = "error"
 }
 
-abstract class BaseIntegrationTestSuite extends FunSuite with Matchers with BeforeAndAfter {
+abstract class BaseIntegrationTestSuite extends FunSuite with Matchers with BeforeAndAfterAll {
   import BaseIntegrationTestSuite._
 
   var cluster: Cluster = _
@@ -97,15 +97,17 @@ abstract class BaseIntegrationTestSuite extends FunSuite with Matchers with Befo
     }
   }
 
-  before {
+  // We need beforeAll() here because BatchIT's beforeAll() has to be executed after this.
+  // Please create an issue if this breaks test logging for cluster creation.
+  protected override def beforeAll() = {
     cluster = Cluster.get()
     httpClient = new AsyncHttpClient()
     livyClient = new LivyRestClient(httpClient, livyEndpoint)
   }
 
   test("initialize test cluster") {
-    // Empty test case to separate time spent on creating cluster in before() and executing actual
-    // test cases.
+    // Empty test case to separate time spent on creating cluster in beforeAll() and
+    // executing actual test cases.
   }
 
   class LivyRestClient(httpClient: AsyncHttpClient, livyEndpoint: String) {

--- a/integration-test/src/main/scala/com/cloudera/livy/test/framework/RealCluster.scala
+++ b/integration-test/src/main/scala/com/cloudera/livy/test/framework/RealCluster.scala
@@ -199,7 +199,7 @@ class RealCluster(_config: Map[String, String])
       doAsClusterUser {
         // Cannot use the shared `fs` since this runs in a shutdown hook, and that instance
         // may have been closed already.
-        val fs = FileSystem.newInstance(hadoopConf)
+        val fs = FileSystem.newInstance(coreSiteConf)
         try {
           fs.delete(hdfsScratch, true)
         } finally {

--- a/integration-test/src/main/scala/com/cloudera/livy/test/framework/RealCluster.scala
+++ b/integration-test/src/main/scala/com/cloudera/livy/test/framework/RealCluster.scala
@@ -199,7 +199,7 @@ class RealCluster(_config: Map[String, String])
       doAsClusterUser {
         // Cannot use the shared `fs` since this runs in a shutdown hook, and that instance
         // may have been closed already.
-        val fs = FileSystem.newInstance(coreSiteConf)
+        val fs = FileSystem.newInstance(hadoopConf)
         try {
           fs.delete(hdfsScratch, true)
         } finally {

--- a/integration-test/src/test/scala/com/cloudera/livy/test/BatchIT.scala
+++ b/integration-test/src/test/scala/com/cloudera/livy/test/BatchIT.scala
@@ -57,21 +57,21 @@ class BatchIT extends BaseIntegrationTestSuite with BeforeAndAfterAll {
 
   test("submit spark app") {
     assume(testLibPath != null, "Test lib not uploaded.")
-    val output = newOutputPath
+    val output = newOutputPath()
     val result = runSpark(classOf[SimpleSparkApp], args = List(output))
 
     dumpLogOnFailure(result.id) {
-      assert(result.state === SessionState.Success().toString)
+      assert(result.state === SessionState.Success().toString())
       assert(cluster.fs.isDirectory(new Path(output)))
     }
   }
 
   test("submit an app that fails") {
     assume(testLibPath != null, "Test lib not uploaded.")
-    val output = newOutputPath
+    val output = newOutputPath()
     val result = runSpark(classOf[FailingApp], args = List(output))
     // At this point the application has exited. State should be 'dead' instead of 'error'.
-    assert(result.state === SessionState.Dead().toString)
+    assert(result.state === SessionState.Dead().toString())
 
     // The file is written to make sure the app actually ran, instead of just failing for
     // some other reason.
@@ -80,9 +80,9 @@ class BatchIT extends BaseIntegrationTestSuite with BeforeAndAfterAll {
 
   pytest("submit a pyspark application") {
     val hdfsPath = uploadResource("pytest.py")
-    val output = newOutputPath
+    val output = newOutputPath()
     val result = runScript(hdfsPath, args = List(output))
-    assert(result.state === SessionState.Success().toString)
+    assert(result.state === SessionState.Success().toString())
     assert(cluster.fs.isDirectory(new Path(output)))
   }
 
@@ -91,12 +91,12 @@ class BatchIT extends BaseIntegrationTestSuite with BeforeAndAfterAll {
   ignore("submit a SparkR application") {
     val hdfsPath = uploadResource("rtest.R")
     val result = runScript(hdfsPath)
-    assert(result.state === SessionState.Success().toString)
+    assert(result.state === SessionState.Success().toString())
   }
 
   test("deleting a session should kill YARN app") {
     assume(testLibPath != null, "Test lib not uploaded.")
-    val output = newOutputPath
+    val output = newOutputPath()
     val batchId = runSpark(classOf[SimpleSparkApp], List(output, "false"), waitForExit = false).id
 
     dumpLogOnFailure(batchId, cleanup = false) {
@@ -112,7 +112,7 @@ class BatchIT extends BaseIntegrationTestSuite with BeforeAndAfterAll {
 
   test("killing YARN app should change batch state to dead") {
     assume(testLibPath != null, "Test lib not uploaded.")
-    val output = newOutputPath
+    val output = newOutputPath()
     val batchId = runSpark(classOf[SimpleSparkApp], List(output, "false"), waitForExit = false).id
 
     dumpLogOnFailure(batchId) {
@@ -125,7 +125,7 @@ class BatchIT extends BaseIntegrationTestSuite with BeforeAndAfterAll {
           .getFinalApplicationStatus == FinalApplicationStatus.KILLED,
           "YARN app should be killed.")
         val batchInfo = getBatchSessionInfo(batchId)
-        assert(batchInfo.state == SessionState.Dead().toString, "Batch state should be dead.")
+        assert(batchInfo.state == SessionState.Dead().toString(), "Batch state should be dead.")
         assert(batchInfo.log.contains("Application killed by user."),
           "Batch log doesn't contain yarn final diagnostics.")
       }
@@ -157,12 +157,12 @@ class BatchIT extends BaseIntegrationTestSuite with BeforeAndAfterAll {
       val appReport = cluster.yarnClient.getApplicationReport(ConverterUtils.toApplicationId(appId))
       assert(appReport != null, "appReport shouldn't be null")
 
-      appReport.getDiagnostics
-    } getOrElse ""
+      appReport.getDiagnostics()
+    }.getOrElse("")
   }
 
-  private def newOutputPath: String = {
-    cluster.hdfsScratchDir().toString + "/" + UUID.randomUUID().toString
+  private def newOutputPath(): String = {
+    cluster.hdfsScratchDir().toString() + "/" + UUID.randomUUID().toString()
   }
 
   private def uploadResource(name: String): String = {
@@ -175,7 +175,7 @@ class BatchIT extends BaseIntegrationTestSuite with BeforeAndAfterAll {
       in.close()
       out.close()
     }
-    hdfsPath.toUri.getPath
+    hdfsPath.toUri().getPath()
   }
 
   private def runScript(script: String, args: List[String] = Nil): SessionInfo = {
@@ -202,7 +202,7 @@ class BatchIT extends BaseIntegrationTestSuite with BeforeAndAfterAll {
     val r = httpClient.prepareGet(s"$livyEndpoint/batches/$batchId")
       .execute()
       .get()
-    assert(r.getStatusCode === SC_OK)
+    assert(r.getStatusCode() === SC_OK)
     mapper.readValue(r.getResponseBodyAsStream(), classOf[SessionInfo])
   }
 
@@ -210,7 +210,7 @@ class BatchIT extends BaseIntegrationTestSuite with BeforeAndAfterAll {
     val r = httpClient.prepareDelete(s"$livyEndpoint/batches/$batchId")
       .execute()
       .get()
-    assert(r.getStatusCode === SC_OK)
+    assert(r.getStatusCode() === SC_OK)
   }
 
   private def startBatch(request: CreateBatchRequest): SessionInfo = {
@@ -233,14 +233,14 @@ class BatchIT extends BaseIntegrationTestSuite with BeforeAndAfterAll {
       val batch = getBatchSessionInfo(batchId)
 
       // If batch state transits to any error state, fail test immediately.
-      if (batch.state == SessionState.Error().toString ||
-        batch.state == SessionState.Dead().toString) {
+      if (batch.state == SessionState.Error().toString() ||
+        batch.state == SessionState.Dead().toString()) {
         throw new TestPendingException {
           override def getMessage = s"Session shouldn't be in a terminal state: ${batch.state}"
         }
       }
 
-      assert(batch.state === SessionState.Running().toString)
+      assert(batch.state === SessionState.Running().toString())
 
       ConverterUtils.toApplicationId(batch.appId)
     }
@@ -248,7 +248,7 @@ class BatchIT extends BaseIntegrationTestSuite with BeforeAndAfterAll {
 
   private def waitAndDeleteBatch(batchId: Int): SessionInfo = {
     val terminalStates = Set(SessionState.Error(), SessionState.Dead(), SessionState.Success())
-      .map (_.toString)
+      .map(_.toString())
 
     var finished = false
     try {

--- a/integration-test/src/test/scala/com/cloudera/livy/test/BatchIT.scala
+++ b/integration-test/src/test/scala/com/cloudera/livy/test/BatchIT.scala
@@ -24,10 +24,15 @@ import javax.servlet.http.HttpServletResponse._
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
+import scala.util.control.Exception.allCatch
 
 import org.apache.commons.io.IOUtils
 import org.apache.hadoop.fs.Path
+import org.apache.hadoop.yarn.api.records.{ApplicationId, FinalApplicationStatus}
+import org.apache.hadoop.yarn.util.ConverterUtils
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually._
+import org.scalatest.exceptions.TestPendingException
 
 import com.cloudera.livy.client.common.HttpMessages._
 import com.cloudera.livy.server.batch.CreateBatchRequest
@@ -35,27 +40,38 @@ import com.cloudera.livy.sessions.SessionState
 import com.cloudera.livy.test.apps._
 import com.cloudera.livy.test.framework.BaseIntegrationTestSuite
 
-class BatchIT extends BaseIntegrationTestSuite {
+class BatchIT extends BaseIntegrationTestSuite with BeforeAndAfterAll {
+  implicit val patienceConfig = PatienceConfig(timeout = 2 minutes, interval = 1 second)
 
   private var testLibPath: String = _
 
-  test("upload test lib") {
+  protected override def beforeAll() = {
+    super.beforeAll()
     testLibPath = uploadToHdfs(new File(testLib))
+  }
+
+  test("upload test lib") {
+    // Empty test case to separate time spent on uploading test lib in beforeAll() and
+    // executing actual test cases.
   }
 
   test("submit spark app") {
     assume(testLibPath != null, "Test lib not uploaded.")
-    val output = newOutputPath()
+    val output = newOutputPath
     val result = runSpark(classOf[SimpleSparkApp], args = List(output))
-    assert(result.state === SessionState.Success().toString)
-    assert(cluster.fs.isDirectory(new Path(output)))
+
+    dumpLogOnFailure(result.id) {
+      assert(result.state === SessionState.Success().toString)
+      assert(cluster.fs.isDirectory(new Path(output)))
+    }
   }
 
   test("submit an app that fails") {
     assume(testLibPath != null, "Test lib not uploaded.")
-    val output = newOutputPath()
+    val output = newOutputPath
     val result = runSpark(classOf[FailingApp], args = List(output))
-    assert(result.state === SessionState.Error().toString)
+    // At this point the application has exited. State should be 'dead' instead of 'error'.
+    assert(result.state === SessionState.Dead().toString)
 
     // The file is written to make sure the app actually ran, instead of just failing for
     // some other reason.
@@ -64,7 +80,7 @@ class BatchIT extends BaseIntegrationTestSuite {
 
   pytest("submit a pyspark application") {
     val hdfsPath = uploadResource("pytest.py")
-    val output = newOutputPath()
+    val output = newOutputPath
     val result = runScript(hdfsPath, args = List(output))
     assert(result.state === SessionState.Success().toString)
     assert(cluster.fs.isDirectory(new Path(output)))
@@ -78,12 +94,79 @@ class BatchIT extends BaseIntegrationTestSuite {
     assert(result.state === SessionState.Success().toString)
   }
 
-  private def newOutputPath(): String = {
-    cluster.hdfsScratchDir().toString() + "/" + UUID.randomUUID().toString()
+  test("deleting a session should kill YARN app") {
+    assume(testLibPath != null, "Test lib not uploaded.")
+    val output = newOutputPath
+    val batchId = runSpark(classOf[SimpleSparkApp], List(output, "false"), waitForExit = false).id
+
+    dumpLogOnFailure(batchId, cleanup = false) {
+      val appId = waitBatchForRunning(batchId)
+
+      // Delete the session then verify the YARN app state is KILLED.
+      deleteBatch(batchId)
+      assert(cluster.yarnClient.getApplicationReport(appId)
+        .getFinalApplicationStatus == FinalApplicationStatus.KILLED,
+        "YARN app should be killed.")
+    }
+  }
+
+  test("killing YARN app should change batch state to dead") {
+    assume(testLibPath != null, "Test lib not uploaded.")
+    val output = newOutputPath
+    val batchId = runSpark(classOf[SimpleSparkApp], List(output, "false"), waitForExit = false).id
+
+    dumpLogOnFailure(batchId) {
+      val appId = waitBatchForRunning(batchId)
+
+      // Kill the YARN app and check batch state should be KILLED.
+      cluster.yarnClient.killApplication(appId)
+      eventually {
+        assert(cluster.yarnClient.getApplicationReport(appId)
+          .getFinalApplicationStatus == FinalApplicationStatus.KILLED,
+          "YARN app should be killed.")
+        val batchInfo = getBatchSessionInfo(batchId)
+        assert(batchInfo.state == SessionState.Dead().toString, "Batch state should be dead.")
+        assert(batchInfo.log.contains("Application killed by user."),
+          "Batch log doesn't contain yarn final diagnostics.")
+      }
+    }
+  }
+
+  private def dumpLogOnFailure[T](batchId: Int, cleanup: Boolean = true)(f: => T): T = {
+    try {
+      f
+    } catch {
+      case e: Throwable =>
+        allCatch {
+          info(s"Session log: ${getBatchSessionInfo(batchId).log}")
+          info(s"YARN log: ${getYarnLog(batchId)}")
+        }
+        throw e
+    } finally {
+      if (cleanup) {
+        deleteBatch(batchId)
+      }
+    }
+  }
+
+  private def getYarnLog(batchId: Int): String = {
+    allCatch.opt {
+      val appId = getBatchSessionInfo(batchId).appId
+      assert(appId != null, "appId shouldn't be null")
+
+      val appReport = cluster.yarnClient.getApplicationReport(ConverterUtils.toApplicationId(appId))
+      assert(appReport != null, "appReport shouldn't be null")
+
+      appReport.getDiagnostics
+    } getOrElse ""
+  }
+
+  private def newOutputPath: String = {
+    cluster.hdfsScratchDir().toString + "/" + UUID.randomUUID().toString
   }
 
   private def uploadResource(name: String): String = {
-    val hdfsPath = new Path(cluster.hdfsScratchDir(), UUID.randomUUID().toString() + "-" + name)
+    val hdfsPath = new Path(cluster.hdfsScratchDir(), UUID.randomUUID().toString + "-" + name)
     val in = getClass.getResourceAsStream("/" + name)
     val out = cluster.fs.create(hdfsPath)
     try {
@@ -92,25 +175,45 @@ class BatchIT extends BaseIntegrationTestSuite {
       in.close()
       out.close()
     }
-    hdfsPath.toUri().getPath()
+    hdfsPath.toUri.getPath
   }
 
   private def runScript(script: String, args: List[String] = Nil): SessionInfo = {
     val request = new CreateBatchRequest()
     request.file = script
     request.args = args
-    runBatch(request)
+    waitAndDeleteBatch(startBatch(request).id)
   }
 
-  private def runSpark(klass: Class[_], args: List[String] = Nil): SessionInfo = {
+  private def runSpark(
+      klass: Class[_],
+      args: List[String] = Nil,
+      waitForExit: Boolean = true): SessionInfo = {
     val request = new CreateBatchRequest()
     request.file = testLibPath
-    request.className = Some(klass.getName())
+    request.className = Some(klass.getName)
     request.args = args
-    runBatch(request)
+
+    val batchId = startBatch(request)
+    if (waitForExit) waitAndDeleteBatch(batchId.id) else batchId
   }
 
-  private def runBatch(request: CreateBatchRequest): SessionInfo = {
+  private def getBatchSessionInfo(batchId: Int): SessionInfo = {
+    val r = httpClient.prepareGet(s"$livyEndpoint/batches/$batchId")
+      .execute()
+      .get()
+    assert(r.getStatusCode === SC_OK)
+    mapper.readValue(r.getResponseBodyAsStream(), classOf[SessionInfo])
+  }
+
+  private def deleteBatch(batchId: Int): Unit = {
+    val r = httpClient.prepareDelete(s"$livyEndpoint/batches/$batchId")
+      .execute()
+      .get()
+    assert(r.getStatusCode === SC_OK)
+  }
+
+  private def startBatch(request: CreateBatchRequest): SessionInfo = {
     request.conf = Map("spark.yarn.maxAppAttempts" -> "1")
 
     val response = httpClient.preparePost(s"$livyEndpoint/batches")
@@ -118,31 +221,48 @@ class BatchIT extends BaseIntegrationTestSuite {
       .execute()
       .get()
 
-    assert(response.getStatusCode() === SC_CREATED)
+    withClue(response) {
+      assert(response.getStatusCode === SC_CREATED)
+    }
 
-    val batchInfo = mapper.readValue(response.getResponseBodyAsStream(), classOf[SessionInfo])
+    mapper.readValue(response.getResponseBodyAsStream(), classOf[SessionInfo])
+  }
 
-    val terminalStates = Set(SessionState.Error(), SessionState.Dead(), SessionState.Success())
-      .map(_.toString)
+  private def waitBatchForRunning(batchId: Int): ApplicationId = {
+    eventually {
+      val batch = getBatchSessionInfo(batchId)
 
-    var finished = false
-    try {
-      eventually(timeout(1 minute), interval(1 second)) {
-        val response2 = httpClient.prepareGet(s"$livyEndpoint/batches/${batchInfo.id}")
-          .execute()
-          .get()
-        assert(response2.getStatusCode() === SC_OK)
-        val result = mapper.readValue(response2.getResponseBodyAsStream(), classOf[SessionInfo])
-        assert(terminalStates.contains(result.state))
-
-        finished = true
-        result
+      // If batch state transits to any error state, fail test immediately.
+      if (batch.state == SessionState.Error().toString ||
+        batch.state == SessionState.Dead().toString) {
+        throw new TestPendingException {
+          override def getMessage = s"Session shouldn't be in a terminal state: ${batch.state}"
+        }
       }
-    } finally {
-      if (!finished) {
-        httpClient.prepareDelete(s"$livyEndpoint/batches/${batchInfo.id}").execute()
-      }
+
+      assert(batch.state === SessionState.Running().toString)
+
+      ConverterUtils.toApplicationId(batch.appId)
     }
   }
 
+  private def waitAndDeleteBatch(batchId: Int): SessionInfo = {
+    val terminalStates = Set(SessionState.Error(), SessionState.Dead(), SessionState.Success())
+      .map (_.toString)
+
+    var finished = false
+    try {
+      eventually {
+        val r = getBatchSessionInfo(batchId)
+        assert(terminalStates.contains(r.state))
+
+        finished = true
+        r
+      }
+    } finally {
+      if (!finished) {
+        deleteBatch(batchId)
+      }
+    }
+  }
 }

--- a/server/src/main/scala/com/cloudera/livy/LivyConf.scala
+++ b/server/src/main/scala/com/cloudera/livy/LivyConf.scala
@@ -77,7 +77,7 @@ object LivyConf {
   val YARN_APP_LOOKUP_TIMEOUT = Entry("livy.server.yarn.app-lookup-timeout", "30s")
 
   // How often Livy polls YARN to refresh YARN app state.
-  val YARN_POLL_INTERVAL = Entry("livy.server.yarn.poll-interval", "1s")
+  val YARN_POLL_INTERVAL = Entry("livy.server.yarn.poll-interval", "5s")
 
   val SPARK_MASTER = "spark.master"
   val SPARK_DEPLOY_MODE = "spark.submit.deployMode"

--- a/server/src/main/scala/com/cloudera/livy/LivyConf.scala
+++ b/server/src/main/scala/com/cloudera/livy/LivyConf.scala
@@ -141,6 +141,9 @@ class LivyConf(loadDefaults: Boolean) extends ClientConf[LivyConf](null) {
     this
   }
 
+  /** Return true if spark master starts with yarn. */
+  def isRunningOnYarn: Boolean = sparkMaster().startsWith("yarn")
+
   /** Return the spark deploy mode Livy sessions should use. */
   def sparkDeployMode(): Option[String] = Option(get(LIVY_SPARK_DEPLOY_MODE)).filterNot(_.isEmpty)
 

--- a/server/src/main/scala/com/cloudera/livy/LivyConf.scala
+++ b/server/src/main/scala/com/cloudera/livy/LivyConf.scala
@@ -73,6 +73,12 @@ object LivyConf {
   val KINIT_FAIL_THRESHOLD =
     LivyConf.Entry("livy.server.launch.kerberos.kinit_fail_threshold", 5)
 
+  // If Livy can't find the yarn app within this time, consider it lost.
+  val YARN_APP_LOOKUP_TIMEOUT = Entry("livy.server.yarn.app-lookup-timeout", "30s")
+
+  // How often Livy polls YARN to refresh YARN app state.
+  val YARN_POLL_INTERVAL = Entry("livy.server.yarn.poll-interval", "1s")
+
   val SPARK_MASTER = "spark.master"
   val SPARK_DEPLOY_MODE = "spark.submit.deployMode"
   val SPARK_JARS = "spark.jars"
@@ -142,7 +148,7 @@ class LivyConf(loadDefaults: Boolean) extends ClientConf[LivyConf](null) {
   }
 
   /** Return true if spark master starts with yarn. */
-  def isRunningOnYarn: Boolean = sparkMaster().startsWith("yarn")
+  def isRunningOnYarn(): Boolean = sparkMaster().startsWith("yarn")
 
   /** Return the spark deploy mode Livy sessions should use. */
   def sparkDeployMode(): Option[String] = Option(get(LIVY_SPARK_DEPLOY_MODE)).filterNot(_.isEmpty)

--- a/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
@@ -25,6 +25,7 @@ import javax.servlet._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import scala.math.Ordering.Implicits._
 
 import org.apache.hadoop.security.SecurityUtil
 import org.apache.hadoop.security.authentication.server._
@@ -264,17 +265,16 @@ class LivyServer extends Logging {
   private[server] def testSparkVersion(version: String): Unit = {
     val versionPattern = """(\d)+\.(\d)+(?:\.\d*)?""".r
     // This is exclusive. Version which equals to this will be rejected.
-    val (maxMajor, maxMinor) = (2, 0)
-    val (minMajor, minMinor) = (1, 6)
+    val maxVersion = (2, 0)
+    val minVersion = (1, 6)
 
     val supportedVersion = version match {
       case versionPattern(major, minor) =>
-        (major.toInt > minMajor || major.toInt == minMajor && minor.toInt >= minMinor) &&
-        (major.toInt < maxMajor || major.toInt == maxMajor && minor.toInt < maxMinor)
+        val v = (major.toInt, minor.toInt)
+        v >= minVersion && v < maxVersion
       case _ => false
     }
-    require(supportedVersion,
-      s"Unsupported Spark version $version. Minimum version: $minMajor.$minMinor.")
+    require(supportedVersion, s"Unsupported Spark version $version.")
   }
 
   /**

--- a/server/src/main/scala/com/cloudera/livy/server/batch/BatchSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/batch/BatchSession.scala
@@ -82,6 +82,7 @@ class BatchSession(
 
   override def stateChanged(oldState: SparkApp.State, newState: SparkApp.State): Unit = {
     synchronized {
+      debug(s"$this state changed from $oldState to $newState")
       newState match {
         case SparkApp.State.RUNNING => _state = SessionState.Running()
         case SparkApp.State.FINISHED => _state = SessionState.Success()

--- a/server/src/main/scala/com/cloudera/livy/server/batch/BatchSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/batch/BatchSession.scala
@@ -20,11 +20,12 @@ package com.cloudera.livy.server.batch
 
 import java.lang.ProcessBuilder.Redirect
 
-import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
+import scala.util.Random
 
 import com.cloudera.livy.LivyConf
 import com.cloudera.livy.sessions.{Session, SessionState}
-import com.cloudera.livy.utils.SparkProcessBuilder
+import com.cloudera.livy.utils.{SparkApp, SparkAppListener, SparkProcessBuilder}
 
 class BatchSession(
     id: Int,
@@ -32,11 +33,13 @@ class BatchSession(
     override val proxyUser: Option[String],
     livyConf: LivyConf,
     request: CreateBatchRequest)
-    extends Session(id, owner, livyConf) {
+    extends Session(id, owner, livyConf) with SparkAppListener {
 
-  private val process = {
-    val conf = prepareConf(request.conf, request.jars, request.files, request.archives,
-      request.pyFiles)
+  private val app = {
+    val uniqueAppTag = s"livy-batch-$id-${Random.alphanumeric.take(8).mkString}"
+
+    val conf = SparkApp.prepareSparkConf(uniqueAppTag, livyConf,
+      prepareConf(request.conf, request.jars, request.files, request.archives, request.pyFiles))
     require(request.file != null, "File is required.")
 
     val builder = new SparkProcessBuilder(livyConf)
@@ -59,42 +62,33 @@ class BatchSession(
     builder.redirectErrorStream(true)
 
     val file = resolveURIs(Seq(request.file))(0)
-    builder.start(Some(file), request.args)
+    val sparkSubmitProcess = builder.start(Some(file), request.args)
+    SparkApp.create(uniqueAppTag, sparkSubmitProcess, livyConf, Some(this))
   }
 
   protected implicit def executor: ExecutionContextExecutor = ExecutionContext.global
 
-  private[this] var _state: SessionState = SessionState.Running()
+  private[this] var _state: SessionState = SessionState.Starting()
 
   override def state: SessionState = _state
 
-  override def logLines(): IndexedSeq[String] = process.inputLines
+  override def logLines(): IndexedSeq[String] = app.log()
 
-  override def stopSession(): Unit = destroyProcess()
+  override def stopSession(): Unit = app.kill()
 
-  private def destroyProcess() = {
-    if (process.isAlive) {
-      process.destroy()
-      reapProcess(process.waitFor())
-    }
+  override def appIdKnown(appId: String): Unit = {
+    _appId = Option(appId)
   }
 
-  private def reapProcess(exitCode: Int) = synchronized {
-    if (_state.isActive) {
-      if (exitCode == 0) {
-        _state = SessionState.Success()
-      } else {
-        _state = SessionState.Error()
+  override def stateChanged(oldState: SparkApp.State, newState: SparkApp.State): Unit = {
+    synchronized {
+      newState match {
+        case SparkApp.State.RUNNING => _state = SessionState.Running()
+        case SparkApp.State.FINISHED => _state = SessionState.Success()
+        case SparkApp.State.KILLED | SparkApp.State.FAILED =>
+          _state = SessionState.Dead()
+        case _ =>
       }
     }
   }
-
-  /** Simple daemon thread to make sure we change state when the process exits. */
-  private[this] val thread = new Thread("Batch Process Reaper") {
-    override def run(): Unit = {
-      reapProcess(process.waitFor())
-    }
-  }
-  thread.setDaemon(true)
-  thread.start()
 }

--- a/server/src/main/scala/com/cloudera/livy/server/batch/BatchSessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/batch/BatchSessionServlet.scala
@@ -23,7 +23,7 @@ import javax.servlet.http.HttpServletRequest
 import com.cloudera.livy.LivyConf
 import com.cloudera.livy.server.SessionServlet
 
-case class BatchSessionView(id: Long, state: String, log: Seq[String])
+case class BatchSessionView(id: Long, state: String, appId: Option[String], log: Seq[String])
 
 class BatchSessionServlet(livyConf: LivyConf)
   extends SessionServlet[BatchSession](livyConf)
@@ -48,7 +48,7 @@ class BatchSessionServlet(livyConf: LivyConf)
       } else {
         Nil
       }
-    BatchSessionView(session.id, session.state.toString, logs)
+    BatchSessionView(session.id, session.state.toString, session.appId, logs)
   }
 
 }

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSessionServlet.scala
@@ -70,8 +70,8 @@ class InteractiveSessionServlet(livyConf: LivyConf)
         Nil
       }
 
-    new SessionInfo(session.id, session.owner, session.proxyUser.orNull, session.state.toString,
-      session.kind.toString, logs.asJava)
+    new SessionInfo(session.id, null, session.owner, session.proxyUser.orNull,
+      session.state.toString, session.kind.toString, logs.asJava)
   }
 
   private def statementView(statement: Statement): Any = {

--- a/server/src/main/scala/com/cloudera/livy/utils/Clock.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/Clock.scala
@@ -26,7 +26,14 @@ package com.cloudera.livy.utils
 object Clock {
   private var _sleep: Long => Unit = Thread.sleep
 
-  def setSleepMethod(sleep: Long => Unit): Unit = _sleep = sleep
+  def withSleepMethod(mockSleep: Long => Unit)(f: => Unit): Unit = {
+    try {
+      _sleep = sleep
+      f
+    } finally {
+      _sleep = Thread.sleep
+    }
+  }
 
   def sleep(milliseconds: Long): Unit = _sleep
 }

--- a/server/src/main/scala/com/cloudera/livy/utils/Clock.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/Clock.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cloudera.livy.utils
+
+/**
+ * A lot of Livy code relies on time related functions like Thread.sleep.
+ * To timing effects from unit test, this class is created to mock out time.
+ *
+ * Code in Livy should not call Thread.sleep() directly. It should call this class instead.
+ */
+object Clock {
+  private var _sleep: Long => Unit = Thread.sleep
+
+  def setSleepMethod(sleep: Long => Unit): Unit = _sleep = sleep
+
+  def sleep(milliseconds: Long): Unit = _sleep
+}

--- a/server/src/main/scala/com/cloudera/livy/utils/SparkApp.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/SparkApp.scala
@@ -29,13 +29,10 @@ trait SparkAppListener {
   def stateChanged(oldState: SparkApp.State, newState: SparkApp.State): Unit = {}
 }
 
-// This class looks quite similar to SparkLauncher. Consider adding recovery to SparkLauncher.
 /**
  * Provide factory methods for SparkApp.
  */
 object SparkApp {
-  import SparkYarnApp.getAppIdFromTagAsync
-
   private val SPARK_YARN_TAG_KEY = "spark.yarn.tags"
 
   object State extends Enumeration {
@@ -54,7 +51,7 @@ object SparkApp {
       uniqueAppTag: String,
       livyConf: LivyConf,
       sparkConf: Map[String, String]): Map[String, String] = {
-    if (livyConf.isRunningOnYarn) {
+    if (livyConf.isRunningOnYarn()) {
       val userYarnTags = sparkConf.get(uniqueAppTag).map("," + _).getOrElse("")
       val mergedYarnTags = uniqueAppTag + userYarnTags
       sparkConf ++ Map(
@@ -75,8 +72,8 @@ object SparkApp {
       process: LineBufferedProcess,
       livyConf: LivyConf,
       listener: Option[SparkAppListener]): SparkApp = {
-    if (livyConf.isRunningOnYarn) {
-      new SparkYarnApp(getAppIdFromTagAsync(uniqueAppTag), Some(process), listener)
+    if (livyConf.isRunningOnYarn()) {
+      SparkYarnApp.fromAppTag(uniqueAppTag, Some(process), listener, livyConf)
     } else {
       new SparkProcApp(process, listener)
     }

--- a/server/src/main/scala/com/cloudera/livy/utils/SparkApp.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/SparkApp.scala
@@ -1,0 +1,92 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.utils
+
+import com.cloudera.livy.LivyConf
+import com.cloudera.livy.util.LineBufferedProcess
+
+trait SparkAppListener {
+  /** Fired when appId is known, even during recovery. */
+  def appIdKnown(appId: String): Unit = {}
+
+  /** Fired when the app state in the cluster changes. */
+  def stateChanged(oldState: SparkApp.State, newState: SparkApp.State): Unit = {}
+}
+
+// This class looks quite similar to SparkLauncher. Consider adding recovery to SparkLauncher.
+/**
+ * Provide factory methods for SparkApp.
+ */
+object SparkApp {
+  import SparkYarnApp.getAppIdFromTagAsync
+
+  private val SPARK_YARN_TAG_KEY = "spark.yarn.tags"
+
+  object State extends Enumeration {
+    val STARTING, RUNNING, FINISHED, FAILED, KILLED = Value
+  }
+  type State = State.Value
+
+  /**
+   * Return cluster manager dependent SparkConf.
+   *
+   * @param uniqueAppTag A tag that can uniquely identify the application.
+   * @param livyConf
+   * @param sparkConf
+   */
+  def prepareSparkConf(
+      uniqueAppTag: String,
+      livyConf: LivyConf,
+      sparkConf: Map[String, String]): Map[String, String] = {
+    if (livyConf.isRunningOnYarn) {
+      val userYarnTags = sparkConf.get(uniqueAppTag).map("," + _).getOrElse("")
+      val mergedYarnTags = uniqueAppTag + userYarnTags
+      sparkConf ++ Map(
+        SPARK_YARN_TAG_KEY -> mergedYarnTags,
+        "spark.yarn.submit.waitAppCompletion" -> "false")
+    } else {
+      sparkConf
+    }
+  }
+
+  /**
+   * Return a SparkApp object to control the underlying Spark application via YARN or spark-submit.
+   *
+   * @param uniqueAppTag A tag that can uniquely identify the application.
+   */
+  def create(
+      uniqueAppTag: String,
+      process: LineBufferedProcess,
+      livyConf: LivyConf,
+      listener: Option[SparkAppListener]): SparkApp = {
+    if (livyConf.isRunningOnYarn) {
+      new SparkYarnApp(getAppIdFromTagAsync(uniqueAppTag), Some(process), listener)
+    } else {
+      new SparkProcApp(process, listener)
+    }
+  }
+}
+
+/**
+ * Encapsulate a Spark application.
+ */
+abstract class SparkApp {
+  def kill(): Unit
+  def log(): IndexedSeq[String]
+}

--- a/server/src/main/scala/com/cloudera/livy/utils/SparkProcApp.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/SparkProcApp.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.utils
+
+import com.cloudera.livy.Logging
+import com.cloudera.livy.util.LineBufferedProcess
+
+/**
+ * Provide a class to control a Spark application using spark-submit.
+ *
+ * @param process The spark-submit process launched the Spark application.
+ */
+class SparkProcApp (
+    process: LineBufferedProcess,
+    listener: Option[SparkAppListener])
+  extends SparkApp with Logging{
+
+  private var state = SparkApp.State.STARTING
+
+  override def kill(): Unit = {
+    if (process.isAlive) {
+      process.destroy()
+    }
+  }
+
+  override def log(): IndexedSeq[String] = process.inputLines
+
+  private def changeState(newState: SparkApp.State.Value) = {
+    if (state != newState) {
+      listener.foreach(_.stateChanged(state, newState))
+      state = newState
+    }
+  }
+
+  val waitThread = new Thread(new Runnable {
+    override def run(): Unit = {
+      changeState(SparkApp.State.RUNNING)
+      process.waitFor() match {
+        case 0 => changeState(SparkApp.State.FINISHED)
+        case exitCode =>
+          changeState(SparkApp.State.FAILED)
+          error(s"spark-submit exited with code $exitCode")
+      }
+    }
+  }, s"SparProcApp_$this")
+
+  waitThread.setDaemon(true)
+  waitThread.start()
+}

--- a/server/src/main/scala/com/cloudera/livy/utils/SparkProcApp.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/SparkProcApp.scala
@@ -29,7 +29,7 @@ import com.cloudera.livy.util.LineBufferedProcess
 class SparkProcApp (
     process: LineBufferedProcess,
     listener: Option[SparkAppListener])
-  extends SparkApp with Logging{
+  extends SparkApp with Logging {
 
   private var state = SparkApp.State.STARTING
 

--- a/server/src/main/scala/com/cloudera/livy/utils/SparkYarnApp.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/SparkYarnApp.scala
@@ -50,7 +50,7 @@ object SparkYarnApp extends Logging {
     Executors.newCachedThreadPool(new NonDaemonThreadFactory()))
 
   // It takes at least 5 seconds to see the newly submitted app.
-  private val APP_TAG_TO_ID_TIMEOUT = 10 seconds
+  private val APP_TAG_TO_ID_TIMEOUT = 30 seconds
   private val KILL_TIMEOUT = APP_TAG_TO_ID_TIMEOUT
   private val POLL_INTERVAL = 1 second
 

--- a/server/src/main/scala/com/cloudera/livy/utils/SparkYarnApp.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/SparkYarnApp.scala
@@ -17,7 +17,6 @@
  */
 package com.cloudera.livy.utils
 
-import java.util.concurrent.Executors
 import java.util.concurrent.TimeoutException
 
 import scala.annotation.tailrec
@@ -32,15 +31,9 @@ import org.apache.hadoop.yarn.client.api.YarnClient
 import org.apache.hadoop.yarn.conf.YarnConfiguration
 
 import com.cloudera.livy.{LivyConf, Logging, Utils}
-import com.cloudera.livy.rsc.{Utils => RSCUtils}
 import com.cloudera.livy.util.LineBufferedProcess
 
 object SparkYarnApp extends Logging {
-  // Create a non daemon thread pool to run getAppIdFromTag().
-  // getAppIdFromTag() might take a while and should not use the global default thread pool.
-  private implicit val ec = ExecutionContext.fromExecutor(
-    Executors.newCachedThreadPool(RSCUtils.newDaemonThreadFactory("getAppIdFromTag-%d")))
-
   // YarnClient is thread safe. Create once, share it across threads.
   lazy val yarnClient = {
     val c = YarnClient.createYarnClient()
@@ -154,7 +147,7 @@ class SparkYarnApp private[utils] (
 
   private def isRunning: Boolean = {
     state != SparkApp.State.FAILED && state != SparkApp.State.FINISHED &&
-    state != SparkApp.State.KILLED
+      state != SparkApp.State.KILLED
   }
 
   // Exposed for unit test.

--- a/server/src/main/scala/com/cloudera/livy/utils/SparkYarnApp.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/SparkYarnApp.scala
@@ -1,0 +1,232 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cloudera.livy.utils
+
+import java.util.concurrent.{ThreadFactory, TimeoutException}
+import java.util.concurrent.Executors
+
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.{blocking, Await, ExecutionContext, Future}
+import scala.concurrent.duration._
+import scala.language.postfixOps
+import scala.util.{Failure, Success, Try}
+
+import org.apache.hadoop.yarn.api.records.{ApplicationId, ApplicationReport, FinalApplicationStatus, YarnApplicationState}
+import org.apache.hadoop.yarn.client.api.YarnClient
+import org.apache.hadoop.yarn.conf.YarnConfiguration
+
+import com.cloudera.livy.Logging
+import com.cloudera.livy.util.LineBufferedProcess
+
+object SparkYarnApp extends Logging {
+  private class NonDaemonThreadFactory extends ThreadFactory {
+    def newThread(r: Runnable): Thread = {
+      val t = new Thread(r)
+      t.setDaemon(true)
+      t
+    }
+  }
+
+  // Create a non daemon thread pool to run getAppIdFromTagAsync().
+  // getAppIdFromTagAsync() might take a while and should not use the global default thread pool.
+  private implicit val ec = ExecutionContext.fromExecutor(
+    Executors.newCachedThreadPool(new NonDaemonThreadFactory()))
+
+  // It takes at least 5 seconds to see the newly submitted app.
+  private val APP_TAG_TO_ID_TIMEOUT = 10 seconds
+  private val KILL_TIMEOUT = APP_TAG_TO_ID_TIMEOUT
+  private val POLL_INTERVAL = 1 second
+
+  // YarnClient is thread safe. Create once, share it across threads.
+  private[this] lazy val yarnClient = YarnClient.createYarnClient()
+  private[this] var yarnClientCreated = false
+
+  def getYarnClient(): YarnClient = synchronized {
+    if (!yarnClientCreated) {
+      yarnClient.init(new YarnConfiguration())
+      yarnClient.start()
+      yarnClientCreated = true
+    }
+    yarnClient
+  }
+
+  def getAppIdFromTagAsync(appTag: String): Future[ApplicationId] =
+    Future { getAppIdFromTag(appTag).get }
+
+  /**
+   * Find the corresponding YARN application id from an application tag.
+   *
+   * @param appTag The application tag tagged on the target application.
+   *               If the tag is not unique, it returns the first application it found.
+   *               It will be converted to lower case to match YARN's behaviour.
+   * @return ApplicationId or the failure.
+   */
+  @tailrec
+  private def getAppIdFromTag(
+    appTag: String,
+    deadline: Deadline = APP_TAG_TO_ID_TIMEOUT.fromNow): Try[ApplicationId] = {
+    val appTagLowerCase = appTag.toLowerCase
+
+    // FIXME Should not loop thru all YARN applications but YarnClient doesn't offer an API.
+    // Consider calling rmClient in YarnClient directly.
+    getYarnClient().getApplications().asScala.find(_.getApplicationTags.contains(appTagLowerCase))
+      match {
+        case Some(app) => Success(app.getApplicationId)
+        case None =>
+          if (deadline.isOverdue) {
+            Failure(new Exception(s"No YARN application is tagged with $appTagLowerCase."))
+          } else {
+            blocking { Thread.sleep(POLL_INTERVAL.toMillis) }
+            getAppIdFromTag(appTagLowerCase, deadline)
+          }
+      }
+  }
+}
+
+/**
+ * Provide a class to control a Spark application using YARN API.
+ *
+ * @param appIdFuture A future that returns the YARN application id for this application.
+ * @param process The spark-submit process launched the YARN application. This is optional.
+ *                If it's provided, SparkYarnApp.log() will include its log.
+ */
+class SparkYarnApp (
+    appIdFuture: Future[ApplicationId],
+    process: Option[LineBufferedProcess],
+    listener: Option[SparkAppListener])
+  extends SparkApp
+  with Logging {
+  import SparkYarnApp.ec
+
+  private lazy val yarnClient = SparkYarnApp.getYarnClient()
+  private var state: SparkApp.State = SparkApp.State.STARTING
+  private var yarnDiagnostics: IndexedSeq[String] = IndexedSeq.empty[String]
+
+  override def log(): IndexedSeq[String] =
+    (process map (_.inputLines) getOrElse ArrayBuffer.empty[String]) ++ yarnDiagnostics
+
+  override def kill(): Unit = synchronized {
+    if (isRunning) {
+      process foreach (_.destroy())
+
+      try {
+        Await.result(appIdFuture map (yarnClient.killApplication), SparkYarnApp.KILL_TIMEOUT)
+      } catch {
+        // We cannot kill the YARN app without the app id.
+        // There's a chance the YARN app hasn't been submitted during a livy-server failure.
+        // We don't want a stuck session that can't be deleted. Emit a warning and move on.
+        case _: TimeoutException | _: InterruptedException =>
+          warn("Deleting a session while its YARN application is not found.")
+          yarnAppMonitorThread.interrupt()
+      }
+    }
+  }
+
+  private def changeState(newState: SparkApp.State.Value): Unit = {
+    if (state != newState) {
+      listener foreach (_.stateChanged(state, newState))
+      state = newState
+    }
+  }
+
+  private def getYarnDiagnostics(appReport: ApplicationReport): IndexedSeq[String] = {
+    Option(appReport.getDiagnostics)
+      .filter(_.nonEmpty)
+      .map[IndexedSeq[String]]("YARN Diagnostics:" +: _.split("\n"))
+      .getOrElse(IndexedSeq.empty)
+  }
+
+  private def isRunning: Boolean = {
+    state != SparkApp.State.FAILED && state != SparkApp.State.FINISHED &&
+    state != SparkApp.State.KILLED
+  }
+
+  private def mapYarnState(applicationReport: ApplicationReport): SparkApp.State.Value = {
+      applicationReport.getYarnApplicationState match {
+      case (YarnApplicationState.NEW |
+            YarnApplicationState.NEW_SAVING |
+            YarnApplicationState.SUBMITTED |
+            YarnApplicationState.ACCEPTED) => SparkApp.State.STARTING
+      case YarnApplicationState.RUNNING => SparkApp.State.RUNNING
+      case YarnApplicationState.FINISHED =>
+        applicationReport.getFinalApplicationStatus match {
+          case FinalApplicationStatus.SUCCEEDED => SparkApp.State.FINISHED
+          case FinalApplicationStatus.FAILED => SparkApp.State.FAILED
+          case FinalApplicationStatus.KILLED => SparkApp.State.KILLED
+          case s =>
+            error(s"Unknown YARN final status ${applicationReport.getApplicationId} $s")
+            SparkApp.State.FAILED
+        }
+      case YarnApplicationState.FAILED => SparkApp.State.FAILED
+      case YarnApplicationState.KILLED => SparkApp.State.KILLED
+    }
+  }
+
+  // TODO Instead of spawning a thread for every session, create a centralized thread and
+  // batch YARN queries.
+  private val yarnAppMonitorThread = new Thread(s"yarnAppMonitorThread-$this") {
+    override def run() = {
+      @tailrec
+      def waitForAppId(): ApplicationId = {
+        try {
+          // Wait for spark-submit to finish submitting the app to YARN.
+          process map (_.waitFor()) match {
+            case (None | Some(0)) => Await.result(appIdFuture, SparkYarnApp.POLL_INTERVAL)
+            case Some(exitCode) =>
+              throw new Exception(s"spark-submit exited with code $exitCode}.\n" +
+                s"${process.get.inputLines mkString "\n"}")
+          }
+        } catch {
+          case e: TimeoutException => waitForAppId()
+        }
+      }
+
+      try {
+        val appId = waitForAppId()
+
+        Thread.currentThread().setName(s"yarnAppMonitorThread-$appId")
+
+        listener foreach (_.appIdKnown(appId.toString))
+
+        while (isRunning) {
+          Thread.sleep(SparkYarnApp.POLL_INTERVAL.toMillis)
+
+          // Refresh application state
+          val appReport = yarnClient.getApplicationReport(appId)
+          yarnDiagnostics = getYarnDiagnostics(appReport)
+          changeState(mapYarnState(appReport))
+        }
+
+        debug(s"$appId $state ${yarnDiagnostics.mkString(" ")}")
+      } catch {
+        case e: InterruptedException =>
+          yarnDiagnostics = ArrayBuffer("Session stopped by user.")
+          changeState(SparkApp.State.KILLED)
+        case e: Throwable =>
+          error(s"Error whiling refreshing YARN state: $e")
+          yarnDiagnostics = ArrayBuffer(e.toString)
+          changeState(SparkApp.State.FAILED)
+      }
+    }
+  }
+
+  yarnAppMonitorThread.setDaemon(true)
+  yarnAppMonitorThread.start()
+}

--- a/server/src/test/scala/com/cloudera/livy/server/LivyServerSuite.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/LivyServerSuite.scala
@@ -48,4 +48,11 @@ class LivyServerSuite extends FunSuite {
     intercept[IllegalArgumentException] { s.testSparkVersion("1.5.1") }
     intercept[IllegalArgumentException] { s.testSparkVersion("1.5.2") }
   }
+
+  test("should not support Spark 2.0+") {
+    val s = new LivyServer()
+    intercept[IllegalArgumentException] { s.testSparkVersion("2.0.0") }
+    intercept[IllegalArgumentException] { s.testSparkVersion("2.0.1") }
+    intercept[IllegalArgumentException] { s.testSparkVersion("2.1.0") }
+  }
 }

--- a/server/src/test/scala/com/cloudera/livy/server/LivyServerSuite.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/LivyServerSuite.scala
@@ -34,4 +34,18 @@ class LivyServerSuite extends FunSuite {
     new LivyServer().testSparkSubmit(livyConf)
   }
 
+  test("should support Spark 1.6") {
+    val s = new LivyServer()
+    s.testSparkVersion("1.6.0")
+    s.testSparkVersion("1.6.1")
+    s.testSparkVersion("1.6.2")
+  }
+
+  test("should not support Spark older than 1.6") {
+    val s = new LivyServer()
+    intercept[IllegalArgumentException] { s.testSparkVersion("1.4.0") }
+    intercept[IllegalArgumentException] { s.testSparkVersion("1.5.0") }
+    intercept[IllegalArgumentException] { s.testSparkVersion("1.5.1") }
+    intercept[IllegalArgumentException] { s.testSparkVersion("1.5.2") }
+  }
 }

--- a/server/src/test/scala/com/cloudera/livy/utils/SparkYarnAppSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/utils/SparkYarnAppSpec.scala
@@ -19,7 +19,6 @@ package com.cloudera.livy.utils
 
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 
-import scala.concurrent.Promise
 import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.control.Exception.noCatch
@@ -35,6 +34,7 @@ import org.mockito.stubbing.Answer
 import org.scalatest.FunSpec
 import org.scalatest.mock.MockitoSugar.mock
 
+import com.cloudera.livy.LivyConf
 import com.cloudera.livy.util.LineBufferedProcess
 import com.cloudera.livy.utils.SparkApp._
 
@@ -47,126 +47,137 @@ class SparkYarnAppSpec extends FunSpec {
     Thread.`yield`()
   }
 
+  private def withSleepMethod(mockSleep: Long => Unit)(f: => Unit): Unit = {
+    noCatch.andFinally { Clock.setSleepMethod(Thread.sleep) } {
+      Clock.setSleepMethod(mockSleep)
+      f
+    }
+  }
+
   describe("SparkYarnApp") {
+    val TEST_TIMEOUT = 30 seconds
     val appId = ConverterUtils.toApplicationId("application_1467912463905_0021")
-    val fakeAppIdFuture = Promise.successful(appId).future
-    val unfulfilledPromise = Promise[ApplicationId]()
+    val livyConf = new LivyConf()
+    livyConf.set(LivyConf.YARN_APP_LOOKUP_TIMEOUT, "0")
 
     it("should poll YARN state and terminate") {
-      Clock.setSleepMethod(mockSleep(_))
+      withSleepMethod(mockSleep) {
+        val mockYarnClient = mock[YarnClient]
+        val mockAppListener = mock[SparkAppListener]
 
-      val mockYarnClient = mock[YarnClient]
-      val mockAppListener = mock[SparkAppListener]
+        val mockAppReport = mock[ApplicationReport]
+        when(mockAppReport.getApplicationId).thenReturn(appId)
+        when(mockAppReport.getFinalApplicationStatus).thenReturn(FinalApplicationStatus.SUCCEEDED)
+        // Simulate YARN app state progression.
+        when(mockAppReport.getYarnApplicationState).thenAnswer(new Answer[YarnApplicationState]() {
+          private var stateSeq = List(ACCEPTED, RUNNING, FINISHED)
 
-      val mockAppReport = mock[ApplicationReport]
-      when(mockAppReport.getApplicationId).thenReturn(appId)
-      when(mockAppReport.getFinalApplicationStatus).thenReturn(FinalApplicationStatus.SUCCEEDED)
-      // Simulate YARN app state progression.
-      when(mockAppReport.getYarnApplicationState).thenAnswer(new Answer[YarnApplicationState]() {
-        private var stateSeq = List(ACCEPTED, RUNNING, FINISHED)
-
-        override def answer(invocation: InvocationOnMock): YarnApplicationState = {
-          val currentState = stateSeq.head
-          if (stateSeq.tail.nonEmpty) {
-            stateSeq = stateSeq.tail
+          override def answer(invocation: InvocationOnMock): YarnApplicationState = {
+            val currentState = stateSeq.head
+            if (stateSeq.tail.nonEmpty) {
+              stateSeq = stateSeq.tail
+            }
+            currentState
           }
-          currentState
-        }
-      })
-      when(mockYarnClient.getApplicationReport(appId)).thenReturn(mockAppReport)
+        })
+        when(mockYarnClient.getApplicationReport(appId)).thenReturn(mockAppReport)
 
-      val app = new SparkYarnApp(fakeAppIdFuture, None, Some(mockAppListener), mockYarnClient)
-      cleanupThread(app.yarnAppMonitorThread) {
-        app.yarnAppMonitorThread.join(30.seconds toMillis)
-        assert(!app.yarnAppMonitorThread.isAlive,
-          "YarnAppMonitorThread should terminate after YARN app is finished.")
-        verify(mockYarnClient, atLeast(1)).getApplicationReport(appId)
-        verify(mockAppListener).stateChanged(State.STARTING, State.RUNNING)
-        verify(mockAppListener).stateChanged(State.RUNNING, State.FINISHED)
+        val app = new SparkYarnApp(appId, None, Some(mockAppListener), livyConf, mockYarnClient)
+        cleanupThread(app.yarnAppMonitorThread) {
+          app.yarnAppMonitorThread.join(TEST_TIMEOUT.toMillis)
+          assert(!app.yarnAppMonitorThread.isAlive,
+            "YarnAppMonitorThread should terminate after YARN app is finished.")
+          verify(mockYarnClient, atLeast(1)).getApplicationReport(appId)
+          verify(mockAppListener).stateChanged(State.STARTING, State.RUNNING)
+          verify(mockAppListener).stateChanged(State.RUNNING, State.FINISHED)
+        }
       }
     }
 
     it("should kill yarn app") {
-      Clock.setSleepMethod(mockSleep(_))
+      withSleepMethod(mockSleep) {
+        val diag = "DIAG"
+        val mockYarnClient = mock[YarnClient]
 
-      val diag = "DIAG"
-      val mockYarnClient = mock[YarnClient]
+        val mockAppReport = mock[ApplicationReport]
+        when(mockAppReport.getApplicationId).thenReturn(appId)
+        when(mockAppReport.getDiagnostics).thenReturn(diag)
+        when(mockAppReport.getFinalApplicationStatus).thenReturn(FinalApplicationStatus.SUCCEEDED)
 
-      val mockAppReport = mock[ApplicationReport]
-      when(mockAppReport.getApplicationId).thenReturn(appId)
-      when(mockAppReport.getDiagnostics).thenReturn(diag)
-      when(mockAppReport.getFinalApplicationStatus).thenReturn(FinalApplicationStatus.SUCCEEDED)
-
-      var appKilled = false
-      when(mockAppReport.getYarnApplicationState).thenAnswer(new Answer[YarnApplicationState]() {
-        override def answer(invocation: InvocationOnMock): YarnApplicationState = {
-          if (!appKilled) {
-            RUNNING
-          } else {
-            KILLED
+        var appKilled = false
+        when(mockAppReport.getYarnApplicationState).thenAnswer(new Answer[YarnApplicationState]() {
+          override def answer(invocation: InvocationOnMock): YarnApplicationState = {
+            if (!appKilled) {
+              RUNNING
+            } else {
+              KILLED
+            }
           }
+        })
+        when(mockYarnClient.getApplicationReport(appId)).thenReturn(mockAppReport)
+
+        val app = new SparkYarnApp(appId, None, None, livyConf, mockYarnClient)
+        cleanupThread(app.yarnAppMonitorThread) {
+          app.kill()
+          appKilled = true
+
+          app.yarnAppMonitorThread.join(TEST_TIMEOUT.toMillis)
+          assert(!app.yarnAppMonitorThread.isAlive,
+            "YarnAppMonitorThread should terminate after YARN app is finished.")
+          verify(mockYarnClient, atLeast(1)).getApplicationReport(appId)
+          verify(mockYarnClient).killApplication(appId)
+          assert(app.log().mkString.contains(diag))
         }
-      })
-      when(mockYarnClient.getApplicationReport(appId)).thenReturn(mockAppReport)
-
-      val app = new SparkYarnApp(fakeAppIdFuture, None, None, mockYarnClient)
-      cleanupThread(app.yarnAppMonitorThread) {
-        app.kill()
-        appKilled = true
-
-        app.yarnAppMonitorThread.join(30.seconds toMillis)
-        assert(!app.yarnAppMonitorThread.isAlive,
-          "YarnAppMonitorThread should terminate after YARN app is finished.")
-        verify(mockYarnClient, atLeast(1)).getApplicationReport(appId)
-        verify(mockYarnClient).killApplication(appId)
-        assert(app.log().mkString.contains(diag))
       }
     }
 
     it("should return spark-submit log") {
-      Clock.setSleepMethod(mockSleep(_))
-      val mockYarnClient = mock[YarnClient]
-      val mockSparkSubmit = mock[LineBufferedProcess]
-      val sparkSubmitLog = IndexedSeq("SPARK-SUBMIT", "LOG")
-      when(mockSparkSubmit.inputLines).thenReturn(sparkSubmitLog)
-      val waitForCalledLatch = new CountDownLatch(1)
-      when(mockSparkSubmit.waitFor()).thenAnswer(new Answer[Int]() {
-        override def answer(invocation: InvocationOnMock): Int = {
-          waitForCalledLatch.countDown()
-          1
-        }
-      })
+      withSleepMethod(mockSleep) {
+        val mockYarnClient = mock[YarnClient]
+        val mockSparkSubmit = mock[LineBufferedProcess]
+        val sparkSubmitLog = IndexedSeq("SPARK-SUBMIT", "LOG")
+        when(mockSparkSubmit.inputLines).thenReturn(sparkSubmitLog)
+        val waitForCalledLatch = new CountDownLatch(1)
+        when(mockSparkSubmit.waitFor()).thenAnswer(new Answer[Int]() {
+          override def answer(invocation: InvocationOnMock): Int = {
+            waitForCalledLatch.countDown()
+            1
+          }
+        })
 
-      val app = new SparkYarnApp(fakeAppIdFuture, Some(mockSparkSubmit), None, mockYarnClient)
-      cleanupThread(app.yarnAppMonitorThread) {
-        waitForCalledLatch.await(30, TimeUnit.SECONDS)
-        assert(app.log() == sparkSubmitLog, "Expect spark-submit log")
+        val app = new SparkYarnApp(appId, Some(mockSparkSubmit), None, livyConf, mockYarnClient)
+        cleanupThread(app.yarnAppMonitorThread) {
+          waitForCalledLatch.await(TEST_TIMEOUT.toMillis, TimeUnit.MILLISECONDS)
+          assert(app.log() == sparkSubmitLog, "Expect spark-submit log")
+        }
       }
     }
 
     it("can kill spark-submit while it's running") {
-      Clock.setSleepMethod(mockSleep(_))
-      val mockYarnClient = mock[YarnClient]
-      val mockSparkSubmit = mock[LineBufferedProcess]
-      when(mockSparkSubmit.exitValue()).thenReturn(1)
+      withSleepMethod(mockSleep) {
+        val mockYarnClient = mock[YarnClient]
+        val mockSparkSubmit = mock[LineBufferedProcess]
+        when(mockSparkSubmit.exitValue()).thenReturn(1)
 
-      val sparkSubmitRunningLatch = new CountDownLatch(1)
-      // Simulate a running spark-submit
-      when(mockSparkSubmit.inputLines).thenAnswer(new Answer[Unit]() {
-        override def answer(invocation: InvocationOnMock): Unit = {
-          sparkSubmitRunningLatch.await()
+        val sparkSubmitRunningLatch = new CountDownLatch(1)
+        // Simulate a running spark-submit
+        when(mockSparkSubmit.inputLines).thenAnswer(new Answer[Unit]() {
+          override def answer(invocation: InvocationOnMock): Unit = {
+            sparkSubmitRunningLatch.await()
+          }
+        })
+
+        def appId: ApplicationId = { throw new Exception("fake") }
+        val app = new SparkYarnApp(appId, Some(mockSparkSubmit), None, livyConf, mockYarnClient)
+        cleanupThread(app.yarnAppMonitorThread) {
+          app.kill()
+          verify(mockSparkSubmit, times(1)).destroy()
         }
-      })
-
-      val app = new SparkYarnApp(fakeAppIdFuture, Some(mockSparkSubmit), None, mockYarnClient)
-      cleanupThread(app.yarnAppMonitorThread) {
-        app.kill()
-        verify(mockSparkSubmit, times(1)).destroy()
       }
     }
 
     it("should map YARN state to SparkApp.State correctly") {
-      val app = new SparkYarnApp(unfulfilledPromise.future, None, None)
+      val app = new SparkYarnApp(appId, None, None, livyConf)
       cleanupThread(app.yarnAppMonitorThread) {
         assert(app.mapYarnState(appId, NEW, UNDEFINED) == State.STARTING)
         assert(app.mapYarnState(appId, NEW_SAVING, UNDEFINED) == State.STARTING)

--- a/server/src/test/scala/com/cloudera/livy/utils/SparkYarnAppSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/utils/SparkYarnAppSpec.scala
@@ -1,0 +1,186 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cloudera.livy.utils
+
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
+import scala.concurrent.Promise
+import scala.concurrent.duration._
+import scala.language.postfixOps
+import scala.util.control.Exception.noCatch
+
+import org.apache.hadoop.yarn.api.records.{ApplicationId, ApplicationReport, FinalApplicationStatus, YarnApplicationState}
+import org.apache.hadoop.yarn.api.records.FinalApplicationStatus.UNDEFINED
+import org.apache.hadoop.yarn.api.records.YarnApplicationState._
+import org.apache.hadoop.yarn.client.api.YarnClient
+import org.apache.hadoop.yarn.util.ConverterUtils
+import org.mockito.Mockito._
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
+import org.scalatest.FunSpec
+import org.scalatest.mock.MockitoSugar.mock
+
+import com.cloudera.livy.util.LineBufferedProcess
+import com.cloudera.livy.utils.SparkApp._
+
+class SparkYarnAppSpec extends FunSpec {
+  private def cleanupThread(t: Thread)(f: => Unit) = {
+    noCatch.andFinally { t.interrupt() } (f)
+  }
+
+  private def mockSleep(ms: Long) = {
+    Thread.`yield`()
+  }
+
+  describe("SparkYarnApp") {
+    val appId = ConverterUtils.toApplicationId("application_1467912463905_0021")
+    val fakeAppIdFuture = Promise.successful(appId).future
+    val unfulfilledPromise = Promise[ApplicationId]()
+
+    it("should poll YARN state and terminate") {
+      Clock.setSleepMethod(mockSleep(_))
+
+      val mockYarnClient = mock[YarnClient]
+      val mockAppListener = mock[SparkAppListener]
+
+      val mockAppReport = mock[ApplicationReport]
+      when(mockAppReport.getApplicationId).thenReturn(appId)
+      when(mockAppReport.getFinalApplicationStatus).thenReturn(FinalApplicationStatus.SUCCEEDED)
+      // Simulate YARN app state progression.
+      when(mockAppReport.getYarnApplicationState).thenAnswer(new Answer[YarnApplicationState]() {
+        private var stateSeq = List(ACCEPTED, RUNNING, FINISHED)
+
+        override def answer(invocation: InvocationOnMock): YarnApplicationState = {
+          val currentState = stateSeq.head
+          if (stateSeq.tail.nonEmpty) {
+            stateSeq = stateSeq.tail
+          }
+          currentState
+        }
+      })
+      when(mockYarnClient.getApplicationReport(appId)).thenReturn(mockAppReport)
+
+      val app = new SparkYarnApp(fakeAppIdFuture, None, Some(mockAppListener), mockYarnClient)
+      cleanupThread(app.yarnAppMonitorThread) {
+        app.yarnAppMonitorThread.join(30.seconds toMillis)
+        assert(!app.yarnAppMonitorThread.isAlive,
+          "YarnAppMonitorThread should terminate after YARN app is finished.")
+        verify(mockYarnClient, atLeast(1)).getApplicationReport(appId)
+        verify(mockAppListener).stateChanged(State.STARTING, State.RUNNING)
+        verify(mockAppListener).stateChanged(State.RUNNING, State.FINISHED)
+      }
+    }
+
+    it("should kill yarn app") {
+      Clock.setSleepMethod(mockSleep(_))
+
+      val diag = "DIAG"
+      val mockYarnClient = mock[YarnClient]
+
+      val mockAppReport = mock[ApplicationReport]
+      when(mockAppReport.getApplicationId).thenReturn(appId)
+      when(mockAppReport.getDiagnostics).thenReturn(diag)
+      when(mockAppReport.getFinalApplicationStatus).thenReturn(FinalApplicationStatus.SUCCEEDED)
+
+      var appKilled = false
+      when(mockAppReport.getYarnApplicationState).thenAnswer(new Answer[YarnApplicationState]() {
+        override def answer(invocation: InvocationOnMock): YarnApplicationState = {
+          if (!appKilled) {
+            RUNNING
+          } else {
+            KILLED
+          }
+        }
+      })
+      when(mockYarnClient.getApplicationReport(appId)).thenReturn(mockAppReport)
+
+      val app = new SparkYarnApp(fakeAppIdFuture, None, None, mockYarnClient)
+      cleanupThread(app.yarnAppMonitorThread) {
+        app.kill()
+        appKilled = true
+
+        app.yarnAppMonitorThread.join(30.seconds toMillis)
+        assert(!app.yarnAppMonitorThread.isAlive,
+          "YarnAppMonitorThread should terminate after YARN app is finished.")
+        verify(mockYarnClient, atLeast(1)).getApplicationReport(appId)
+        verify(mockYarnClient).killApplication(appId)
+        assert(app.log().mkString.contains(diag))
+      }
+    }
+
+    it("should return spark-submit log") {
+      Clock.setSleepMethod(mockSleep(_))
+      val mockYarnClient = mock[YarnClient]
+      val mockSparkSubmit = mock[LineBufferedProcess]
+      val sparkSubmitLog = IndexedSeq("SPARK-SUBMIT", "LOG")
+      when(mockSparkSubmit.inputLines).thenReturn(sparkSubmitLog)
+      val waitForCalledLatch = new CountDownLatch(1)
+      when(mockSparkSubmit.waitFor()).thenAnswer(new Answer[Int]() {
+        override def answer(invocation: InvocationOnMock): Int = {
+          waitForCalledLatch.countDown()
+          1
+        }
+      })
+
+      val app = new SparkYarnApp(fakeAppIdFuture, Some(mockSparkSubmit), None, mockYarnClient)
+      cleanupThread(app.yarnAppMonitorThread) {
+        waitForCalledLatch.await(30, TimeUnit.SECONDS)
+        assert(app.log() == sparkSubmitLog, "Expect spark-submit log")
+      }
+    }
+
+    it("can kill spark-submit while it's running") {
+      Clock.setSleepMethod(mockSleep(_))
+      val mockYarnClient = mock[YarnClient]
+      val mockSparkSubmit = mock[LineBufferedProcess]
+      when(mockSparkSubmit.exitValue()).thenReturn(1)
+
+      val sparkSubmitRunningLatch = new CountDownLatch(1)
+      // Simulate a running spark-submit
+      when(mockSparkSubmit.inputLines).thenAnswer(new Answer[Unit]() {
+        override def answer(invocation: InvocationOnMock): Unit = {
+          sparkSubmitRunningLatch.await()
+        }
+      })
+
+      val app = new SparkYarnApp(fakeAppIdFuture, Some(mockSparkSubmit), None, mockYarnClient)
+      cleanupThread(app.yarnAppMonitorThread) {
+        app.kill()
+        verify(mockSparkSubmit, times(1)).destroy()
+      }
+    }
+
+    it("should map YARN state to SparkApp.State correctly") {
+      val app = new SparkYarnApp(unfulfilledPromise.future, None, None)
+      cleanupThread(app.yarnAppMonitorThread) {
+        assert(app.mapYarnState(appId, NEW, UNDEFINED) == State.STARTING)
+        assert(app.mapYarnState(appId, NEW_SAVING, UNDEFINED) == State.STARTING)
+        assert(app.mapYarnState(appId, SUBMITTED, UNDEFINED) == State.STARTING)
+        assert(app.mapYarnState(appId, ACCEPTED, UNDEFINED) == State.STARTING)
+        assert(app.mapYarnState(appId, RUNNING, UNDEFINED) == State.RUNNING)
+        assert(
+          app.mapYarnState(appId, FINISHED, FinalApplicationStatus.SUCCEEDED) == State.FINISHED)
+        assert(app.mapYarnState(appId, FINISHED, FinalApplicationStatus.FAILED) == State.FAILED)
+        assert(app.mapYarnState(appId, FINISHED, FinalApplicationStatus.KILLED) == State.KILLED)
+        assert(app.mapYarnState(appId, FINISHED, UNDEFINED) == State.FAILED)
+        assert(app.mapYarnState(appId, FAILED, UNDEFINED) == State.FAILED)
+        assert(app.mapYarnState(appId, KILLED, UNDEFINED) == State.KILLED)
+      }
+    }
+  }
+}

--- a/server/src/test/scala/com/cloudera/livy/utils/SparkYarnAppSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/utils/SparkYarnAppSpec.scala
@@ -175,7 +175,7 @@ class SparkYarnAppSpec extends FunSpec {
 
         val app = new SparkYarnApp(
           appTag,
-          None,
+          Some(appId),
           Some(mockSparkSubmit),
           None,
           livyConf,

--- a/server/src/test/scala/com/cloudera/livy/utils/SparkYarnAppSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/utils/SparkYarnAppSpec.scala
@@ -47,13 +47,6 @@ class SparkYarnAppSpec extends FunSpec {
     Thread.`yield`()
   }
 
-  private def withSleepMethod(mockSleep: Long => Unit)(f: => Unit): Unit = {
-    noCatch.andFinally { Clock.setSleepMethod(Thread.sleep) } {
-      Clock.setSleepMethod(mockSleep)
-      f
-    }
-  }
-
   describe("SparkYarnApp") {
     val TEST_TIMEOUT = 30 seconds
     val appId = ConverterUtils.toApplicationId("application_1467912463905_0021")
@@ -61,7 +54,7 @@ class SparkYarnAppSpec extends FunSpec {
     livyConf.set(LivyConf.YARN_APP_LOOKUP_TIMEOUT, "0")
 
     it("should poll YARN state and terminate") {
-      withSleepMethod(mockSleep) {
+      Clock.withSleepMethod(mockSleep) {
         val mockYarnClient = mock[YarnClient]
         val mockAppListener = mock[SparkAppListener]
 
@@ -95,7 +88,7 @@ class SparkYarnAppSpec extends FunSpec {
     }
 
     it("should kill yarn app") {
-      withSleepMethod(mockSleep) {
+      Clock.withSleepMethod(mockSleep) {
         val diag = "DIAG"
         val mockYarnClient = mock[YarnClient]
 
@@ -132,7 +125,7 @@ class SparkYarnAppSpec extends FunSpec {
     }
 
     it("should return spark-submit log") {
-      withSleepMethod(mockSleep) {
+      Clock.withSleepMethod(mockSleep) {
         val mockYarnClient = mock[YarnClient]
         val mockSparkSubmit = mock[LineBufferedProcess]
         val sparkSubmitLog = IndexedSeq("SPARK-SUBMIT", "LOG")
@@ -154,7 +147,7 @@ class SparkYarnAppSpec extends FunSpec {
     }
 
     it("can kill spark-submit while it's running") {
-      withSleepMethod(mockSleep) {
+      Clock.withSleepMethod(mockSleep) {
         val mockYarnClient = mock[YarnClient]
         val mockSparkSubmit = mock[LineBufferedProcess]
         when(mockSparkSubmit.exitValue()).thenReturn(1)

--- a/test-lib/src/main/java/com/cloudera/livy/test/apps/SimpleSparkApp.java
+++ b/test-lib/src/main/java/com/cloudera/livy/test/apps/SimpleSparkApp.java
@@ -30,10 +30,16 @@ import org.apache.spark.api.java.function.PairFunction;
 public class SimpleSparkApp {
 
   public static void main(String[] args) throws Exception {
-    if (args.length != 1) {
-      throw new IllegalArgumentException("Missing output path.");
+    if (args.length < 1 || args.length > 2) {
+      throw new IllegalArgumentException(
+              "Invalid arguments. <output path> [exit after output=true]>");
     }
+
     String output = args[0];
+    Boolean exitAfterOutput = true;
+    if (args.length == 2) {
+      exitAfterOutput = Boolean.parseBoolean(args[1]);
+    }
 
     JavaSparkContext sc = new JavaSparkContext();
     try {
@@ -43,6 +49,12 @@ public class SimpleSparkApp {
       JavaPairRDD<String, Integer> rdd = sc.parallelize(data, 3)
         .mapToPair(new Counter());
       rdd.saveAsTextFile(output);
+
+      if (!exitAfterOutput) {
+        while(true) {
+          Thread.sleep(60 * 60 * 1000);
+        }
+      }
     } finally {
       sc.close();
     }

--- a/test-lib/src/main/java/com/cloudera/livy/test/apps/SimpleSparkApp.java
+++ b/test-lib/src/main/java/com/cloudera/livy/test/apps/SimpleSparkApp.java
@@ -32,7 +32,7 @@ public class SimpleSparkApp {
   public static void main(String[] args) throws Exception {
     if (args.length < 1 || args.length > 2) {
       throw new IllegalArgumentException(
-              "Invalid arguments. <output path> [exit after output=true]>");
+        "Invalid arguments. <output path> [exit after output=true]>");
     }
 
     String output = args[0];
@@ -51,7 +51,7 @@ public class SimpleSparkApp {
       rdd.saveAsTextFile(output);
 
       if (!exitAfterOutput) {
-        while(true) {
+        while (true) {
           Thread.sleep(60 * 60 * 1000);
         }
       }


### PR DESCRIPTION
When livy is running with YARN master:
- Stop and log session using YARN API.
- Exposed app id.
- Livy now requires Spark 1.6+. Added a check so Livy won't start if it's running with older Spark.

Test changes:
- Added a test to verify killing the batch session will kill its YARN app.
- Added a test to verify killing the YARN app will change the batch session state.
- Added YarnClient integration in test framework.
- Added halt mode in SimpleSparkApp in test lib for kill session test.
- Added a method to dump logs when Batch test fails.
- Added a Clock interface to allow unit testing to mock out time.