### PR TITLE
LIVY-201. Pick up R executable from configuration first

### DIFF
--- a/repl/src/main/scala/com/cloudera/livy/repl/SparkRInterpreter.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/SparkRInterpreter.scala
@@ -87,7 +87,11 @@ object SparkRInterpreter {
     try {
       // Wait for RBackend initialization to finish
       initialized.tryAcquire(backendTimeout, TimeUnit.SECONDS)
-      val rExec = sys.env.getOrElse("DRIVER_R", "R")
+      val rExec = conf.getOption("spark.sparkr.r.command")
+        .orElse(conf.getOption("spark.r.command"))
+        .orElse(sys.env.get("DRIVER_R"))
+        .getOrElse("R")
+
       var packageDir = ""
       if (sys.env.getOrElse("SPARK_YARN_MODE", "") == "true") {
         packageDir = "./sparkr.zip"

--- a/repl/src/main/scala/com/cloudera/livy/repl/SparkRInterpreter.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/SparkRInterpreter.scala
@@ -87,9 +87,10 @@ object SparkRInterpreter {
     try {
       // Wait for RBackend initialization to finish
       initialized.tryAcquire(backendTimeout, TimeUnit.SECONDS)
-      val rExec = conf.getOption("spark.sparkr.r.command")
-        .orElse(conf.getOption("spark.r.command"))
+      val rExec = conf.getOption("spark.r.driver.command")
         .orElse(sys.env.get("DRIVER_R"))
+        .orElse(conf.getOption("spark.r.command"))
+        .orElse(conf.getOption("spark.sparkr.r.command"))
         .getOrElse("R")
 
       var packageDir = ""


### PR DESCRIPTION
For now, I can not run sparkr in cluster mode as livy pick up R executable from environment variable DRIVER_R, but spark didn't pass DRIVER_R to AM in yarn-cluster mode (This can be fixed in spark side). And since spark introduce spark.sparkr.r.command & spark.r.command for configuring R executable. Livy should also take this configuration over environment variable DRIVER_R.