### PR TITLE
LIVY-216. Fix wrong executor number configuration in interactive session.

### DIFF
--- a/integration-test/src/main/scala/com/cloudera/livy/test/framework/BaseIntegrationTestSuite.scala
+++ b/integration-test/src/main/scala/com/cloudera/livy/test/framework/BaseIntegrationTestSuite.scala
@@ -126,6 +126,7 @@ abstract class BaseIntegrationTestSuite extends FunSuite with Matchers with Befo
       val requestBody = new CreateInteractiveRequest()
       requestBody.kind = kind
       requestBody.conf = sparkConf
+      requestBody.numExecutors = Some(1)
 
       val rep = httpClient.preparePost(s"$livyEndpoint/sessions")
         .setBody(mapper.writeValueAsString(requestBody))

--- a/integration-test/src/test/scala/com/cloudera/livy/test/InteractiveIT.scala
+++ b/integration-test/src/test/scala/com/cloudera/livy/test/InteractiveIT.scala
@@ -47,7 +47,8 @@ class InteractiveIT extends BaseIntegrationTestSuite with BeforeAndAfter {
 
     dumpLogOnFailure(sessionId) {
       matchResult("1+1", "res0: Int = 2")
-      matchResult("sqlContext", startsWith("res1: org.apache.spark.sql.hive.HiveContext"))
+      matchResult("""sc.getConf.get("spark.executor.instances")""", "res1: String = 1")
+      matchResult("sqlContext", startsWith("res2: org.apache.spark.sql.hive.HiveContext"))
       matchResult("val sql = new org.apache.spark.sql.SQLContext(sc)",
         startsWith("sql: org.apache.spark.sql.SQLContext = org.apache.spark.sql.SQLContext"))
 

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
@@ -133,7 +133,7 @@ class InteractiveSession(
       SparkLauncher.DRIVER_MEMORY -> request.driverMemory.map(_.toString),
       SparkLauncher.EXECUTOR_CORES -> request.executorCores.map(_.toString),
       SparkLauncher.EXECUTOR_MEMORY -> request.executorMemory.map(_.toString),
-      "spark.dynamicAllocation.maxExecutors" -> request.numExecutors.map(_.toString)
+      "spark.executor.instances" -> request.numExecutors.map(_.toString)
     )
 
     userOpts.foreach { case (key, opt) =>


### PR DESCRIPTION
Should use `spark.executor.instances` instead.