### PR TITLE
Minor. Update gitignore to ignore egg files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dependency-reduced-pom.xml
 python-api/dist
 .eggs
 *.egg-info
+*.egg


### PR DESCRIPTION
Update gitignore file to exclude egg files generated by python api module.