### PR TITLE
Minor. Fixed bug in SparkApp that merges user YARN tags and Livy YARN tags incorrectly.

### DIFF
--- a/server/src/main/scala/com/cloudera/livy/utils/SparkApp.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/SparkApp.scala
@@ -52,7 +52,7 @@ object SparkApp {
       livyConf: LivyConf,
       sparkConf: Map[String, String]): Map[String, String] = {
     if (livyConf.isRunningOnYarn()) {
-      val userYarnTags = sparkConf.get(uniqueAppTag).map("," + _).getOrElse("")
+      val userYarnTags = sparkConf.get(SPARK_YARN_TAG_KEY).map("," + _).getOrElse("")
       val mergedYarnTags = uniqueAppTag + userYarnTags
       sparkConf ++ Map(
         SPARK_YARN_TAG_KEY -> mergedYarnTags,


### PR DESCRIPTION
The user defined tags will be merged into generated tags. The key is not used correctly. 