### PR TITLE
LIVY-220. Workaround SPARK-17512 for Spark 2.

### DIFF
--- a/server/src/main/scala/com/cloudera/livy/utils/SparkProcessBuilder.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/SparkProcessBuilder.scala
@@ -178,8 +178,13 @@ class SparkProcessBuilder(livyConf: LivyConf) extends Logging {
     addOpt("--name", _name)
     addOpt("--class", _className)
     _conf.foreach { case (key, value) =>
-      arguments += "--conf"
-      arguments += f"$key=$value"
+      if (key == "spark.submit.pyFiles") {
+         arguments += "--py-files"
+         arguments += f"$value"
+      } else {
+         arguments += "--conf"
+         arguments += f"$key=$value"
+      }
     }
     addList("--driver-class-path", _driverClassPath)
 


### PR DESCRIPTION
The livy code takes the pyFiles variable and passes it as a --conf "spark.submit.pyFiles=<whatever>" as a command line to spark.
The spark.submit.pyFiles was only introduced in spark 2.0.X and is not availablw in 1.6.X
I tried to run it with spark 2.0.1 but it turns out that spark 2.0.X has also a bug(!!!) that ignores this option lolol....
This change make it being passed as --py-files instead...

This is critical for pyspark users as it solves a bug that makes livy useless for pyspark developers.