### PR TITLE
LIVY-210. Add test context for Livy unit test

### DIFF
--- a/client-http/pom.xml
+++ b/client-http/pom.xml
@@ -49,6 +49,14 @@
     </dependency>
 
     <dependency>
+      <groupId>com.cloudera.livy</groupId>
+      <artifactId>livy-core</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>

--- a/client-http/src/test/scala/com/cloudera/livy/client/http/HttpClientSpec.scala
+++ b/client-http/src/test/scala/com/cloudera/livy/client/http/HttpClientSpec.scala
@@ -26,7 +26,6 @@ import java.util.concurrent.atomic.AtomicLong
 import javax.servlet.ServletContext
 import javax.servlet.http.HttpServletRequest
 
-import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 
 import org.mockito.ArgumentCaptor
@@ -50,7 +49,7 @@ import com.cloudera.livy.utils.AppInfo
  * module, which implements the client session backend. The client servlet has some functionality
  * overridden to avoid creating sub-processes for each seession.
  */
-class HttpClientSpec extends FunSpecLike with BeforeAndAfterAll with LivyTestFixture {
+class HttpClientSpec extends FunSpecLike with BeforeAndAfterAll with LivyBaseUnitTestSuite {
 
   import HttpClientSpec._
 

--- a/client-http/src/test/scala/com/cloudera/livy/client/http/HttpClientSpec.scala
+++ b/client-http/src/test/scala/com/cloudera/livy/client/http/HttpClientSpec.scala
@@ -50,7 +50,7 @@ import com.cloudera.livy.utils.AppInfo
  * module, which implements the client session backend. The client servlet has some functionality
  * overridden to avoid creating sub-processes for each seession.
  */
-class HttpClientSpec extends FunSpecLike with BeforeAndAfterAll {
+class HttpClientSpec extends FunSpecLike with BeforeAndAfterAll with LivyTestFixture {
 
   import HttpClientSpec._
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -68,4 +68,20 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/core/src/test/scala/com/cloudera/livy/LivyBaseUnitTestSuite.scala
+++ b/core/src/test/scala/com/cloudera/livy/LivyBaseUnitTestSuite.scala
@@ -20,7 +20,7 @@ package com.cloudera.livy
 
 import org.scalatest.{Outcome, Suite}
 
-trait LivyTestFixture extends Suite with Logging {
+trait LivyBaseUnitTestSuite extends Suite with Logging {
 
   protected override def withFixture(test: NoArgTest): Outcome = {
     val testName = test.name

--- a/core/src/test/scala/com/cloudera/livy/LivyTestFixture.scala
+++ b/core/src/test/scala/com/cloudera/livy/LivyTestFixture.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy
+
+import org.scalatest.{Outcome, Suite}
+
+trait LivyTestFixture extends Suite with Logging {
+
+  protected override def withFixture(test: NoArgTest): Outcome = {
+    val testName = test.name
+    val suiteName = this.getClass.getName
+    try {
+      info(s"\n\n==== TEST OUTPUT FOR $suiteName: '$testName' ====\n")
+      test()
+    } finally {
+      info(s"\n\n==== FINISHED $suiteName: '$testName' ====\n")
+    }
+  }
+}

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -58,6 +58,14 @@
         </dependency>
 
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>livy-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <scope>provided</scope>

--- a/repl/src/test/scala/com/cloudera/livy/repl/BaseInterpreterSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/BaseInterpreterSpec.scala
@@ -20,7 +20,9 @@ package com.cloudera.livy.repl
 
 import org.scalatest.{FlatSpec, Matchers}
 
-abstract class BaseInterpreterSpec extends FlatSpec with Matchers {
+import com.cloudera.livy.LivyTestFixture
+
+abstract class BaseInterpreterSpec extends FlatSpec with Matchers with LivyTestFixture {
 
   def createInterpreter(): Interpreter
 

--- a/repl/src/test/scala/com/cloudera/livy/repl/BaseInterpreterSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/BaseInterpreterSpec.scala
@@ -20,9 +20,9 @@ package com.cloudera.livy.repl
 
 import org.scalatest.{FlatSpec, Matchers}
 
-import com.cloudera.livy.LivyTestFixture
+import com.cloudera.livy.LivyBaseUnitTestSuite
 
-abstract class BaseInterpreterSpec extends FlatSpec with Matchers with LivyTestFixture {
+abstract class BaseInterpreterSpec extends FlatSpec with Matchers with LivyBaseUnitTestSuite {
 
   def createInterpreter(): Interpreter
 

--- a/repl/src/test/scala/com/cloudera/livy/repl/BaseSessionSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/BaseSessionSpec.scala
@@ -26,10 +26,10 @@ import org.json4s.DefaultFormats
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.concurrent.Eventually._
 
-import com.cloudera.livy.LivyTestFixture
+import com.cloudera.livy.LivyBaseUnitTestSuite
 import com.cloudera.livy.sessions.SessionState
 
-abstract class BaseSessionSpec extends FlatSpec with Matchers with LivyTestFixture {
+abstract class BaseSessionSpec extends FlatSpec with Matchers with LivyBaseUnitTestSuite {
 
   implicit val formats = DefaultFormats
 

--- a/repl/src/test/scala/com/cloudera/livy/repl/BaseSessionSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/BaseSessionSpec.scala
@@ -26,9 +26,10 @@ import org.json4s.DefaultFormats
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.concurrent.Eventually._
 
+import com.cloudera.livy.LivyTestFixture
 import com.cloudera.livy.sessions.SessionState
 
-abstract class BaseSessionSpec extends FlatSpec with Matchers {
+abstract class BaseSessionSpec extends FlatSpec with Matchers with LivyTestFixture {
 
   implicit val formats = DefaultFormats
 

--- a/repl/src/test/scala/com/cloudera/livy/repl/ReplDriverSuite.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/ReplDriverSuite.scala
@@ -34,7 +34,7 @@ import com.cloudera.livy._
 import com.cloudera.livy.rsc.{PingJob, RSCClient, RSCConf}
 import com.cloudera.livy.sessions.Spark
 
-class ReplDriverSuite extends FunSuite {
+class ReplDriverSuite extends FunSuite with LivyTestFixture {
 
   private implicit val formats = DefaultFormats
 

--- a/repl/src/test/scala/com/cloudera/livy/repl/ReplDriverSuite.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/ReplDriverSuite.scala
@@ -34,7 +34,7 @@ import com.cloudera.livy._
 import com.cloudera.livy.rsc.{PingJob, RSCClient, RSCConf}
 import com.cloudera.livy.sessions.Spark
 
-class ReplDriverSuite extends FunSuite with LivyTestFixture {
+class ReplDriverSuite extends FunSuite with LivyBaseUnitTestSuite {
 
   private implicit val formats = DefaultFormats
 

--- a/repl/src/test/scala/com/cloudera/livy/repl/SparkRInterpreterSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/SparkRInterpreterSpec.scala
@@ -29,7 +29,7 @@ class SparkRInterpreterSpec extends BaseInterpreterSpec {
 
   override protected def withFixture(test: NoArgTest): Outcome = {
     assume(!sys.props.getOrElse("skipRTests", "false").toBoolean, "Skipping R tests.")
-    test()
+    super.withFixture(test)
   }
 
   override def createInterpreter(): Interpreter = SparkRInterpreter(new SparkConf())

--- a/repl/src/test/scala/com/cloudera/livy/repl/SparkRSessionSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/SparkRSessionSpec.scala
@@ -30,7 +30,7 @@ class SparkRSessionSpec extends BaseSessionSpec {
 
   override protected def withFixture(test: NoArgTest) = {
     assume(!sys.props.getOrElse("skipRTests", "false").toBoolean, "Skipping R tests.")
-    test()
+    super.withFixture(test)
   }
 
   override def createInterpreter(): Interpreter = SparkRInterpreter(new SparkConf())

--- a/scala-api/pom.xml
+++ b/scala-api/pom.xml
@@ -46,6 +46,19 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.cloudera.livy</groupId>
+            <artifactId>livy-core</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.cloudera.livy</groupId>
+            <artifactId>livy-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.binary.version}</artifactId>
             <scope>provided</scope>

--- a/scala-api/src/test/scala/com/cloudera/livy/scalaapi/ScalaClientTest.scala
+++ b/scala-api/src/test/scala/com/cloudera/livy/scalaapi/ScalaClientTest.scala
@@ -26,19 +26,21 @@ import java.util.concurrent.CountDownLatch
 import java.util.jar.JarOutputStream
 import java.util.zip.ZipEntry
 
-import org.apache.spark.SparkFiles
-import org.apache.spark.launcher.SparkLauncher
-import org.scalatest.{BeforeAndAfter, FunSuite}
-import org.scalatest.concurrent.ScalaFutures
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.{Failure, Success}
 
+import org.apache.spark.SparkFiles
+import org.apache.spark.launcher.SparkLauncher
+import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.concurrent.ScalaFutures
+
+import com.cloudera.livy.LivyTestFixture
 import com.cloudera.livy.rsc.RSCConf.Entry._
 
-class ScalaClientTest extends FunSuite with ScalaFutures with BeforeAndAfter {
+class ScalaClientTest extends FunSuite with ScalaFutures with BeforeAndAfter with LivyTestFixture {
 
   import com.cloudera.livy._
 

--- a/scala-api/src/test/scala/com/cloudera/livy/scalaapi/ScalaClientTest.scala
+++ b/scala-api/src/test/scala/com/cloudera/livy/scalaapi/ScalaClientTest.scala
@@ -37,10 +37,13 @@ import org.apache.spark.launcher.SparkLauncher
 import org.scalatest.{BeforeAndAfter, FunSuite}
 import org.scalatest.concurrent.ScalaFutures
 
-import com.cloudera.livy.LivyTestFixture
+import com.cloudera.livy.LivyBaseUnitTestSuite
 import com.cloudera.livy.rsc.RSCConf.Entry._
 
-class ScalaClientTest extends FunSuite with ScalaFutures with BeforeAndAfter with LivyTestFixture {
+class ScalaClientTest extends FunSuite
+  with ScalaFutures
+  with BeforeAndAfter
+  with LivyBaseUnitTestSuite {
 
   import com.cloudera.livy._
 

--- a/scala-api/src/test/scala/com/cloudera/livy/scalaapi/ScalaClientTestUtils.scala
+++ b/scala-api/src/test/scala/com/cloudera/livy/scalaapi/ScalaClientTestUtils.scala
@@ -26,9 +26,9 @@ import scala.concurrent.duration._
 
 import org.scalatest.FunSuite
 
-import com.cloudera.livy.LivyTestFixture
+import com.cloudera.livy.LivyBaseUnitTestSuite
 
-object ScalaClientTestUtils extends FunSuite with LivyTestFixture {
+object ScalaClientTestUtils extends FunSuite with LivyBaseUnitTestSuite {
 
   val Timeout = 40
 

--- a/scala-api/src/test/scala/com/cloudera/livy/scalaapi/ScalaClientTestUtils.scala
+++ b/scala-api/src/test/scala/com/cloudera/livy/scalaapi/ScalaClientTestUtils.scala
@@ -20,12 +20,15 @@ package com.cloudera.livy.scalaapi
 import java.util.Random
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 
-import org.scalatest.FunSuite
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
-object ScalaClientTestUtils extends FunSuite {
+import org.scalatest.FunSuite
+
+import com.cloudera.livy.LivyTestFixture
+
+object ScalaClientTestUtils extends FunSuite with LivyTestFixture {
 
   val Timeout = 40
 

--- a/scala-api/src/test/scala/com/cloudera/livy/scalaapi/ScalaJobHandleTest.scala
+++ b/scala-api/src/test/scala/com/cloudera/livy/scalaapi/ScalaJobHandleTest.scala
@@ -19,20 +19,22 @@ package com.cloudera.livy.scalaapi
 
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 
-import org.mockito.Matchers._
-import org.mockito.Mockito._
-import org.scalatest.{BeforeAndAfter, FunSuite}
-import org.scalatest.concurrent.ScalaFutures
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.language.postfixOps
 import scala.util.{Failure, Success}
 
-import com.cloudera.livy.JobHandle
+import org.mockito.Matchers._
+import org.mockito.Mockito._
+import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.concurrent.ScalaFutures
+
+import com.cloudera.livy.{JobHandle, LivyTestFixture}
 import com.cloudera.livy.JobHandle.{Listener, State}
 
-class ScalaJobHandleTest extends FunSuite with ScalaFutures with BeforeAndAfter {
+class ScalaJobHandleTest extends FunSuite
+    with ScalaFutures with BeforeAndAfter with LivyTestFixture {
 
   private var mockJobHandle: JobHandle[String] = null
   private var scalaJobHandle: ScalaJobHandle[String] = null

--- a/scala-api/src/test/scala/com/cloudera/livy/scalaapi/ScalaJobHandleTest.scala
+++ b/scala-api/src/test/scala/com/cloudera/livy/scalaapi/ScalaJobHandleTest.scala
@@ -30,11 +30,13 @@ import org.mockito.Mockito._
 import org.scalatest.{BeforeAndAfter, FunSuite}
 import org.scalatest.concurrent.ScalaFutures
 
-import com.cloudera.livy.{JobHandle, LivyTestFixture}
+import com.cloudera.livy.{JobHandle, LivyBaseUnitTestSuite}
 import com.cloudera.livy.JobHandle.{Listener, State}
 
 class ScalaJobHandleTest extends FunSuite
-    with ScalaFutures with BeforeAndAfter with LivyTestFixture {
+  with ScalaFutures
+  with BeforeAndAfter
+  with LivyBaseUnitTestSuite {
 
   private var mockJobHandle: JobHandle[String] = null
   private var scalaJobHandle: ScalaJobHandle[String] = null

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -45,6 +45,14 @@
 
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>livy-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>livy-rsc</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/server/src/test/scala/com/cloudera/livy/server/ApiVersioningSupportSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/ApiVersioningSupportSpec.scala
@@ -24,7 +24,9 @@ import org.scalatest.FunSpecLike
 import org.scalatra.ScalatraServlet
 import org.scalatra.test.scalatest.ScalatraSuite
 
-class ApiVersioningSupportSpec extends ScalatraSuite with FunSpecLike {
+import com.cloudera.livy.LivyTestFixture
+
+class ApiVersioningSupportSpec extends ScalatraSuite with FunSpecLike with LivyTestFixture {
   val LatestVersionOutput = "latest"
 
   object FakeApiVersions extends Enumeration {

--- a/server/src/test/scala/com/cloudera/livy/server/ApiVersioningSupportSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/ApiVersioningSupportSpec.scala
@@ -24,9 +24,9 @@ import org.scalatest.FunSpecLike
 import org.scalatra.ScalatraServlet
 import org.scalatra.test.scalatest.ScalatraSuite
 
-import com.cloudera.livy.LivyTestFixture
+import com.cloudera.livy.LivyBaseUnitTestSuite
 
-class ApiVersioningSupportSpec extends ScalatraSuite with FunSpecLike with LivyTestFixture {
+class ApiVersioningSupportSpec extends ScalatraSuite with FunSpecLike with LivyBaseUnitTestSuite {
   val LatestVersionOutput = "latest"
 
   object FakeApiVersions extends Enumeration {

--- a/server/src/test/scala/com/cloudera/livy/server/BaseJsonServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/BaseJsonServletSpec.scala
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.scalatest.FunSpecLike
 import org.scalatra.test.scalatest.ScalatraSuite
 
-import com.cloudera.livy.LivyTestFixture
+import com.cloudera.livy.LivyBaseUnitTestSuite
 
 /**
  * Base class that enhances ScalatraSuite so that it's easier to test JsonServlet
@@ -38,7 +38,8 @@ import com.cloudera.livy.LivyTestFixture
  * In case the response is not JSON, the expected type for the test function should be
  * `Unit`, and the `response` object should be checked directly.
  */
-abstract class BaseJsonServletSpec extends ScalatraSuite with FunSpecLike with LivyTestFixture {
+abstract class BaseJsonServletSpec extends ScalatraSuite
+  with FunSpecLike with LivyBaseUnitTestSuite {
 
   protected val mapper = new ObjectMapper()
     .registerModule(com.fasterxml.jackson.module.scala.DefaultScalaModule)

--- a/server/src/test/scala/com/cloudera/livy/server/BaseJsonServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/BaseJsonServletSpec.scala
@@ -25,8 +25,9 @@ import scala.reflect.ClassTag
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.scalatest.FunSpecLike
-import org.scalatra._
 import org.scalatra.test.scalatest.ScalatraSuite
+
+import com.cloudera.livy.LivyTestFixture
 
 /**
  * Base class that enhances ScalatraSuite so that it's easier to test JsonServlet
@@ -37,7 +38,7 @@ import org.scalatra.test.scalatest.ScalatraSuite
  * In case the response is not JSON, the expected type for the test function should be
  * `Unit`, and the `response` object should be checked directly.
  */
-abstract class BaseJsonServletSpec extends ScalatraSuite with FunSpecLike {
+abstract class BaseJsonServletSpec extends ScalatraSuite with FunSpecLike with LivyTestFixture {
 
   protected val mapper = new ObjectMapper()
     .registerModule(com.fasterxml.jackson.module.scala.DefaultScalaModule)

--- a/server/src/test/scala/com/cloudera/livy/server/LivyServerSuite.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/LivyServerSuite.scala
@@ -20,9 +20,9 @@ package com.cloudera.livy.server
 
 import org.scalatest.FunSuite
 
-import com.cloudera.livy.{LivyConf, LivyTestFixture}
+import com.cloudera.livy.{LivyBaseUnitTestSuite, LivyConf}
 
-class LivyServerSuite extends FunSuite with LivyTestFixture {
+class LivyServerSuite extends FunSuite with LivyBaseUnitTestSuite {
 
   private val livyConf = new LivyConf()
 

--- a/server/src/test/scala/com/cloudera/livy/server/LivyServerSuite.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/LivyServerSuite.scala
@@ -19,10 +19,9 @@
 package com.cloudera.livy.server
 
 import org.scalatest.FunSuite
+import com.cloudera.livy.{LivyConf, LivyTestFixture}
 
-import com.cloudera.livy.LivyConf
-
-class LivyServerSuite extends FunSuite {
+class LivyServerSuite extends FunSuite with LivyTestFixture {
 
   private val livyConf = new LivyConf()
 

--- a/server/src/test/scala/com/cloudera/livy/server/LivyServerSuite.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/LivyServerSuite.scala
@@ -19,6 +19,7 @@
 package com.cloudera.livy.server
 
 import org.scalatest.FunSuite
+
 import com.cloudera.livy.{LivyConf, LivyTestFixture}
 
 class LivyServerSuite extends FunSuite with LivyTestFixture {

--- a/server/src/test/scala/com/cloudera/livy/server/batch/BatchSessionSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/batch/BatchSessionSpec.scala
@@ -27,14 +27,15 @@ import scala.concurrent.duration.Duration
 import org.scalatest.{BeforeAndAfterAll, FunSpec, ShouldMatchers}
 import org.scalatest.mock.MockitoSugar.mock
 
-import com.cloudera.livy.{LivyConf, Utils}
+import com.cloudera.livy.{LivyConf,LivyTestFixture, Utils}
 import com.cloudera.livy.sessions.SessionState
 import com.cloudera.livy.utils.{AppInfo, SparkApp}
 
 class BatchSessionSpec
   extends FunSpec
   with BeforeAndAfterAll
-  with ShouldMatchers {
+  with ShouldMatchers
+  with LivyTestFixture {
 
   val script: Path = {
     val script = Files.createTempFile("livy-test", ".py")

--- a/server/src/test/scala/com/cloudera/livy/server/batch/BatchSessionSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/batch/BatchSessionSpec.scala
@@ -27,7 +27,7 @@ import scala.concurrent.duration.Duration
 import org.scalatest.{BeforeAndAfterAll, FunSpec, ShouldMatchers}
 import org.scalatest.mock.MockitoSugar.mock
 
-import com.cloudera.livy.{LivyConf,LivyTestFixture, Utils}
+import com.cloudera.livy.{LivyConf, LivyTestFixture, Utils}
 import com.cloudera.livy.sessions.SessionState
 import com.cloudera.livy.utils.{AppInfo, SparkApp}
 

--- a/server/src/test/scala/com/cloudera/livy/server/batch/BatchSessionSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/batch/BatchSessionSpec.scala
@@ -27,7 +27,7 @@ import scala.concurrent.duration.Duration
 import org.scalatest.{BeforeAndAfterAll, FunSpec, ShouldMatchers}
 import org.scalatest.mock.MockitoSugar.mock
 
-import com.cloudera.livy.{LivyConf, LivyTestFixture, Utils}
+import com.cloudera.livy.{LivyBaseUnitTestSuite, LivyConf, Utils}
 import com.cloudera.livy.sessions.SessionState
 import com.cloudera.livy.utils.{AppInfo, SparkApp}
 
@@ -35,7 +35,7 @@ class BatchSessionSpec
   extends FunSpec
   with BeforeAndAfterAll
   with ShouldMatchers
-  with LivyTestFixture {
+  with LivyBaseUnitTestSuite {
 
   val script: Path = {
     val script = Files.createTempFile("livy-test", ".py")

--- a/server/src/test/scala/com/cloudera/livy/server/batch/CreateBatchRequestSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/batch/CreateBatchRequestSpec.scala
@@ -21,9 +21,9 @@ package com.cloudera.livy.server.batch
 import com.fasterxml.jackson.databind.{JsonMappingException, ObjectMapper}
 import org.scalatest.FunSpec
 
-import com.cloudera.livy.LivyTestFixture
+import com.cloudera.livy.LivyBaseUnitTestSuite
 
-class CreateBatchRequestSpec extends FunSpec with LivyTestFixture {
+class CreateBatchRequestSpec extends FunSpec with LivyBaseUnitTestSuite {
 
   private val mapper = new ObjectMapper()
     .registerModule(com.fasterxml.jackson.module.scala.DefaultScalaModule)

--- a/server/src/test/scala/com/cloudera/livy/server/batch/CreateBatchRequestSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/batch/CreateBatchRequestSpec.scala
@@ -21,7 +21,9 @@ package com.cloudera.livy.server.batch
 import com.fasterxml.jackson.databind.{JsonMappingException, ObjectMapper}
 import org.scalatest.FunSpec
 
-class CreateBatchRequestSpec extends FunSpec {
+import com.cloudera.livy.LivyTestFixture
+
+class CreateBatchRequestSpec extends FunSpec with LivyTestFixture {
 
   private val mapper = new ObjectMapper()
     .registerModule(com.fasterxml.jackson.module.scala.DefaultScalaModule)

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/CreateInteractiveRequestSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/CreateInteractiveRequestSpec.scala
@@ -21,10 +21,10 @@ package com.cloudera.livy.server.interactive
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.scalatest.FunSpec
 
-import com.cloudera.livy.LivyTestFixture
+import com.cloudera.livy.LivyBaseUnitTestSuite
 import com.cloudera.livy.sessions.{PySpark, SessionKindModule}
 
-class CreateInteractiveRequestSpec extends FunSpec with LivyTestFixture {
+class CreateInteractiveRequestSpec extends FunSpec with LivyBaseUnitTestSuite {
 
   private val mapper = new ObjectMapper()
     .registerModule(com.fasterxml.jackson.module.scala.DefaultScalaModule)

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/CreateInteractiveRequestSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/CreateInteractiveRequestSpec.scala
@@ -21,9 +21,10 @@ package com.cloudera.livy.server.interactive
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.scalatest.FunSpec
 
+import com.cloudera.livy.LivyTestFixture
 import com.cloudera.livy.sessions.{PySpark, SessionKindModule}
 
-class CreateInteractiveRequestSpec extends FunSpec {
+class CreateInteractiveRequestSpec extends FunSpec with LivyTestFixture {
 
   private val mapper = new ObjectMapper()
     .registerModule(com.fasterxml.jackson.module.scala.DefaultScalaModule)

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionSpec.scala
@@ -28,12 +28,13 @@ import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.mock.MockitoSugar.mock
 
-import com.cloudera.livy.{ExecuteRequest, LivyConf}
+import com.cloudera.livy.{ExecuteRequest, LivyConf, LivyTestFixture}
 import com.cloudera.livy.rsc.RSCConf
 import com.cloudera.livy.sessions.{PySpark, SessionState}
 import com.cloudera.livy.utils.{AppInfo, SparkApp}
 
-class InteractiveSessionSpec extends FunSpec with Matchers with BeforeAndAfterAll {
+class InteractiveSessionSpec extends FunSpec
+    with Matchers with BeforeAndAfterAll with LivyTestFixture {
 
   private val livyConf = new LivyConf()
   livyConf.set(InteractiveSession.LivyReplJars, "")

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionSpec.scala
@@ -28,13 +28,13 @@ import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.mock.MockitoSugar.mock
 
-import com.cloudera.livy.{ExecuteRequest, LivyConf, LivyTestFixture}
+import com.cloudera.livy.{ExecuteRequest, LivyBaseUnitTestSuite, LivyConf}
 import com.cloudera.livy.rsc.RSCConf
 import com.cloudera.livy.sessions.{PySpark, SessionState}
 import com.cloudera.livy.utils.{AppInfo, SparkApp}
 
 class InteractiveSessionSpec extends FunSpec
-    with Matchers with BeforeAndAfterAll with LivyTestFixture {
+    with Matchers with BeforeAndAfterAll with LivyBaseUnitTestSuite {
 
   private val livyConf = new LivyConf()
   livyConf.set(InteractiveSession.LivyReplJars, "")

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/StatementSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/StatementSpec.scala
@@ -25,9 +25,9 @@ import org.json4s.{DefaultFormats, Extraction}
 import org.json4s.JsonAST.JString
 import org.scalatest.{FunSpec, Matchers}
 
-import com.cloudera.livy.{ExecuteRequest, LivyTestFixture}
+import com.cloudera.livy.{ExecuteRequest, LivyBaseUnitTestSuite}
 
-class StatementSpec extends FunSpec with Matchers with LivyTestFixture {
+class StatementSpec extends FunSpec with Matchers with LivyBaseUnitTestSuite {
 
   implicit val formats = DefaultFormats
 

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/StatementSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/StatementSpec.scala
@@ -25,9 +25,9 @@ import org.json4s.{DefaultFormats, Extraction}
 import org.json4s.JsonAST.JString
 import org.scalatest.{FunSpec, Matchers}
 
-import com.cloudera.livy.ExecuteRequest
+import com.cloudera.livy.{ExecuteRequest, LivyTestFixture}
 
-class StatementSpec extends FunSpec with Matchers {
+class StatementSpec extends FunSpec with Matchers with LivyTestFixture {
 
   implicit val formats = DefaultFormats
 

--- a/server/src/test/scala/com/cloudera/livy/sessions/SessionManagerSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/sessions/SessionManagerSpec.scala
@@ -25,9 +25,9 @@ import scala.language.postfixOps
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.concurrent.Eventually._
 
-import com.cloudera.livy.LivyConf
+import com.cloudera.livy.{LivyConf, LivyTestFixture}
 
-class SessionManagerSpec extends FlatSpec with Matchers {
+class SessionManagerSpec extends FlatSpec with Matchers with LivyTestFixture {
 
   it should "garbage collect old sessions" in {
     val livyConf = new LivyConf()

--- a/server/src/test/scala/com/cloudera/livy/sessions/SessionManagerSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/sessions/SessionManagerSpec.scala
@@ -25,9 +25,9 @@ import scala.language.postfixOps
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.concurrent.Eventually._
 
-import com.cloudera.livy.{LivyConf, LivyTestFixture}
+import com.cloudera.livy.{LivyBaseUnitTestSuite, LivyConf}
 
-class SessionManagerSpec extends FlatSpec with Matchers with LivyTestFixture {
+class SessionManagerSpec extends FlatSpec with Matchers with LivyBaseUnitTestSuite {
 
   it should "garbage collect old sessions" in {
     val livyConf = new LivyConf()

--- a/server/src/test/scala/com/cloudera/livy/sessions/SessionSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/sessions/SessionSpec.scala
@@ -22,9 +22,9 @@ import java.net.URI
 
 import org.scalatest.FunSuite
 
-import com.cloudera.livy.{LivyConf, LivyTestFixture}
+import com.cloudera.livy.{LivyBaseUnitTestSuite, LivyConf}
 
-class SessionSpec extends FunSuite with LivyTestFixture {
+class SessionSpec extends FunSuite with LivyBaseUnitTestSuite {
 
   test("use default fs in paths") {
     val conf = new LivyConf(false)

--- a/server/src/test/scala/com/cloudera/livy/sessions/SessionSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/sessions/SessionSpec.scala
@@ -22,9 +22,9 @@ import java.net.URI
 
 import org.scalatest.FunSuite
 
-import com.cloudera.livy.LivyConf
+import com.cloudera.livy.{LivyConf, LivyTestFixture}
 
-class SessionSpec extends FunSuite {
+class SessionSpec extends FunSuite with LivyTestFixture {
 
   test("use default fs in paths") {
     val conf = new LivyConf(false)

--- a/server/src/test/scala/com/cloudera/livy/utils/SparkYarnAppSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/utils/SparkYarnAppSpec.scala
@@ -34,11 +34,11 @@ import org.mockito.stubbing.Answer
 import org.scalatest.FunSpec
 import org.scalatest.mock.MockitoSugar.mock
 
-import com.cloudera.livy.{LivyConf, LivyTestFixture}
+import com.cloudera.livy.{LivyBaseUnitTestSuite, LivyConf}
 import com.cloudera.livy.util.LineBufferedProcess
 import com.cloudera.livy.utils.SparkApp._
 
-class SparkYarnAppSpec extends FunSpec with LivyTestFixture {
+class SparkYarnAppSpec extends FunSpec with LivyBaseUnitTestSuite {
   private def cleanupThread(t: Thread)(f: => Unit) = {
     try { f } finally { t.interrupt() }
   }

--- a/server/src/test/scala/com/cloudera/livy/utils/SparkYarnAppSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/utils/SparkYarnAppSpec.scala
@@ -34,11 +34,11 @@ import org.mockito.stubbing.Answer
 import org.scalatest.FunSpec
 import org.scalatest.mock.MockitoSugar.mock
 
-import com.cloudera.livy.LivyConf
+import com.cloudera.livy.{LivyConf, LivyTestFixture}
 import com.cloudera.livy.util.LineBufferedProcess
 import com.cloudera.livy.utils.SparkApp._
 
-class SparkYarnAppSpec extends FunSpec {
+class SparkYarnAppSpec extends FunSpec with LivyTestFixture {
   private def cleanupThread(t: Thread)(f: => Unit) = {
     try { f } finally { t.interrupt() }
   }


### PR DESCRIPTION
Propose to add unit test context info before and after each unit test, so unit test log can be distinguished from test to test, here is the sample output:

```
==== TEST OUTPUT FOR com.cloudera.livy.repl.SparkSessionSpec: 'should start in the starting or idle state' ====

16/09/09 10:59:15.735 pool-17-thread-1 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
16/09/09 10:59:15.871 pool-17-thread-1 INFO SecurityManager: Changing view acls to: sshao
16/09/09 10:59:15.872 pool-17-thread-1 INFO SecurityManager: Changing modify acls to: sshao
16/09/09 10:59:15.873 pool-17-thread-1 INFO SecurityManager: SecurityManager: authentication disabled; ui acls disabled; users with view permissions: Set(sshao); users with modify permissions: Set(sshao)
16/09/09 10:59:16.040 pool-17-thread-1 INFO HttpServer: Starting HTTP Server
16/09/09 10:59:16.119 pool-17-thread-1 INFO Utils: Successfully started service 'HTTP class server' on port 56636.
16/09/09 10:59:18.840 pool-17-thread-1 INFO SparkContext: Running Spark version 1.6.2
16/09/09 10:59:18.878 pool-17-thread-1 INFO SecurityManager: Changing view acls to: sshao
16/09/09 10:59:18.878 pool-17-thread-1 INFO SecurityManager: Changing modify acls to: sshao
16/09/09 10:59:18.878 pool-17-thread-1 INFO SecurityManager: SecurityManager: authentication disabled; ui acls disabled; users with view permissions: Set(sshao); users with modify permissions: Set(sshao)
16/09/09 10:59:19.093 pool-17-thread-1 INFO Utils: Successfully started service 'sparkDriver' on port 56638.
16/09/09 10:59:19.695 sparkDriverActorSystem-akka.actor.default-dispatcher-3 INFO Slf4jLogger: Slf4jLogger started
16/09/09 10:59:19.734 sparkDriverActorSystem-akka.actor.default-dispatcher-3 INFO Remoting: Starting remoting
16/09/09 10:59:19.897 sparkDriverActorSystem-akka.actor.default-dispatcher-3 INFO Remoting: Remoting started; listening on addresses :[akka.tcp://sparkDriverActorSystem@192.168.0.103:56640]
16/09/09 10:59:19.904 pool-17-thread-1 INFO Utils: Successfully started service 'sparkDriverActorSystem' on port 56640.
16/09/09 10:59:19.916 pool-17-thread-1 INFO SparkEnv: Registering MapOutputTracker
16/09/09 10:59:19.937 pool-17-thread-1 INFO SparkEnv: Registering BlockManagerMaster
16/09/09 10:59:19.953 pool-17-thread-1 INFO DiskBlockManager: Created local directory at /Users/sshao/projects/livy/repl/target/tmp/blockmgr-ba269a9b-0b0e-4d3e-86a0-6a384e1f6d6e
16/09/09 10:59:19.958 pool-17-thread-1 INFO MemoryStore: MemoryStore started with capacity 1140.4 MB
16/09/09 10:59:20.025 pool-17-thread-1 INFO SparkEnv: Registering OutputCommitCoordinator
16/09/09 10:59:20.122 pool-17-thread-1 INFO Executor: Starting executor ID driver on host localhost
16/09/09 10:59:20.130 pool-17-thread-1 INFO Executor: Using REPL class URI: http://192.168.0.103:56636
16/09/09 10:59:20.145 pool-17-thread-1 INFO Utils: Successfully started service 'org.apache.spark.network.netty.NettyBlockTransferService' on port 56641.
16/09/09 10:59:20.145 pool-17-thread-1 INFO NettyBlockTransferService: Server created on 56641
16/09/09 10:59:20.146 pool-17-thread-1 INFO BlockManagerMaster: Trying to register BlockManager
16/09/09 10:59:20.149 dispatcher-event-loop-2 INFO BlockManagerMasterEndpoint: Registering block manager localhost:56641 with 1140.4 MB RAM, BlockManagerId(driver, localhost, 56641)
16/09/09 10:59:20.151 pool-17-thread-1 INFO BlockManagerMaster: Registered BlockManager
16/09/09 10:59:20.427 pool-17-thread-1 INFO SparkInterpreter: Created sql context.
16/09/09 10:59:23.108 dispatcher-event-loop-6 INFO MapOutputTrackerMasterEndpoint: MapOutputTrackerMasterEndpoint stopped!
16/09/09 10:59:23.113 ScalaTest-main-running-SparkSessionSpec INFO MemoryStore: MemoryStore cleared
16/09/09 10:59:23.114 ScalaTest-main-running-SparkSessionSpec INFO BlockManager: BlockManager stopped
16/09/09 10:59:23.122 ScalaTest-main-running-SparkSessionSpec INFO BlockManagerMaster: BlockManagerMaster stopped
16/09/09 10:59:23.126 dispatcher-event-loop-3 INFO OutputCommitCoordinator$OutputCommitCoordinatorEndpoint: OutputCommitCoordinator stopped!
16/09/09 10:59:23.128 ScalaTest-main-running-SparkSessionSpec INFO SparkContext: Successfully stopped SparkContext
16/09/09 10:59:23.133 sparkDriverActorSystem-akka.actor.default-dispatcher-2 INFO RemoteActorRefProvider$RemotingTerminator: Shutting down remote daemon.
16/09/09 10:59:23.137 sparkDriverActorSystem-akka.actor.default-dispatcher-2 INFO RemoteActorRefProvider$RemotingTerminator: Remote daemon shut down; proceeding with flushing remote transports.
16/09/09 10:59:23.173 sparkDriverActorSystem-akka.actor.default-dispatcher-2 INFO RemoteActorRefProvider$RemotingTerminator: Remoting shut down.
16/09/09 10:59:23.182 ScalaTest-main-running-SparkSessionSpec INFO SparkSessionSpec:

==== FINISHED com.cloudera.livy.repl.SparkSessionSpec: 'should start in the starting or idle state' ====
```

The idea is brought from Spark, since Livy has 3 different testing styles: `FlatSpec`, `FunSuite` and `FunSpec`, so cannot make it as Spark to strictly inherited from `SparkFunSuite`, here instead use trait to mix into the existing unit test.

I think this is quite useful for unit test, please review and comment, thanks a lot.