### PR TITLE
LIVY-209. Fix getPathInfo return null issue

### DIFF
--- a/server/src/main/scala/com/cloudera/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/SessionServlet.scala
@@ -128,7 +128,7 @@ abstract class SessionServlet[S <: Session](livyConf: LivyConf)
   }
 
   private def getRequestPathInfo(request: HttpServletRequest): String = {
-    if (request.getPathInfo != "/") {
+    if (request.getPathInfo != null && request.getPathInfo != "/") {
       request.getPathInfo
     } else {
       ""

--- a/server/src/test/scala/com/cloudera/livy/server/SessionServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/SessionServletSpec.scala
@@ -80,6 +80,17 @@ class SessionServletSpec
 
   describe("SessionServlet") {
 
+    it("should return correct Location in header") {
+      // mount to "/sessions/*" to test. If request URI is "/session", getPathInfo() will
+      // return null, since there's no extra path.
+      // mount to "/*" will always return "/", so that it cannot reflect the issue.
+      addServlet(servlet, "/sessions/*")
+      jpost[MockSessionView]("/sessions", Map(), headers = aliceHeaders) { res =>
+        assert(header("Location") === "/sessions/0")
+        jdelete[Map[String, Any]]("/sessions/0", SC_OK, aliceHeaders)
+      }
+    }
+
     it("should attach owner information to sessions") {
       jpost[MockSessionView]("/", Map(), headers = aliceHeaders) { res =>
         assert(res.owner === "alice")

--- a/server/src/test/scala/com/cloudera/livy/server/SessionServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/SessionServletSpec.scala
@@ -87,7 +87,7 @@ class SessionServletSpec
       addServlet(servlet, "/sessions/*")
       jpost[MockSessionView]("/sessions", Map(), headers = aliceHeaders) { res =>
         assert(header("Location") === "/sessions/0")
-        jdelete[Map[String, Any]]("/sessions/0", SC_OK, aliceHeaders)
+        jdelete[Map[String, Any]]("/sessions/0", SC_OK, aliceHeaders) { _ => }
       }
     }
 


### PR DESCRIPTION
getPathInfo may return null if there's no path info, this will lead to wrong `location` data in the returning headers, so here fix this.

To produce this issue:

```python
>>> import json, pprint, requests, textwrap
>>> host = 'http://localhost:8998'
>>> data = {'kind': 'spark'}
>>> headers = {'Content-Type': 'application/json'}
>>> r = requests.post(host + '/sessions', data=json.dumps(data), headers=headers)
>>> r.json()
{u'kind': u'spark', u'log': [], u'proxyUser': None, u'state': u'starting', u'appId': None, u'owner': None, u'id': 0}
>>> r.headers['location']
'null/sessions/0'
```

the right value should be:

```python
>>> r.headers['location']
'/sessions/0'
```