### PR TITLE
LIVY-194. Share SparkContext across languages

### DIFF
--- a/core/src/main/scala/com/cloudera/livy/sessions/Kind.scala
+++ b/core/src/main/scala/com/cloudera/livy/sessions/Kind.scala
@@ -39,6 +39,10 @@ case class SparkR() extends Kind {
   override def toString: String = "sparkr"
 }
 
+case class Shared() extends Kind {
+  override def toString: String = "shared"
+}
+
 object Kind {
 
   def apply(kind: String): Kind = kind match {
@@ -46,6 +50,7 @@ object Kind {
     case "pyspark" | "python" => PySpark()
     case "pyspark3" | "python3" => PySpark3()
     case "sparkr" | "r" => SparkR()
+    case "shared" => Shared()
     case other => throw new IllegalArgumentException(s"Invalid kind: $other")
   }
 

--- a/integration-test/src/main/scala/com/cloudera/livy/test/framework/BaseIntegrationTestSuite.scala
+++ b/integration-test/src/main/scala/com/cloudera/livy/test/framework/BaseIntegrationTestSuite.scala
@@ -97,6 +97,13 @@ abstract class BaseIntegrationTestSuite extends FunSuite with Matchers with Befo
     }
   }
 
+  protected def sharedtest(desc: String) (testFn: => Unit): Unit = {
+    test(desc) {
+      assume(cluster.isRealSpark(), "Shared Interpreter tests require a real Spark installation.")
+      testFn
+    }
+  }
+
   // We need beforeAll() here because BatchIT's beforeAll() has to be executed after this.
   // Please create an issue if this breaks test logging for cluster creation.
   protected override def beforeAll() = {

--- a/integration-test/src/test/scala/com/cloudera/livy/test/InteractiveIT.scala
+++ b/integration-test/src/test/scala/com/cloudera/livy/test/InteractiveIT.scala
@@ -83,6 +83,11 @@ class InteractiveIT extends BaseIntegrationTestSuite with BeforeAndAfter {
          | |-- age: double (nullable = true)""".stripMargin))
   }
 
+  sharedtest("SparkContext shared session") {
+    sessionId = livyClient.startSession(Shared())
+    matchResult("%spark sc.parallelize(1 to 10).sum()", startsWith("res1: 55"))
+  }
+
   test("application kills session") {
     sessionId = livyClient.startSession(Spark())
     waitTillSessionIdle(sessionId)

--- a/repl/src/main/resources/fake_shell.r
+++ b/repl/src/main/resources/fake_shell.r
@@ -1,0 +1,12 @@
+
+library(SparkR)
+port <- Sys.getenv("EXISTING_SPARKR_BACKEND_PORT", "")
+SparkR:::connectBackend("localhost", port)
+
+assign(".scStartTime", as.integer(Sys.time()), envir = SparkR:::.sparkREnv)
+# get SparkConf/SparkContext/SQLContext from JVM side rather than creating them
+# from R. So that we can share the same SparkContext/SQLContext in one jvm.
+assign(".sc", SparkR:::callJStatic("com.cloudera.livy.repl.SparkRInterpreter", "getSparkContext"), envir = SparkR:::.sparkREnv)
+assign("sc", get(".sc", envir = SparkR:::.sparkREnv), envir=.GlobalEnv)
+assign(".sqlc", SparkR:::callJStatic("com.cloudera.livy.repl.SparkRInterpreter", "getSQLContext"), envir = SparkR:::.sparkREnv)
+assign("sqlContext", get(".sqlc", envir = SparkR:::.sparkREnv), envir = .GlobalEnv)

--- a/repl/src/main/scala/com/cloudera/livy/repl/ProcessInterpreter.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/ProcessInterpreter.scala
@@ -75,7 +75,6 @@ abstract class ProcessInterpreter(process: Process)
       } catch {
         case _: IOException =>
       }
-
       try {
         process.destroy()
       } finally {
@@ -126,7 +125,7 @@ abstract class ProcessInterpreter(process: Process)
     override def run() = {
       val exitCode = process.waitFor()
       if (exitCode != 0) {
-        error(f"Process has died with $exitCode")
+        error(f"Process has died with $exitCode, " + stderrLines.mkString("\n"))
       }
     }
   }

--- a/repl/src/main/scala/com/cloudera/livy/repl/PythonInterpreter.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/PythonInterpreter.scala
@@ -43,8 +43,8 @@ object PythonInterpreter extends Logging {
         case PySpark3() => sys.env.getOrElse("PYSPARK3_DRIVER_PYTHON", "python3")
         case PySpark() => sys.env.getOrElse("PYSPARK_DRIVER_PYTHON", "python")
     }
-
-    val gatewayServer = new GatewayServer(null, 0)
+    SparkFactory.setSparkConf(conf)
+    val gatewayServer = new GatewayServer(SparkFactory, 0)
     gatewayServer.start()
 
     val builder = new ProcessBuilder(Seq(pythonExec, createFakeShell().toString).asJava)

--- a/repl/src/main/scala/com/cloudera/livy/repl/ReplDriver.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/ReplDriver.scala
@@ -50,6 +50,7 @@ class ReplDriver(conf: SparkConf, livyConf: RSCConf)
       case PySpark3() => PythonInterpreter(conf, PySpark3())
       case Spark() => new SparkInterpreter(conf)
       case SparkR() => SparkRInterpreter(conf)
+      case Shared() => new SharedInterpreter(conf)
     }
 
     session = new Session(interpreter)

--- a/repl/src/main/scala/com/cloudera/livy/repl/SharedInterpreter.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/SharedInterpreter.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.cloudera.livy.repl
+
+import org.apache.spark.{SparkConf, SparkContext}
+
+import com.cloudera.livy.repl.Interpreter.ExecuteResponse
+import com.cloudera.livy.sessions.PySpark
+
+class SharedInterpreter(conf: SparkConf) extends Interpreter {
+
+  private val interpreters: Map[String, Interpreter] = Map(
+    "spark" -> new SparkInterpreter(conf),
+    "pyspark" -> PythonInterpreter(conf, PySpark()),
+    "sparkr" -> SparkRInterpreter(conf))
+
+  override def kind: String = "shared"
+
+  /**
+   * Execute the code and return the result as a Future as it may
+   * take some time to execute.
+   * The input to SharedInterpreter should like '%kind code'
+   * e.g. %spark 1+1
+   */
+  override def execute(code: String): ExecuteResponse = {
+    require(code.startsWith("%"))
+    val firstSpace = code.indexOf(' ')
+    val codeType = code.substring(1, firstSpace)
+    interpreters(codeType).execute(code.substring(firstSpace + 1))
+  }
+
+  /** Shut down the interpreter. */
+  override def close(): Unit = {
+    interpreters.foreach(_._2.close())
+  }
+
+  /**
+   * Start the Interpreter.
+   *
+   */
+  override def start(): SparkContext = {
+    interpreters.foreach(_._2.start())
+    interpreters("spark").asInstanceOf[SparkInterpreter].getSparkContext()
+  }
+}

--- a/repl/src/main/scala/com/cloudera/livy/repl/SparkFactory.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/SparkFactory.scala
@@ -1,0 +1,96 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.cloudera.livy.repl
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.api.java.JavaSparkContext
+import org.apache.spark.sql.hive.HiveContext
+import org.apache.spark.sql.SQLContext
+
+import com.cloudera.livy.Logging
+
+
+/**
+  * SparkContext/SQLContext are created in this object, so that we can share the
+  * SparkContext/SQLContext in one jvm.
+  */
+object SparkFactory extends Logging {
+
+  private var sparkContext: SparkContext = _
+
+  private var sqlContext: SQLContext = _
+
+  private var conf: SparkConf = _
+
+
+  def setSparkConf(conf: SparkConf): Unit = {
+    this.conf = conf
+  }
+
+  def getSparkConf(): SparkConf = this.conf
+
+  def getOrCreateSparkContext(): SparkContext = {
+    synchronized {
+      if (sparkContext == null) {
+        sparkContext = SparkContext.getOrCreate(conf)
+      }
+      sparkContext
+    }
+  }
+
+  def close(): Unit = {
+    synchronized {
+      if (sparkContext != null) {
+        sparkContext.stop()
+        sparkContext = null
+      }
+      sqlContext = null
+    }
+  }
+
+  def getJavaSparkContext(): JavaSparkContext = new JavaSparkContext(getOrCreateSparkContext())
+
+  def getOrCreateSQLContext(): SQLContext = {
+    synchronized {
+      if (sqlContext == null) {
+        if (conf.getBoolean("spark.repl.enableHiveContext", false)) {
+          try {
+            val loader = Option(Thread.currentThread().getContextClassLoader)
+              .getOrElse(getClass.getClassLoader)
+            if (loader.getResource("hive-site.xml") == null) {
+              warn("livy.repl.enableHiveContext is true but no hive-site.xml found on classpath.")
+            }
+            info("Created sql context (with Hive support).")
+            sqlContext = new HiveContext(sparkContext)
+
+          } catch {
+            case _: java.lang.NoClassDefFoundError =>
+              info("Created sql context.")
+              sqlContext = new SQLContext(sparkContext)
+          }
+        } else {
+          info("Created sql context.")
+          sqlContext = new SQLContext(sparkContext)
+        }
+      }
+      sqlContext
+    }
+  }
+}

--- a/repl/src/test/scala/com/cloudera/livy/repl/ReplDriverSuite.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/ReplDriverSuite.scala
@@ -52,7 +52,7 @@ class ReplDriverSuite extends FunSuite {
 
     try {
       // This is sort of what InteractiveSession.scala does to detect an idle session.
-      val handle = client.submit(new PingJob()).get(30, TimeUnit.SECONDS)
+      val handle = client.submit(new PingJob()).get(60, TimeUnit.SECONDS)
 
       assert(client.getReplState().get(10, TimeUnit.SECONDS) === "idle")
 

--- a/repl/src/test/scala/com/cloudera/livy/repl/SharedInterpreterSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/SharedInterpreterSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.repl
+
+import org.apache.spark.SparkConf
+import org.json4s.{DefaultFormats, Extraction}
+import org.json4s.JsonDSL._
+
+class SharedInterpreterSpec extends BaseInterpreterSpec {
+
+  implicit val formats = DefaultFormats
+
+  override def createInterpreter(): Interpreter = new SharedInterpreter(new SparkConf())
+
+  it should "execute `1 + 2` == 3" in withInterpreter { interpreter =>
+    var response = interpreter.execute("%spark 1 + 2")
+    response should equal (Interpreter.ExecuteSuccess(
+      TEXT_PLAIN -> "res0: Int = 3"
+    ))
+
+    response = interpreter.execute("%pyspark 1 + 2")
+    response should equal (Interpreter.ExecuteSuccess(
+      TEXT_PLAIN -> "3"
+    ))
+
+    response = interpreter.execute("%sparkr 1 + 2")
+    response should equal (Interpreter.ExecuteSuccess(
+      TEXT_PLAIN -> "[1] 3"
+    ))
+  }
+
+  it should "execute spark command" in withInterpreter { interpreter =>
+    var response = interpreter.execute(
+      """%spark sc.parallelize(0 to 10).sum()""".stripMargin)
+
+    response should equal(Interpreter.ExecuteSuccess(
+      TEXT_PLAIN -> "res0: Double = 55.0"
+    ))
+  }
+}

--- a/repl/src/test/scala/com/cloudera/livy/repl/SparkInterpreterSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/SparkInterpreterSpec.scala
@@ -22,7 +22,7 @@ import org.apache.spark.SparkConf
 import org.json4s.{DefaultFormats, JValue}
 import org.json4s.JsonDSL._
 
-class ScalaInterpreterSpec extends BaseInterpreterSpec {
+class SparkInterpreterSpec extends BaseInterpreterSpec {
 
   implicit val formats = DefaultFormats
 

--- a/rsc/src/main/java/com/cloudera/livy/rsc/ContextLauncher.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/ContextLauncher.java
@@ -28,13 +28,7 @@ import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -42,6 +36,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.attribute.PosixFilePermission.*;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.concurrent.Promise;
 import org.apache.spark.launcher.SparkLauncher;
@@ -169,9 +165,9 @@ class ContextLauncher {
     merge(conf, SPARK_JARS_KEY, livyJars, ",");
 
     String kind = conf.get(SESSION_KIND);
-    if ("sparkr".equals(kind)) {
+    if (Sets.newHashSet("sparkr", "shared").contains(kind)) {
       merge(conf, SPARK_ARCHIVES_KEY, conf.get(RSCConf.Entry.SPARKR_PACKAGE), ",");
-    } else if ("pyspark".equals(kind)) {
+    } else if (Sets.newHashSet("pyspark", "shared").equals(kind)) {
       merge(conf, "spark.submit.pyFiles", conf.get(RSCConf.Entry.PYSPARK_ARCHIVES), ",");
     }
 

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
@@ -111,6 +111,14 @@ class InteractiveSession(
         sparkRArchive.foreach { archive =>
           builderProperties.put(RSCConf.Entry.SPARKR_PACKAGE.key(), archive)
         }
+      case Shared() =>
+        val pySparkFiles = if (!LivyConf.TEST_MODE) findPySparkArchives() else Nil
+        mergeConfList(pySparkFiles, LivyConf.SPARK_PY_FILES)
+        builderProperties.put(SparkYarnIsPython, "true")
+        val sparkRArchive = if (!LivyConf.TEST_MODE) findSparkRArchive() else None
+        sparkRArchive.foreach { archive =>
+          builderProperties.put(RSCConf.Entry.SPARKR_PACKAGE.key(), archive)
+        }
       case _ =>
     }
     builderProperties.put(RSCConf.Entry.SESSION_KIND.key, kind.toString)


### PR DESCRIPTION
This PR is to share the same SparkContext across languages (scala/python/R). I introduce another new kind `shared` interpreter which support scala/python/R.  And they share the same SparkContext. 

Main changes:
- new kind interpreter `SharedInterpreter` which contains a map of other kinds of interpreter. The input code format of SharedInterpreter should be `%kind code`,  e.g. 

```
%spark sc.parallelize(1 to 10).sum()
```
- SparkContext/SQLContext will be created from SparkFactory so that we can share the same SparkContext/SQLContext. Scala/Python/R will all get SparkContext/SQLContext from SparkFactory.
