### PR TITLE
LIVY-204: statement history kept in memory indefinitely

### DIFF
--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
+import scala.collection.immutable.TreeMap
 import scala.collection.mutable
 import scala.concurrent.{Future, _}
 import scala.util.{Failure, Success, Try}
@@ -169,7 +170,7 @@ class InteractiveSession(
 
 
   private[this] var _executedStatements = 0
-  private[this] var _statements = IndexedSeq[Statement]()
+  private[this] var _statements = TreeMap[Int, Statement]()
 
   override def logLines(): IndexedSeq[String] = IndexedSeq()
 
@@ -181,7 +182,7 @@ class InteractiveSession(
     transition(SessionState.Dead())
   }
 
-  def statements: IndexedSeq[Statement] = _statements
+  def statements: TreeMap[Int, Statement] = _statements
 
   def interrupt(): Future[Unit] = {
     stop()
@@ -200,9 +201,21 @@ class InteractiveSession(
     val statement = new Statement(_executedStatements, content, future)
 
     _executedStatements += 1
-    _statements = _statements :+ statement
+    addStatement(statement)
 
     statement
+  }
+
+  def addStatement(statement: Statement): Unit = {
+    _statements.synchronized {
+      _statements = _statements + (statement.id -> statement)
+    }
+  }
+
+  def removeStatement(statementId: Int): Unit = {
+    _statements.synchronized {
+      _statements = _statements - statementId
+    }
   }
 
   def runJob(job: Array[Byte]): Long = {

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSessionServlet.scala
@@ -88,10 +88,11 @@ class InteractiveSessionServlet(livyConf: LivyConf)
       "output" -> output)
   }
 
-  private def slice(from: Option[Int], to: Option[Int], size: Option[Int], offset: Option[Int], items: TreeMap[Int, Statement]): TreeMap[Int, Statement] = {
+  private def slice(from: Option[Int], to: Option[Int], size: Option[Int], offset: Option[Int],
+                    items: TreeMap[Int, Statement]): TreeMap[Int, Statement] = {
 
     // Can't slice an empty list
-    if(items.isEmpty) {
+    if (items.isEmpty) {
       return items
     }
 


### PR DESCRIPTION
Storing statements in a better structure that allows for slicing and removal.
Adding support for statement deletion.
