### PR TITLE
LIVY-208. Exposing YARN driver log url and Spark UI url for YARN sessions.

### DIFF
--- a/client-common/src/main/java/com/cloudera/livy/client/common/HttpMessages.java
+++ b/client-common/src/main/java/com/cloudera/livy/client/common/HttpMessages.java
@@ -59,21 +59,23 @@ public class HttpMessages {
     public final String proxyUser;
     public final String state;
     public final String kind;
+    public final Map<String, String> appInfo;
     public final List<String> log;
 
     public SessionInfo(int id, String appId, String owner, String proxyUser, String state,
-        String kind, List<String> log) {
+        String kind, Map<String, String> appInfo, List<String> log) {
       this.id = id;
       this.appId = appId;
       this.owner = owner;
       this.proxyUser = proxyUser;
       this.state = state;
       this.kind = kind;
+      this.appInfo = appInfo;
       this.log = log;
     }
 
     private SessionInfo() {
-      this(-1, null, null, null, null, null, null);
+      this(-1, null, null, null, null, null, null, null);
     }
 
   }

--- a/client-http/src/test/scala/com/cloudera/livy/client/http/HttpClientSpec.scala
+++ b/client-http/src/test/scala/com/cloudera/livy/client/http/HttpClientSpec.scala
@@ -43,6 +43,7 @@ import com.cloudera.livy.server.WebServer
 import com.cloudera.livy.server.interactive.{InteractiveSession, InteractiveSessionServlet}
 import com.cloudera.livy.sessions.{SessionState, Spark}
 import com.cloudera.livy.test.jobs.Echo
+import com.cloudera.livy.utils.AppInfo
 
 /**
  * The test for the HTTP client is written in Scala so we can reuse the code in the livy-server
@@ -270,6 +271,7 @@ private class HttpClientTestBootstrap extends LifeCycle {
         val id = sessionManager.nextId()
         when(session.id).thenReturn(id)
         when(session.appId).thenReturn(None)
+        when(session.appInfo).thenReturn(AppInfo())
         when(session.state).thenReturn(SessionState.Idle())
         when(session.proxyUser).thenReturn(None)
         when(session.kind).thenReturn(Spark())

--- a/integration-test/src/test/scala/com/cloudera/livy/test/BatchIT.scala
+++ b/integration-test/src/test/scala/com/cloudera/livy/test/BatchIT.scala
@@ -40,6 +40,7 @@ import com.cloudera.livy.test.apps._
 import com.cloudera.livy.test.framework.BaseIntegrationTestSuite
 
 class BatchIT extends BaseIntegrationTestSuite with BeforeAndAfterAll {
+  import com.cloudera.livy.utils.AppInfo._
   implicit val patienceConfig = PatienceConfig(timeout = 2 minutes, interval = 1 second)
 
   private var testLibPath: String = _
@@ -56,10 +57,10 @@ class BatchIT extends BaseIntegrationTestSuite with BeforeAndAfterAll {
     dumpLogOnFailure(result.id) {
       assert(result.state === SessionState.Success().toString())
       assert(cluster.fs.isDirectory(new Path(output)))
-      result.appInfo should contain key ("driverLogUrl")
-      result.appInfo should contain key ("sparkUiUrl")
-      result.appInfo.get("driverLogUrl")
-      result.appInfo.get("sparkUiUrl") should startWith ("http")
+      result.appInfo should contain key DRIVER_LOG_URL_NAME
+      result.appInfo should contain key SPARK_UI_URL_NAME
+      result.appInfo.get(DRIVER_LOG_URL_NAME) should include ("containerlogs")
+      result.appInfo.get(SPARK_UI_URL_NAME) should startWith ("http")
     }
   }
 

--- a/integration-test/src/test/scala/com/cloudera/livy/test/BatchIT.scala
+++ b/integration-test/src/test/scala/com/cloudera/livy/test/BatchIT.scala
@@ -56,6 +56,10 @@ class BatchIT extends BaseIntegrationTestSuite with BeforeAndAfterAll {
     dumpLogOnFailure(result.id) {
       assert(result.state === SessionState.Success().toString())
       assert(cluster.fs.isDirectory(new Path(output)))
+      result.appInfo should contain key ("driverLogUrl")
+      result.appInfo should contain key ("sparkUiUrl")
+      result.appInfo.get("driverLogUrl")
+      result.appInfo.get("sparkUiUrl") should startWith ("http")
     }
   }
 

--- a/server/src/main/scala/com/cloudera/livy/server/batch/BatchSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/batch/BatchSession.scala
@@ -25,17 +25,18 @@ import scala.util.Random
 
 import com.cloudera.livy.LivyConf
 import com.cloudera.livy.sessions.{Session, SessionState}
-import com.cloudera.livy.utils.{SparkApp, SparkAppListener, SparkProcessBuilder}
+import com.cloudera.livy.utils.{AppInfo, SparkApp, SparkAppListener, SparkProcessBuilder}
 
 class BatchSession(
     id: Int,
     owner: String,
     override val proxyUser: Option[String],
     livyConf: LivyConf,
-    request: CreateBatchRequest)
-    extends Session(id, owner, livyConf) with SparkAppListener {
+    request: CreateBatchRequest,
+    mockApp: Option[SparkApp] = None) // For unit test.
+  extends Session(id, owner, livyConf) with SparkAppListener {
 
-  private val app = {
+  private val app = mockApp.getOrElse {
     val uniqueAppTag = s"livy-batch-$id-${Random.alphanumeric.take(8).mkString}"
 
     val conf = SparkApp.prepareSparkConf(uniqueAppTag, livyConf,
@@ -92,4 +93,6 @@ class BatchSession(
       }
     }
   }
+
+  override def infoChanged(appInfo: AppInfo): Unit = { this.appInfo = appInfo }
 }

--- a/server/src/main/scala/com/cloudera/livy/server/batch/BatchSessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/batch/BatchSessionServlet.scala
@@ -22,8 +22,14 @@ import javax.servlet.http.HttpServletRequest
 
 import com.cloudera.livy.LivyConf
 import com.cloudera.livy.server.SessionServlet
+import com.cloudera.livy.utils.AppInfo
 
-case class BatchSessionView(id: Long, state: String, appId: Option[String], log: Seq[String])
+case class BatchSessionView(
+  id: Long,
+  state: String,
+  appId: Option[String],
+  appInfo: AppInfo,
+  log: Seq[String])
 
 class BatchSessionServlet(livyConf: LivyConf)
   extends SessionServlet[BatchSession](livyConf)
@@ -35,7 +41,9 @@ class BatchSessionServlet(livyConf: LivyConf)
     new BatchSession(sessionManager.nextId(), remoteUser(req), proxyUser, livyConf, createRequest)
   }
 
-  override protected def clientSessionView(session: BatchSession, req: HttpServletRequest): Any = {
+  override protected[batch] def clientSessionView(
+      session: BatchSession,
+      req: HttpServletRequest): Any = {
     val logs =
       if (hasAccess(session.owner, req)) {
         val lines = session.logLines()
@@ -48,7 +56,7 @@ class BatchSessionServlet(livyConf: LivyConf)
       } else {
         Nil
       }
-    BatchSessionView(session.id, session.state.toString, session.appId, logs)
+    BatchSessionView(session.id, session.state.toString, session.appId, session.appInfo, logs)
   }
 
 }

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSessionServlet.scala
@@ -53,7 +53,7 @@ class InteractiveSessionServlet(livyConf: LivyConf)
       createRequest)
   }
 
-  override protected def clientSessionView(
+  override protected[interactive] def clientSessionView(
       session: InteractiveSession,
       req: HttpServletRequest): Any = {
     val logs =
@@ -72,7 +72,7 @@ class InteractiveSessionServlet(livyConf: LivyConf)
       }
 
     new SessionInfo(session.id, session.appId.orNull, session.owner, session.proxyUser.orNull,
-      session.state.toString, session.kind.toString, logs.asJava)
+      session.state.toString, session.kind.toString, session.appInfo.asJavaMap, logs.asJava)
   }
 
   private def statementView(statement: Statement): Any = {

--- a/server/src/main/scala/com/cloudera/livy/sessions/Session.scala
+++ b/server/src/main/scala/com/cloudera/livy/sessions/Session.scala
@@ -31,6 +31,7 @@ import org.apache.hadoop.fs.permission.FsPermission
 import org.apache.hadoop.security.UserGroupInformation
 
 import com.cloudera.livy.{LivyConf, Logging, Utils}
+import com.cloudera.livy.utils.AppInfo
 
 object Session {
 
@@ -56,6 +57,8 @@ abstract class Session(val id: Int, val owner: String, val livyConf: LivyConf) e
   private var stagingDir: Path = null
 
   def appId: Option[String] = _appId
+
+  var appInfo: AppInfo = AppInfo()
 
   def lastActivity: Long = state match {
     case SessionState.Error(time) => time

--- a/server/src/main/scala/com/cloudera/livy/utils/SparkApp.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/SparkApp.scala
@@ -23,9 +23,15 @@ import scala.collection.JavaConverters._
 import com.cloudera.livy.LivyConf
 import com.cloudera.livy.util.LineBufferedProcess
 
+object AppInfo {
+  val DRIVER_LOG_URL_NAME = "driverLogUrl"
+  val SPARK_UI_URL_NAME = "sparkUiUrl"
+}
+
 case class AppInfo(var driverLogUrl: Option[String] = None, var sparkUiUrl: Option[String] = None) {
-  def asJavaMap: java.util.Map[String, String]
-    = Map("driverLogUrl" -> driverLogUrl.orNull, "sparkUiUrl" -> sparkUiUrl.orNull).asJava
+  import AppInfo._
+  def asJavaMap: java.util.Map[String, String] =
+    Map(DRIVER_LOG_URL_NAME -> driverLogUrl.orNull, SPARK_UI_URL_NAME -> sparkUiUrl.orNull).asJava
 }
 
 trait SparkAppListener {

--- a/server/src/main/scala/com/cloudera/livy/utils/SparkApp.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/SparkApp.scala
@@ -18,8 +18,15 @@
 
 package com.cloudera.livy.utils
 
+import scala.collection.JavaConverters._
+
 import com.cloudera.livy.LivyConf
 import com.cloudera.livy.util.LineBufferedProcess
+
+case class AppInfo(var driverLogUrl: Option[String] = None, var sparkUiUrl: Option[String] = None) {
+  def asJavaMap: java.util.Map[String, String]
+    = Map("driverLogUrl" -> driverLogUrl.orNull, "sparkUiUrl" -> sparkUiUrl.orNull).asJava
+}
 
 trait SparkAppListener {
   /** Fired when appId is known, even during recovery. */
@@ -27,6 +34,9 @@ trait SparkAppListener {
 
   /** Fired when the app state in the cluster changes. */
   def stateChanged(oldState: SparkApp.State, newState: SparkApp.State): Unit = {}
+
+  /** Fired when the app info is changed. */
+  def infoChanged(appInfo: AppInfo): Unit = {}
 }
 
 /**

--- a/server/src/test/scala/com/cloudera/livy/server/batch/BatchSessionSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/batch/BatchSessionSpec.scala
@@ -25,9 +25,11 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.Duration
 
 import org.scalatest.{BeforeAndAfterAll, FunSpec, ShouldMatchers}
+import org.scalatest.mock.MockitoSugar.mock
 
 import com.cloudera.livy.{LivyConf, Utils}
 import com.cloudera.livy.sessions.SessionState
+import com.cloudera.livy.utils.{AppInfo, SparkApp}
 
 class BatchSessionSpec
   extends FunSpec
@@ -65,6 +67,21 @@ class BatchSessionSpec
       }) should be (true)
 
       batch.logLines() should contain("hello world")
+    }
+
+    it("should update appId and appInfo") {
+      val conf = new LivyConf()
+      val req = new CreateBatchRequest()
+      val mockApp = mock[SparkApp]
+      val batch = new BatchSession(0, null, None, conf, req, Some(mockApp))
+
+      val expectedAppId = "APPID"
+      batch.appIdKnown(expectedAppId)
+      batch.appId shouldEqual Some(expectedAppId)
+
+      val expectedAppInfo = AppInfo(Some("DRIVER LOG URL"), Some("SPARK UI URL"))
+      batch.infoChanged(expectedAppInfo)
+      batch.appInfo shouldEqual expectedAppInfo
     }
   }
 }

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionServletSpec.scala
@@ -153,8 +153,8 @@ class InteractiveSessionServletSpec extends BaseInteractiveServletSpec {
     view.proxyUser shouldEqual proxyUser
     view.state shouldEqual state.toString
     view.kind shouldEqual kind.toString
-    view.appInfo should contain (Entry("driverLogUrl", appInfo.driverLogUrl.get))
-    view.appInfo should contain (Entry("sparkUiUrl", appInfo.sparkUiUrl.get))
+    view.appInfo should contain (Entry(AppInfo.DRIVER_LOG_URL_NAME, appInfo.driverLogUrl.get))
+    view.appInfo should contain (Entry(AppInfo.SPARK_UI_URL_NAME, appInfo.sparkUiUrl.get))
     view.log shouldEqual log.asJava
   }
 

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionServletSpec.scala
@@ -21,7 +21,8 @@ package com.cloudera.livy.server.interactive
 import java.util.concurrent.atomic.AtomicInteger
 import javax.servlet.http.HttpServletRequest
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.collection.JavaConverters._
+import scala.concurrent.Future
 
 import org.json4s.JsonAST._
 import org.json4s.jackson.Json4sScalaModule
@@ -29,9 +30,13 @@ import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
+import org.scalatest.Entry
+import org.scalatest.mock.MockitoSugar.mock
 
 import com.cloudera.livy.ExecuteRequest
+import com.cloudera.livy.client.common.HttpMessages.SessionInfo
 import com.cloudera.livy.sessions._
+import com.cloudera.livy.utils.AppInfo
 
 class InteractiveSessionServletSpec extends BaseInteractiveServletSpec {
 
@@ -44,9 +49,10 @@ class InteractiveSessionServletSpec extends BaseInteractiveServletSpec {
     override protected def createSession(req: HttpServletRequest): InteractiveSession = {
       val statementCounter = new AtomicInteger()
 
-      val session = mock(classOf[InteractiveSession])
+      val session = mock[InteractiveSession]
       when(session.kind).thenReturn(Spark())
       when(session.appId).thenReturn(None)
+      when(session.appInfo).thenReturn(AppInfo())
       when(session.logLines()).thenReturn(IndexedSeq())
       when(session.state).thenReturn(SessionState.Idle())
       when(session.stop()).thenReturn(Future.successful(()))
@@ -114,6 +120,42 @@ class InteractiveSessionServletSpec extends BaseInteractiveServletSpec {
       val session = servlet.sessionManager.get(0)
       session should not be defined
     }
+  }
+
+  it("should show session properties") {
+    val id = 0
+    val appId = "appid"
+    val owner = "owner"
+    val proxyUser = "proxyUser"
+    val state = SessionState.Running()
+    val kind = Spark()
+    val appInfo = AppInfo(Some("DRIVER LOG URL"), Some("SPARK UI URL"))
+    val log = IndexedSeq[String]("log1", "log2")
+
+    val session = mock[InteractiveSession]
+    when(session.id).thenReturn(id)
+    when(session.appId).thenReturn(Some(appId))
+    when(session.owner).thenReturn(owner)
+    when(session.proxyUser).thenReturn(Some(proxyUser))
+    when(session.state).thenReturn(state)
+    when(session.kind).thenReturn(kind)
+    when(session.appInfo).thenReturn(appInfo)
+    when(session.logLines()).thenReturn(log)
+
+    val req = mock[HttpServletRequest]
+
+    val view = servlet.asInstanceOf[InteractiveSessionServlet].clientSessionView(session, req)
+      .asInstanceOf[SessionInfo]
+
+    view.id shouldEqual id
+    view.appId shouldEqual appId
+    view.owner shouldEqual owner
+    view.proxyUser shouldEqual proxyUser
+    view.state shouldEqual state.toString
+    view.kind shouldEqual kind.toString
+    view.appInfo should contain (Entry("driverLogUrl", appInfo.driverLogUrl.get))
+    view.appInfo should contain (Entry("sparkUiUrl", appInfo.sparkUiUrl.get))
+    view.log shouldEqual log.asJava
   }
 
 }


### PR DESCRIPTION
They are exposed as:
- appInfo.driverLogUrl
- appInfo.sparkUiUrl