### PR TITLE
Fixed Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,19 @@ addons:
     packages:
       r-base
 
-script:
-  - mvn verify -Dtest.redirectToFile=false
+cache:
+  pip: true
+  directories:
+    - $HOME/.m2
 
 before_install:
   - pip install --user codecov
+
+install:
+  - mvn install -DskipTests=true -DskipITs=true -Dmaven.javadoc.skip=true -B -V
+
+script:
+  - mvn verify
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
- Don't run integration test during Travis's dependency install step.
- Fixed TestSparkClient to not dump tons of debug logs.
- Use Travis cache.