### PR TITLE
LIVY-161. Avoid exposing livy internal configurations to Spark

### DIFF
--- a/rsc/src/main/java/com/cloudera/livy/rsc/driver/RSCDriverBootstrapper.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/driver/RSCDriverBootstrapper.java
@@ -66,6 +66,7 @@ public final class RSCDriverBootstrapper {
       String value = props.getProperty(key);
       if (key.startsWith(RSCConf.LIVY_SPARK_PREFIX)) {
         livyConf.set(key.substring(RSCConf.LIVY_SPARK_PREFIX.length()), value);
+        props.remove(key);
       } else if (key.startsWith(RSCConf.SPARK_CONF_PREFIX)) {
         conf.set(key, value);
       }


### PR DESCRIPTION
Livy internal configurations will be existed as system properties in Spark driver process, and these can be fetched through various ways in Spark's runtime, so here propose to remove these Livy only system properties after being set to `RSCConf`.