### PR TITLE
LIVY-186. Better YARN integration for Interactive Session.

### DIFF
--- a/client-http/src/test/scala/com/cloudera/livy/client/http/HttpClientSpec.scala
+++ b/client-http/src/test/scala/com/cloudera/livy/client/http/HttpClientSpec.scala
@@ -269,6 +269,7 @@ private class HttpClientTestBootstrap extends LifeCycle {
         val session = mock(classOf[InteractiveSession])
         val id = sessionManager.nextId()
         when(session.id).thenReturn(id)
+        when(session.appId).thenReturn(None)
         when(session.state).thenReturn(SessionState.Idle())
         when(session.proxyUser).thenReturn(None)
         when(session.kind).thenReturn(Spark())

--- a/conf/livy.conf
+++ b/conf/livy.conf
@@ -54,7 +54,7 @@
 # livy.repl.enableHiveContext =
 
 # If Livy can't find the yarn app within this time, consider it lost.
-livy.server.yarn.app-lookup-timeout = 30s
+## livy.server.yarn.app-lookup-timeout = 30s
 
 # How often Livy polls YARN to refresh YARN app state.
-# livy.server.yarn.poll-interval = 1s
+## livy.server.yarn.poll-interval = 1s

--- a/conf/livy.conf
+++ b/conf/livy.conf
@@ -1,26 +1,26 @@
 # Use this keystore for the SSL certificate and key.
-## livy.keystore =
+# livy.keystore =
 
 # Specify the keystore password.
-## livy.keystore.password =
+# livy.keystore.password =
 
 # What host address to start the server on. By default, Livy will bind to all network interfaces.
-## livy.server.host = 0.0.0.0
+# livy.server.host = 0.0.0.0
 
 # What port to start the server on.
-## livy.server.port = 8998
+# livy.server.port = 8998
 
 # What spark master Livy sessions should use.
-## livy.spark.master = local
+# livy.spark.master = local
 
 # What spark deploy mode Livy sessions should use.
-## livy.spark.deployMode =
+# livy.spark.deployMode =
 
 # Time in milliseconds on how long Livy will wait before timing out an idle session.
-## livy.server.session.timeout = 1h
+# livy.server.session.timeout = 1h
 
 # If livy should impersonate the requesting users when creating a new session.
-## livy.impersonation.enabled = true
+# livy.impersonation.enabled = true
 
 # Comma-separated list of Livy RSC jars. By default Livy will upload jars from its installation
 # directory every time a session is started. By caching these files in HDFS, for example, startup
@@ -54,7 +54,7 @@
 # livy.repl.enableHiveContext =
 
 # If Livy can't find the yarn app within this time, consider it lost.
-## livy.server.yarn.app-lookup-timeout = 30s
+# livy.server.yarn.app-lookup-timeout = 30s
 
 # How often Livy polls YARN to refresh YARN app state.
-## livy.server.yarn.poll-interval = 1s
+# livy.server.yarn.poll-interval = 1s

--- a/integration-test/src/main/scala/com/cloudera/livy/test/framework/MiniCluster.scala
+++ b/integration-test/src/main/scala/com/cloudera/livy/test/framework/MiniCluster.scala
@@ -144,9 +144,14 @@ object MiniLivyMain extends MiniClusterBase {
   var livyUrl: Option[String] = None
 
   def start(config: MiniClusterConfig, configPath: String): Unit = {
-    val livyConf = Map(
+    var livyConf = Map(
       LivyConf.LIVY_SPARK_MASTER.key -> "yarn",
       LivyConf.LIVY_SPARK_DEPLOY_MODE.key -> "cluster")
+
+    if (BaseIntegrationTestSuite.isRunningOnTravis) {
+      livyConf ++= Map("livy.server.yarn.app-lookup-timeout" -> "2m")
+    }
+
     saveProperties(livyConf, new File(configPath + "/livy.conf"))
 
     val server = new LivyServer()

--- a/integration-test/src/test/scala/com/cloudera/livy/test/BatchIT.scala
+++ b/integration-test/src/test/scala/com/cloudera/livy/test/BatchIT.scala
@@ -129,7 +129,7 @@ class BatchIT extends BaseIntegrationTestSuite with BeforeAndAfterAll {
       case e: Throwable =>
         ignoringAll {
           info(s"Session log: ${getBatchSessionInfo(batchId).log}")
-          info(s"YARN log: ${getYarnLog(batchId)}")
+          info(s"YARN log: ${getBatchYarnLog(batchId)}")
         }
         throw e
     } finally {
@@ -137,15 +137,12 @@ class BatchIT extends BaseIntegrationTestSuite with BeforeAndAfterAll {
     }
   }
 
-  private def getYarnLog(batchId: Int): String = {
+  private def getBatchYarnLog(batchId: Int): String = {
     allCatch.opt {
       val appId = getBatchSessionInfo(batchId).appId
       assert(appId != null, "appId shouldn't be null")
 
-      val appReport = cluster.yarnClient.getApplicationReport(ConverterUtils.toApplicationId(appId))
-      assert(appReport != null, "appReport shouldn't be null")
-
-      appReport.getDiagnostics()
+      getYarnLog(appId)
     }.getOrElse("")
   }
 

--- a/rsc/src/main/java/com/cloudera/livy/rsc/RSCClient.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/RSCClient.java
@@ -205,7 +205,7 @@ public class RSCClient implements LivyClient {
         }
       } catch (Exception e) {
         LOG.warn("Exception while waiting for end session reply.", e);
-        throw new RuntimeException("Exception while waiting for end session reply.", e);
+        Utils.propagate(e);
       } finally {
         if (driverRpc.isSuccess()) {
           try {

--- a/rsc/src/main/java/com/cloudera/livy/rsc/RSCConf.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/RSCConf.java
@@ -69,7 +69,9 @@ public class RSCConf extends ClientConf<RSCConf> {
     RPC_SECRET_RANDOM_BITS("secret.bits", 256),
 
     SASL_MECHANISMS("rpc.sasl.mechanisms", "DIGEST-MD5"),
-    SASL_QOP("rpc.sasl.qop", null);
+    SASL_QOP("rpc.sasl.qop", null),
+
+    TEST_STUCK_END_SESSION("test.do_not_use.stuck_end_session", false);
 
     private final String key;
     private final Object dflt;

--- a/rsc/src/main/java/com/cloudera/livy/rsc/driver/RSCDriver.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/driver/RSCDriver.java
@@ -364,8 +364,12 @@ public class RSCDriver extends BaseProtocol {
   }
 
   public void handle(ChannelHandlerContext ctx, EndSession msg) {
-    LOG.debug("Shutting down due to EndSession request.");
-    shutdown();
+    if (livyConf.getBoolean(TEST_STUCK_END_SESSION)) {
+      LOG.warn("Ignoring EndSession request because TEST_STUCK_END_SESSION is set.");
+    } else {
+      LOG.debug("Shutting down due to EndSession request.");
+      shutdown();
+    }
   }
 
   public void handle(ChannelHandlerContext ctx, JobRequest<?> msg) {

--- a/server/src/main/scala/com/cloudera/livy/server/batch/BatchSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/batch/BatchSession.scala
@@ -63,7 +63,7 @@ class BatchSession(
 
     val file = resolveURIs(Seq(request.file))(0)
     val sparkSubmitProcess = builder.start(Some(file), request.args)
-    SparkApp.create(uniqueAppTag, sparkSubmitProcess, livyConf, Some(this))
+    SparkApp.create(uniqueAppTag, Option(sparkSubmitProcess), livyConf, Some(this))
   }
 
   protected implicit def executor: ExecutionContextExecutor = ExecutionContext.global

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
@@ -200,10 +200,10 @@ class InteractiveSession(
       client.stop(true)
     } catch {
       case _: Exception =>
-        app.foreach({
+        app.foreach {
           warn(s"Failed to stop RSCDriver. Killing it...")
           _.kill()
-        })
+        }
     } finally {
       transition(SessionState.Dead())
     }

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
@@ -28,7 +28,7 @@ import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.concurrent.{Future, _}
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Random, Success, Try}
 
 import org.apache.spark.launcher.SparkLauncher
 import org.json4s._
@@ -40,6 +40,7 @@ import com.cloudera.livy._
 import com.cloudera.livy.client.common.HttpMessages._
 import com.cloudera.livy.rsc.{PingJob, RSCClient, RSCConf}
 import com.cloudera.livy.sessions._
+import com.cloudera.livy.utils.{SparkApp, SparkAppListener}
 
 object InteractiveSession {
   val LivyReplJars = "livy.repl.jars"
@@ -52,7 +53,8 @@ class InteractiveSession(
     override val proxyUser: Option[String],
     livyConf: LivyConf,
     request: CreateInteractiveRequest)
-  extends Session(id, owner, livyConf) {
+  extends Session(id, owner, livyConf)
+  with SparkAppListener {
 
   import InteractiveSession._
 
@@ -65,9 +67,11 @@ class InteractiveSession(
 
   val kind = request.kind
 
-  private val client = {
-    val conf = prepareConf(request.conf, request.jars, request.files, request.archives,
-      request.pyFiles)
+  private val (client: RSCClient, app: Option[SparkApp]) = {
+    val uniqueAppTag = s"livy-session-$id-${Random.alphanumeric.take(8).mkString}"
+
+    val conf = SparkApp.prepareSparkConf(uniqueAppTag, livyConf,
+      prepareConf(request.conf, request.jars, request.files, request.archives, request.pyFiles))
 
     val builderProperties = mutable.Map[String, String]()
     builderProperties ++= conf
@@ -143,8 +147,19 @@ class InteractiveSession(
       .setConf(RSCConf.Entry.DRIVER_CLASS.key(), "com.cloudera.livy.repl.ReplDriver")
       .setConf(RSCConf.Entry.PROXY_USER.key(), proxyUser.orNull)
       .setURI(new URI("rsc:/"))
-    builder.build()
-  }.asInstanceOf[RSCClient]
+    val client = builder.build().asInstanceOf[RSCClient]
+
+    val app = if (livyConf.isRunningOnYarn()) {
+      // When Livy is running with YARN, SparkYarnApp can provide better YARN integration.
+      // (e.g. Reflect YARN application state to session state).
+      Option(SparkApp.create(uniqueAppTag, None, livyConf, Some(this)))
+    } else {
+      // When Livy is running with other cluster manager, SparkApp doesn't provide any additional
+      // benefit over controlling RSCDriver using RSCClient. Don't use it.
+      None
+    }
+    (client, app)
+  }
 
   // Send a dummy job that will return once the client is ready to be used, and set the
   // state to "idle" at that point.
@@ -152,18 +167,22 @@ class InteractiveSession(
     override def onJobQueued(job: JobHandle[Void]): Unit = { }
     override def onJobStarted(job: JobHandle[Void]): Unit = { }
 
-    override def onJobCancelled(job: JobHandle[Void]): Unit = {
-      transition(SessionState.Error())
-      stop()
-    }
+    override def onJobCancelled(job: JobHandle[Void]): Unit = errorOut()
 
-    override def onJobFailed(job: JobHandle[Void], cause: Throwable): Unit = {
-      transition(SessionState.Error())
-      stop()
-    }
+    override def onJobFailed(job: JobHandle[Void], cause: Throwable): Unit = errorOut()
 
     override def onJobSucceeded(job: JobHandle[Void], result: Void): Unit = {
       transition(SessionState.Idle())
+    }
+
+    private def errorOut(): Unit = {
+      // Other code might call stop() to close the RPC channel. When RPC channel is closing,
+      // this callback might be triggered. Check and don't call stop() to avoid nested called
+      // if the session is already shutting down.
+      if (_state != SessionState.ShuttingDown()) {
+        transition(SessionState.Error())
+        stop()
+      }
     }
   })
 
@@ -171,14 +190,23 @@ class InteractiveSession(
   private[this] var _executedStatements = 0
   private[this] var _statements = IndexedSeq[Statement]()
 
-  override def logLines(): IndexedSeq[String] = IndexedSeq()
+  override def logLines(): IndexedSeq[String] = app.map(_.log()).getOrElse(IndexedSeq.empty)
 
   override def state: SessionState = _state
 
   override def stopSession(): Unit = {
-    transition(SessionState.ShuttingDown())
-    client.stop(true)
-    transition(SessionState.Dead())
+    try {
+      transition(SessionState.ShuttingDown())
+      client.stop(true)
+    } catch {
+      case _: Exception =>
+        app.foreach({
+          warn(s"Failed to stop RSCDriver. Killing it...")
+          _.kill()
+        })
+    } finally {
+      transition(SessionState.Dead())
+    }
   }
 
   def statements: IndexedSeq[Statement] = _statements
@@ -366,7 +394,14 @@ class InteractiveSession(
   }
 
   private def transition(state: SessionState) = synchronized {
-    _state = state
+    // When a statement returns an error, the session should transit to error state.
+    // If the session crashed because of the error, the session should instead go to dead state.
+    // Since these 2 transitions are triggered by different threads, there's a race condition.
+    // Make sure we won't transit from dead to error state.
+    if (!_state.isInstanceOf[SessionState.Dead] || !state.isInstanceOf[SessionState.Error]) {
+      debug(s"$this session state change from ${_state} to $state")
+      _state = state
+    }
   }
 
   private def ensureRunning(): Unit = synchronized {
@@ -386,4 +421,18 @@ class InteractiveSession(
     opId
    }
 
+  override def appIdKnown(appId: String): Unit = {
+    _appId = Option(appId)
+  }
+
+  override def stateChanged(oldState: SparkApp.State, newState: SparkApp.State): Unit = {
+    synchronized {
+      debug(s"$this app state changed from $oldState to $newState")
+      newState match {
+        case SparkApp.State.FINISHED | SparkApp.State.KILLED | SparkApp.State.FAILED =>
+          transition(SessionState.Dead())
+        case _ =>
+      }
+    }
+  }
 }

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSessionServlet.scala
@@ -70,7 +70,7 @@ class InteractiveSessionServlet(livyConf: LivyConf)
         Nil
       }
 
-    new SessionInfo(session.id, null, session.owner, session.proxyUser.orNull,
+    new SessionInfo(session.id, session.appId.orNull, session.owner, session.proxyUser.orNull,
       session.state.toString, session.kind.toString, logs.asJava)
   }
 

--- a/server/src/main/scala/com/cloudera/livy/utils/SparkApp.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/SparkApp.scala
@@ -69,13 +69,14 @@ object SparkApp {
    */
   def create(
       uniqueAppTag: String,
-      process: LineBufferedProcess,
+      process: Option[LineBufferedProcess],
       livyConf: LivyConf,
       listener: Option[SparkAppListener]): SparkApp = {
     if (livyConf.isRunningOnYarn()) {
-      SparkYarnApp.fromAppTag(uniqueAppTag, Some(process), listener, livyConf)
+      SparkYarnApp.fromAppTag(uniqueAppTag, process, listener, livyConf)
     } else {
-      new SparkProcApp(process, listener)
+      require(process.isDefined, "process must not be None when Livy master is not YARN.")
+      new SparkProcApp(process.get, listener)
     }
   }
 }

--- a/server/src/main/scala/com/cloudera/livy/utils/SparkYarnApp.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/SparkYarnApp.scala
@@ -59,9 +59,12 @@ object SparkYarnApp extends Logging {
 /**
  * Provide a class to control a Spark application using YARN API.
  *
- * @param appId A function that returns the YARN application id for this application.
+ * @param appTag An app tag that can unique identify the YARN app.
+ * @param appIdOption The appId of the YARN app. If this's None, SparkYarnApp will find it
+ *                    using appTag.
  * @param process The spark-submit process launched the YARN application. This is optional.
  *                If it's provided, SparkYarnApp.log() will include its log.
+ * @param listener Optional listener for notification of appId discovery and app state changes.
  */
 class SparkYarnApp private[utils] (
     appTag: String,

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionServletSpec.scala
@@ -46,6 +46,7 @@ class InteractiveSessionServletSpec extends BaseInteractiveServletSpec {
 
       val session = mock(classOf[InteractiveSession])
       when(session.kind).thenReturn(Spark())
+      when(session.appId).thenReturn(None)
       when(session.logLines()).thenReturn(IndexedSeq())
       when(session.state).thenReturn(SessionState.Idle())
       when(session.stop()).thenReturn(Future.successful(()))

--- a/server/src/test/scala/com/cloudera/livy/utils/SparkYarnAppSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/utils/SparkYarnAppSpec.scala
@@ -52,7 +52,7 @@ class SparkYarnAppSpec extends FunSpec {
     val appId = ConverterUtils.toApplicationId("application_1467912463905_0021")
     val appTag = "fakeTag"
     val livyConf = new LivyConf()
-    livyConf.set(LivyConf.YARN_APP_LOOKUP_TIMEOUT, "0")
+    livyConf.set(LivyConf.YARN_APP_LOOKUP_TIMEOUT, "30s")
 
     it("should poll YARN state and terminate") {
       Clock.withSleepMethod(mockSleep) {


### PR DESCRIPTION
- Transit to dead state when the YARN application dies.
- If RSCClient.stop() fails to stop RSCDriver, kill the YARN application using YARN API.
- Expose YARN app id.
- Show YARN diagnosis in session log.
- Fixed flaky SparkYarnAppSpec.should kill yarn app.
- Increased some integration test timeout when running on Travis.