### PR TITLE
LIVY-188. 	change kryo serde method usage

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -54,6 +54,7 @@
       <property name="allowEscapesForControlCharacters" value="true"/>
       <property name="allowByTailComment" value="true"/>
       <property name="allowNonPrintableEscapes" value="true"/>
+      <property name="allowIfAllCharactersEscaped" value="true"/>
     </module>
     <module name="LineLength">
       <property name="max" value="100"/>

--- a/client-common/src/main/java/com/cloudera/livy/client/common/Serializer.java
+++ b/client-common/src/main/java/com/cloudera/livy/client/common/Serializer.java
@@ -22,7 +22,6 @@ import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 
 import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.io.ByteBufferInputStream;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.esotericsoftware.shaded.org.objenesis.strategy.StdInstantiatorStrategy;

--- a/client-common/src/main/java/com/cloudera/livy/client/common/Serializer.java
+++ b/client-common/src/main/java/com/cloudera/livy/client/common/Serializer.java
@@ -59,7 +59,9 @@ public class Serializer {
   }
 
   public Object deserialize(ByteBuffer data) {
-    Input kryoIn = new Input(new ByteBufferInputStream(data));
+    byte[] b = new byte[data.remaining()];
+    data.get(b);
+    Input kryoIn = new Input(b);
     return kryos.get().readClassAndObject(kryoIn);
   }
 

--- a/client-common/src/test/java/com/cloudera/livy/client/common/TestSerializer.java
+++ b/client-common/src/test/java/com/cloudera/livy/client/common/TestSerializer.java
@@ -38,7 +38,7 @@ public class TestSerializer {
 
   @Test
   // Scalastyle is treating unicode escape as non ascii characters. Turn off the check.
-  // scalastyle:off non.ascii.character.disallowed  
+  // scalastyle:off non.ascii.character.disallowed
   public void testUnicodeSerializer() throws Exception {
     StringBuilder builder = new StringBuilder();
     for (int x = 0; x < 5000; x++) {

--- a/client-common/src/test/java/com/cloudera/livy/client/common/TestSerializer.java
+++ b/client-common/src/test/java/com/cloudera/livy/client/common/TestSerializer.java
@@ -20,7 +20,6 @@ package com.cloudera.livy.client.common;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 

--- a/client-common/src/test/java/com/cloudera/livy/client/common/TestSerializer.java
+++ b/client-common/src/test/java/com/cloudera/livy/client/common/TestSerializer.java
@@ -37,6 +37,8 @@ public class TestSerializer {
   }
 
   @Test
+  // Scalastyle is treating unicode escape as non ascii characters. Turn off the check.
+  // scalastyle:off non.ascii.character.disallowed  
   public void testUnicodeSerializer() throws Exception {
     StringBuilder builder = new StringBuilder();
     for (int x = 0; x < 5000; x++) {
@@ -46,6 +48,7 @@ public class TestSerializer {
     Object decoded = doSerDe(testMessage);
     assertEquals(testMessage, decoded);
   }
+  // scalastyle:on non.ascii.character.disallowed
 
   @Test
   public void testAutoRegistration() throws Exception {

--- a/client-common/src/test/java/com/cloudera/livy/client/common/TestSerializer.java
+++ b/client-common/src/test/java/com/cloudera/livy/client/common/TestSerializer.java
@@ -37,8 +37,6 @@ public class TestSerializer {
   }
 
   @Test
-  // Scalastyle is treating unicode escape as non ascii characters. Turn off the check.
-  // scalastyle:off non.ascii.character.disallowed
   public void testUnicodeSerializer() throws Exception {
     StringBuilder builder = new StringBuilder();
     for (int x = 0; x < 5000; x++) {
@@ -48,7 +46,6 @@ public class TestSerializer {
     Object decoded = doSerDe(testMessage);
     assertEquals(testMessage, decoded);
   }
-  // scalastyle:on non.ascii.character.disallowed
 
   @Test
   public void testAutoRegistration() throws Exception {

--- a/client-common/src/test/java/com/cloudera/livy/client/common/TestSerializer.java
+++ b/client-common/src/test/java/com/cloudera/livy/client/common/TestSerializer.java
@@ -20,6 +20,7 @@ package com.cloudera.livy.client.common;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -34,6 +35,17 @@ public class TestSerializer {
   public void testSerializer() throws Exception {
     Object decoded = doSerDe(MESSAGE);
     assertEquals(MESSAGE, decoded);
+  }
+
+  @Test
+  public void testUnicodeSerializer() throws Exception {
+    StringBuilder builder = new StringBuilder();
+    for (int x = 0; x < 5000; x++) {
+      builder.append("\u263A");
+    }
+    String testMessage = builder.toString();
+    Object decoded = doSerDe(testMessage);
+    assertEquals(testMessage, decoded);
   }
 
   @Test


### PR DESCRIPTION
currently kryo serde method usage has bug when SerDe long string include unicode.

may be this is kryo bug.
but, may be this is wrong method usage.

so using byte array instead of ByteBufferInputStream.
