### PR TITLE
LIVY-215. Support canceling of statement

### DIFF
--- a/repl/scala-2.10/src/main/scala/com/cloudera/livy/repl/SparkInterpreter.scala
+++ b/repl/scala-2.10/src/main/scala/com/cloudera/livy/repl/SparkInterpreter.scala
@@ -37,9 +37,8 @@ class SparkInterpreter(conf: SparkConf)
   extends AbstractSparkInterpreter with SparkContextInitializer {
 
   private var sparkIMain: SparkIMain = _
-  protected var sparkContext: SparkContext = _
 
-  override def start(): SparkContext = {
+  override def internalStart(): SparkContext = {
     require(sparkIMain == null && sparkContext == null)
 
     val settings = new Settings()

--- a/repl/scala-2.11/src/main/scala/com/cloudera/livy/repl/SparkInterpreter.scala
+++ b/repl/scala-2.11/src/main/scala/com/cloudera/livy/repl/SparkInterpreter.scala
@@ -36,11 +36,10 @@ import org.apache.spark.repl.SparkILoop
 class SparkInterpreter(conf: SparkConf)
   extends AbstractSparkInterpreter with SparkContextInitializer {
 
-  protected var sparkContext: SparkContext = _
   private var sparkILoop: SparkILoop = _
   private var sparkHttpServer: Object = _
 
-  override def start(): SparkContext = {
+  override def internalStart(): SparkContext = {
     require(sparkILoop == null)
 
     val rootDir = conf.get("spark.repl.classdir", System.getProperty("java.io.tmpdir"))

--- a/repl/src/main/scala/com/cloudera/livy/repl/AbstractSparkInterpreter.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/AbstractSparkInterpreter.scala
@@ -29,6 +29,7 @@ import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
 
 import com.cloudera.livy.Logging
+import com.cloudera.livy.repl.Interpreter.ExecuteResponse
 
 object AbstractSparkInterpreter {
   private val EXCEPTION_STACK_TRACE_REGEX = """(.+?)\n((?:[  |\t].+?\n?)*)""".r
@@ -52,9 +53,8 @@ abstract class AbstractSparkInterpreter extends Interpreter with Logging {
 
   protected def valueOfTerm(name: String): Option[Any]
 
-  override def execute(code: String): Interpreter.ExecuteResponse = restoreContextClassLoader {
+  override def internalExecute(code: String): Interpreter.ExecuteResponse = restoreContextClassLoader {
     require(isStarted())
-
     executeLines(code.trim.split("\n").toList, Interpreter.ExecuteSuccess(JObject(
       (TEXT_PLAIN, JString(""))
     )))

--- a/repl/src/main/scala/com/cloudera/livy/repl/ProcessInterpreter.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/ProcessInterpreter.scala
@@ -28,6 +28,7 @@ import org.apache.spark.SparkContext
 import org.json4s.JValue
 
 import com.cloudera.livy.{Logging, Utils}
+import com.cloudera.livy.repl.Interpreter.ExecuteResponse
 
 private sealed trait Request
 private case class ExecuteRequest(code: String, promise: Promise[JValue]) extends Request
@@ -47,15 +48,12 @@ abstract class ProcessInterpreter(process: Process)
   protected[this] val stdin = new PrintWriter(process.getOutputStream)
   protected[this] val stdout = new BufferedReader(new InputStreamReader(process.getInputStream), 1)
 
-  override def start(): SparkContext = {
+  override def internalStart(): SparkContext = {
     waitUntilReady()
-
-    // At this point there should be an already active SparkContext that can be retrieved
-    // using SparkContext.getOrCreate. But we don't really support running "pre-compiled"
-    // jobs against pyspark or sparkr, so just return null here.
-    null
+    SparkContext.getOrCreate
   }
-  override def execute(code: String): Interpreter.ExecuteResponse = {
+
+  override def internalExecute(code: String): ExecuteResponse = {
     try {
       sendExecuteRequest(code)
     } catch {

--- a/repl/src/main/scala/com/cloudera/livy/repl/ReplDriver.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/ReplDriver.scala
@@ -75,7 +75,13 @@ class ReplDriver(conf: SparkConf, livyConf: RSCConf)
 
   def handle(ctx: ChannelHandlerContext, msg: BaseProtocol.ReplJobRequest): Unit = {
     Future {
-      jobFutures(msg.id) = session.execute(msg.code).result
+      jobFutures(msg.id) = session.execute(msg.code, msg.id).result
+    }
+  }
+
+  def handle(ctx: ChannelHandlerContext, msg: BaseProtocol.CancelReplJobRequest): Unit = {
+    Future {
+      session.cancel(msg.id)
     }
   }
 

--- a/repl/src/main/scala/com/cloudera/livy/repl/Session.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/Session.scala
@@ -72,11 +72,15 @@ class Session(interpreter: Interpreter)
 
   def history: IndexedSeq[Statement] = _history
 
-  def execute(code: String): Statement = synchronized {
+  def execute(code: String, statementId: String = ""): Statement = synchronized {
     val executionCount = _history.length
-    val statement = Statement(executionCount, executeCode(executionCount, code))
+    val statement = Statement(executionCount, executeCode(executionCount, code, statementId))
     _history :+= statement
     statement
+  }
+
+  def cancel(statementId: String): Unit = {
+    interpreter.cancel(statementId)
   }
 
   def close(): Unit = {
@@ -88,12 +92,12 @@ class Session(interpreter: Interpreter)
     _history = IndexedSeq()
   }
 
-  private def executeCode(executionCount: Int, code: String) = {
+  private def executeCode(executionCount: Int, code: String, statementId: String) = {
     _state = SessionState.Busy()
 
     try {
 
-      interpreter.execute(code) match {
+      interpreter.execute(code, statementId) match {
         case Interpreter.ExecuteSuccess(data) =>
           _state = SessionState.Idle()
 

--- a/repl/src/test/scala/com/cloudera/livy/repl/ReplDriverSuite.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/ReplDriverSuite.scala
@@ -56,7 +56,8 @@ class ReplDriverSuite extends FunSuite with LivyBaseUnitTestSuite {
 
       assert(client.getReplState().get(10, TimeUnit.SECONDS) === "idle")
 
-      val statementId = client.submitReplCode("1 + 1")
+      val statementId = "1";
+      client.submitReplCode("1 + 1", statementId)
       eventually(timeout(30 seconds), interval(100 millis)) {
         val rawResult = client.getReplJobResult(statementId).get(10, TimeUnit.SECONDS)
         val result = parse(rawResult)

--- a/rsc/src/main/java/com/cloudera/livy/rsc/BaseProtocol.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/BaseProtocol.java
@@ -183,6 +183,18 @@ public abstract class BaseProtocol extends RpcDispatcher {
     }
   }
 
+  public static class CancelReplJobRequest {
+    public final String id;
+
+    public CancelReplJobRequest(String id) {
+      this.id = id;
+    }
+
+    public CancelReplJobRequest() {
+      this(null);
+    }
+  }
+
   public static class GetReplJobResult {
 
     public final String id;

--- a/rsc/src/main/java/com/cloudera/livy/rsc/RSCClient.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/RSCClient.java
@@ -274,10 +274,13 @@ public class RSCClient implements LivyClient {
     return contextInfo;
   }
 
-  public String submitReplCode(String code) throws Exception {
-    String id = UUID.randomUUID().toString();
-    deferredCall(new BaseProtocol.ReplJobRequest(code, id), Void.class);
-    return id;
+  public String submitReplCode(String code, String statementId) throws Exception {
+    deferredCall(new BaseProtocol.ReplJobRequest(code, statementId), Void.class);
+    return statementId;
+  }
+
+  public void cancelReplCode(String statementId) throws Exception {
+    deferredCall(new BaseProtocol.CancelReplJobRequest(statementId), Void.class);
   }
 
   public Future<String> getReplJobResult(String id) throws Exception {

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSessionServlet.scala
@@ -148,6 +148,13 @@ class InteractiveSessionServlet(
     }
   }
 
+  post("/:id/statements/:statementId/cancel") {
+    withSession { session =>
+      val statementId = params("statementId")
+      session.cancelStatement(statementId)
+      Ok(Map("msg" -> "canceled"))
+    }
+  }
   // This endpoint is used by the client-http module to "connect" to an existing session and
   // update its last activity time. It performs authorization checks to make sure the caller
   // has access to the session, so even though it returns the same data, it behaves differently


### PR DESCRIPTION
StatementId is unique in the scope of per session. So I just use the statementId as the jobGroupId.  
I think trait `Interpreter` is not public for extension of other interpreter. So I change `Interpreter` directly to make it support canceling of statement. 

Here's the steps for trying this features.
- curl -X POST --data '{"kind": "spark"}' -H "Content-Type: application/json" localhost:8998/sessions
- curl   http://localhost:8998/sessions/0/statements -X POST -H 'Content-Type: application/json' -d '{"code":"sc.parallelize(0 to 100).map(e=>{Thread.sleep(10000); e}).sum()"}' 
- curl -X POST http://localhost:8998/sessions/0/statements/0/cancel
- curl   http://localhost:8998/sessions/0/statements/0
