### PR TITLE
LIVY-203 Spark version check fails on CDH

### DIFF
--- a/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
@@ -263,10 +263,10 @@ class LivyServer extends Logging {
    * @param version Spark version
    */
   private[server] def testSparkVersion(version: String): Unit = {
-    val versionPattern = """(\d)+\.(\d)+(?:\.\d*)?""".r
+    val versionPattern = """(\d)+\.(\d)+(?:\.\d*).*?""".r
     // This is exclusive. Version which equals to this will be rejected.
     val maxVersion = (2, 0)
-    val minVersion = (1, 6)
+    val minVersion = (1, 5)
 
     val supportedVersion = version match {
       case versionPattern(major, minor) =>

--- a/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
@@ -251,7 +251,7 @@ class LivyServer extends Logging {
    */
   private[server] def testSparkSubmit(livyConf: LivyConf): Unit = {
     try {
-      testSparkVersion(sparkSubmitVersion(livyConf))
+      testSparkVersion(sparkSubmitVersion(livyConf), livyConf.get(LIVY_SPARK_MASTER))
     } catch {
       case e: IOException =>
         throw new IOException("Failed to run spark-submit executable", e)
@@ -262,7 +262,7 @@ class LivyServer extends Logging {
    * Throw an exception if Spark version is not supported.
    * @param version Spark version
    */
-  private[server] def testSparkVersion(version: String): Unit = {
+  private[server] def testSparkVersion(version: String, sparkMaster: String): Unit = {
     val versionPattern = """^(\d)+\.(\d)+(?:\.\d*).*""".r
     // This is exclusive. Version which equals to this will be rejected.
     val maxVersion = (2, 0)
@@ -279,8 +279,7 @@ class LivyServer extends Logging {
     require(supportedVersion, s"Unsupported Spark version $version.")
 
     // Spark >= 1.6 require for Livy yarn-master mode
-    val sparkMaster = livyConf.sparkMaster()
-    if (sparkMaster != null && sparkMaster == "yarn-master") {
+    if (sparkMaster == "yarn-master") {
       val supportedVersion = version match {
         case versionPattern(major, minor) =>
           val v = (major.toInt, minor.toInt)

--- a/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
@@ -263,7 +263,7 @@ class LivyServer extends Logging {
    * @param version Spark version
    */
   private[server] def testSparkVersion(version: String): Unit = {
-    val versionPattern = """(\d)+\.(\d)+(?:\.\d*).*?""".r
+    val versionPattern = """^(\d)+\.(\d)+(?:\.\d*).*""".r
     // This is exclusive. Version which equals to this will be rejected.
     val maxVersion = (2, 0)
     val minVersion = (1, 5)

--- a/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
@@ -267,6 +267,8 @@ class LivyServer extends Logging {
     // This is exclusive. Version which equals to this will be rejected.
     val maxVersion = (2, 0)
     val minVersion = (1, 5)
+    // Minimum spark version that supports YARN integration
+    val minYarnMasterVersion = (1, 6)
 
     val supportedVersion = version match {
       case versionPattern(major, minor) =>
@@ -275,6 +277,17 @@ class LivyServer extends Logging {
       case _ => false
     }
     require(supportedVersion, s"Unsupported Spark version $version.")
+    
+    // Spark >= 1.6 require for Livy yarn-master mode
+    if (livyConf.get(LIVY_SPARK_MASTER) == "yarn-master") {
+      val supportedVersion = version match {
+        case versionPattern(major, minor) =>
+          val v = (major.toInt, minor.toInt)
+          v >= minYarnMasterVersion
+        case _ => true
+      }
+      require(supportedVersion, s"YARN master mode unsupported in Spark version $version.")
+    }
   }
 
   /**

--- a/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
@@ -277,7 +277,7 @@ class LivyServer extends Logging {
       case _ => false
     }
     require(supportedVersion, s"Unsupported Spark version $version.")
-    
+
     // Spark >= 1.6 require for Livy yarn-master mode
     if (livyConf.get(LIVY_SPARK_MASTER) == "yarn-master") {
       val supportedVersion = version match {

--- a/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
@@ -284,7 +284,7 @@ class LivyServer extends Logging {
         case versionPattern(major, minor) =>
           val v = (major.toInt, minor.toInt)
           v >= minYarnMasterVersion
-        case _ => true
+        case _ => false
       }
       require(supportedVersion, s"YARN master mode unsupported in Spark version $version.")
     }

--- a/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
@@ -279,7 +279,8 @@ class LivyServer extends Logging {
     require(supportedVersion, s"Unsupported Spark version $version.")
 
     // Spark >= 1.6 require for Livy yarn-master mode
-    if (livyConf.sparkMaster() == "yarn-master") {
+    val sparkMaster = livyConf.sparkMaster()
+    if (sparkMaster != null && sparkMaster == "yarn-master") {
       val supportedVersion = version match {
         case versionPattern(major, minor) =>
           val v = (major.toInt, minor.toInt)

--- a/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
@@ -279,7 +279,7 @@ class LivyServer extends Logging {
     require(supportedVersion, s"Unsupported Spark version $version.")
 
     // Spark >= 1.6 require for Livy yarn-master mode
-    if (livyConf.get(LIVY_SPARK_MASTER) == "yarn-master") {
+    if (livyConf.sparkMaster() == "yarn-master") {
       val supportedVersion = version match {
         case versionPattern(major, minor) =>
           val v = (major.toInt, minor.toInt)

--- a/server/src/test/scala/com/cloudera/livy/server/LivyServerSuite.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/LivyServerSuite.scala
@@ -41,28 +41,34 @@ class LivyServerSuite extends FunSuite {
     s.testSparkVersion("1.6.2")
   }
 
-  test("should support Spark 1.5") {
-    val s = new LivyServer()
-    s.testSparkVersion("1.5.0")
-    s.testSparkVersion("1.5.1")
-    s.testSparkVersion("1.5.2")
-  }
-
   test("should not support Spark older than 1.5") {
     val s = new LivyServer()
-    intercept[IllegalArgumentException] { s.testSparkVersion("1.4.0") }
-    intercept[IllegalArgumentException] { s.testSparkVersion("1.4.1") }
+    intercept[IllegalArgumentException] { s.testSparkVersion("1.4.0", "yarn-master") }
+    intercept[IllegalArgumentException] { s.testSparkVersion("1.4.1", "yarn-master") }
+  }
+
+  test("should support Spark 1.5 in yarn-client mode") {
+    val s = new LivyServer()
+    s.testSparkVersion("1.5.0", "yarn-client")
+    s.testSparkVersion("1.5.1", "yarn-client")
+    s.testSparkVersion("1.5.2", "yarn-client")
   }
 
   test("should support CDH version of Spark") {
     val s = new LivyServer()
-    intercept[IllegalArgumentException] { s.testSparkVersion("1.5.0-cdh5.5.2") }
+    s.testSparkVersion("1.5.0-cdh5.5.2", "yarn-client")
+    s.testSparkVersion("1.6.0-cdh5.7.3", "yarn-master")
+  }
+
+  test("should not support Spark 1.5 in YARN master mode") {
+    val s = new LivyServer()
+    intercept[IllegalArgumentException] { s.testSparkVersion("1.5.0-cdh5.5.2", "yarn-master") }
   }
 
   test("should not support Spark 2.0+") {
     val s = new LivyServer()
-    intercept[IllegalArgumentException] { s.testSparkVersion("2.0.0") }
-    intercept[IllegalArgumentException] { s.testSparkVersion("2.0.1") }
-    intercept[IllegalArgumentException] { s.testSparkVersion("2.1.0") }
+    intercept[IllegalArgumentException] { s.testSparkVersion("2.0.0", "yarn-master") }
+    intercept[IllegalArgumentException] { s.testSparkVersion("2.0.1", "yarn-master") }
+    intercept[IllegalArgumentException] { s.testSparkVersion("2.1.0", "yarn-master") }
   }
 }

--- a/server/src/test/scala/com/cloudera/livy/server/LivyServerSuite.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/LivyServerSuite.scala
@@ -41,12 +41,17 @@ class LivyServerSuite extends FunSuite {
     s.testSparkVersion("1.6.2")
   }
 
-  test("should not support Spark older than 1.6") {
+  test("should support Spark 1.5") {
+    val s = new LivyServer()
+    s.testSparkVersion("1.5.0")
+    s.testSparkVersion("1.5.1")
+    s.testSparkVersion("1.5.2")
+  }
+
+  test("should not support Spark older than 1.5") {
     val s = new LivyServer()
     intercept[IllegalArgumentException] { s.testSparkVersion("1.4.0") }
-    intercept[IllegalArgumentException] { s.testSparkVersion("1.5.0") }
-    intercept[IllegalArgumentException] { s.testSparkVersion("1.5.1") }
-    intercept[IllegalArgumentException] { s.testSparkVersion("1.5.2") }
+    intercept[IllegalArgumentException] { s.testSparkVersion("1.4.1") }
   }
 
   test("should not support Spark 2.0+") {

--- a/server/src/test/scala/com/cloudera/livy/server/LivyServerSuite.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/LivyServerSuite.scala
@@ -36,9 +36,9 @@ class LivyServerSuite extends FunSuite {
 
   test("should support Spark 1.6") {
     val s = new LivyServer()
-    s.testSparkVersion("1.6.0")
-    s.testSparkVersion("1.6.1")
-    s.testSparkVersion("1.6.2")
+    s.testSparkVersion("1.6.0", "yarn-master")
+    s.testSparkVersion("1.6.1", "yarn-master")
+    s.testSparkVersion("1.6.2", "yarn-master")
   }
 
   test("should not support Spark older than 1.5") {

--- a/server/src/test/scala/com/cloudera/livy/server/LivyServerSuite.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/LivyServerSuite.scala
@@ -54,6 +54,11 @@ class LivyServerSuite extends FunSuite {
     intercept[IllegalArgumentException] { s.testSparkVersion("1.4.1") }
   }
 
+  test("should support CDH version of Spark") {
+    val s = new LivyServer()
+    intercept[IllegalArgumentException] { s.testSparkVersion("1.5.0-cdh5.5.2") }
+  }
+
   test("should not support Spark 2.0+") {
     val s = new LivyServer()
     intercept[IllegalArgumentException] { s.testSparkVersion("2.0.0") }


### PR DESCRIPTION
- Fixed regex to also match the Spark version returned by Cloudera CDH
- Reduced the minimum required version of 1.5; Spark 1.6 was not introduced to CDH until 5.7.x
