### PR TITLE
LIVY-139. Livy server needs notification when remote session dies

### DIFF
--- a/client-common/src/main/java/com/cloudera/livy/client/common/HttpMessages.java
+++ b/client-common/src/main/java/com/cloudera/livy/client/common/HttpMessages.java
@@ -54,15 +54,17 @@ public class HttpMessages {
   public static class SessionInfo implements ClientMessage {
 
     public final int id;
+    public final String appId;
     public final String owner;
     public final String proxyUser;
     public final String state;
     public final String kind;
     public final List<String> log;
 
-    public SessionInfo(int id, String owner, String proxyUser, String state, String kind,
-        List<String> log) {
+    public SessionInfo(int id, String appId, String owner, String proxyUser, String state,
+                       String kind, List<String> log) {
       this.id = id;
+      this.appId = appId;
       this.owner = owner;
       this.proxyUser = proxyUser;
       this.state = state;
@@ -71,7 +73,7 @@ public class HttpMessages {
     }
 
     private SessionInfo() {
-      this(-1, null, null, null, null, null);
+      this(-1, null, null, null, null, null, null);
     }
 
   }

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
   <properties>
     <hadoop.version>2.6.0-cdh5.5.0</hadoop.version>
-    <spark.version>1.5.0-cdh5.5.0</spark.version>
+    <spark.version>1.6.1</spark.version>
     <commons-codec.version>1.9</commons-codec.version>
     <httpclient.version>4.5.2</httpclient.version>
     <httpcore.version>4.4.4</httpcore.version>

--- a/rsc/src/main/java/com/cloudera/livy/rsc/RSCAppListener.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/RSCAppListener.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.cloudera.livy.rsc;
+
+import org.apache.spark.launcher.SparkAppHandle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RSCAppListener implements SparkAppHandle.Listener {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RSCAppListener.class);
+  private SparkAppHandle appHandle;
+  private String appId;
+  private SparkAppHandle.State appState;
+
+  @Override
+  public void stateChanged(SparkAppHandle handle) {
+    this.appHandle = handle;
+    this.appState = handle.getState();
+  }
+
+  @Override
+  public void infoChanged(SparkAppHandle handle) {
+    this.appHandle = handle;
+    this.appId = handle.getAppId();
+  }
+
+  public String getAppId() {
+    return appId;
+  }
+
+  public SparkAppHandle.State getAppState() {
+    return appState;
+  }
+
+  public void stopApp() {
+    LOG.info("Trying to stop app {}", appId);
+    appHandle.stop();
+  }
+
+  public void disconnect() {
+    LOG.info("Disconnect with app {}", appId);
+    appHandle.disconnect();
+  }
+}

--- a/rsc/src/main/java/com/cloudera/livy/rsc/RSCClientFactory.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/RSCClientFactory.java
@@ -57,14 +57,15 @@ public final class RSCClientFactory implements LivyClientFactory {
     boolean needsServer = false;
     try {
       Promise<ContextInfo> info;
+      RSCAppListener appListener = new RSCAppListener();
       if (uri.getUserInfo() != null && uri.getHost() != null && uri.getPort() > 0) {
         info = createContextInfo(uri);
       } else {
         needsServer = true;
         ref(lconf);
-        info = ContextLauncher.create(this, lconf);
+        info = ContextLauncher.create(this, lconf, appListener);
       }
-      return new RSCClient(lconf, info);
+      return new RSCClient(lconf, info, appListener);
     } catch (Exception e) {
       if (needsServer) {
         unref();

--- a/server/src/main/scala/com/cloudera/livy/server/batch/BatchSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/batch/BatchSession.scala
@@ -68,6 +68,8 @@ class BatchSession(
 
   override def state: SessionState = _state
 
+  override def appId: Option[String] = None
+
   override def logLines(): IndexedSeq[String] = process.inputLines
 
   override def stopSession(): Unit = destroyProcess()

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
@@ -30,7 +30,7 @@ import scala.collection.mutable
 import scala.concurrent.{Future, _}
 import scala.util.{Failure, Success, Try}
 
-import org.apache.spark.launcher.SparkLauncher
+import org.apache.spark.launcher.{SparkAppHandle, SparkLauncher}
 import org.json4s._
 import org.json4s.{DefaultFormats, Formats, JValue}
 import org.json4s.JsonAST.JString
@@ -386,4 +386,11 @@ class InteractiveSession(
     opId
    }
 
+  override def appId: Option[String] = {
+    if (client.getAppId != null) {
+      Some(client.getAppId)
+    } else {
+      None
+    }
+  }
 }

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSessionServlet.scala
@@ -70,8 +70,8 @@ class InteractiveSessionServlet(livyConf: LivyConf)
         Nil
       }
 
-    new SessionInfo(session.id, session.owner, session.proxyUser.orNull, session.state.toString,
-      session.kind.toString, logs.asJava)
+    new SessionInfo(session.id, "", session.owner, session.proxyUser.orNull,
+      session.state.toString, session.kind.toString, logs.asJava)
   }
 
   private def statementView(statement: Statement): Any = {

--- a/server/src/main/scala/com/cloudera/livy/sessions/Session.scala
+++ b/server/src/main/scala/com/cloudera/livy/sessions/Session.scala
@@ -53,6 +53,8 @@ abstract class Session(val id: Int, val owner: String, val livyConf: LivyConf) e
   // to the session's effective user.
   private var stagingDir: Path = null
 
+  def appId: Option[String]
+
   def lastActivity: Long = state match {
     case SessionState.Error(time) => time
     case SessionState.Dead(time) => time

--- a/server/src/test/scala/com/cloudera/livy/server/SessionServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/SessionServletSpec.scala
@@ -36,10 +36,11 @@ object SessionServletSpec {
 
     override def state: SessionState = SessionState.Idle()
 
+    override def appId: Option[String] = None
+
     override protected def stopSession(): Unit = ()
 
     override def logLines(): IndexedSeq[String] = IndexedSeq("log")
-
   }
 
   case class MockSessionView(id: Int, owner: String, logs: Seq[String])

--- a/server/src/test/scala/com/cloudera/livy/sessions/MockSession.scala
+++ b/server/src/test/scala/com/cloudera/livy/sessions/MockSession.scala
@@ -31,6 +31,8 @@ class MockSession(id: Int, owner: String, conf: LivyConf) extends Session(id, ow
 
   override def state: SessionState = SessionState.Idle()
 
+  override def appId: Option[String] = None
+
   override val timeout: Long = 0L
 
   override def resolveURIs(uris: Seq[String]): Seq[String] = super.resolveURIs(uris)


### PR DESCRIPTION
We see 2 bugs in livy. 
* livy session state will remain as it was when yarn app is killed/failed
* yarn app will be always in ACCEPT state when session creation timeout. (It happens when no sufficient resource capacity)  

This PR will resolve these 2 issues, but only limit to yarn mode.  