### PR TITLE
Added an override for hadoop.scope to Hadoop dependencies in pom.xml.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
 
   <properties>
     <hadoop.version>2.6.0-cdh5.5.0</hadoop.version>
+    <hadoop.scope>compile</hadoop.scope>
     <spark.version>1.6.2</spark.version>
     <commons-codec.version>1.9</commons-codec.version>
     <httpclient.version>4.5.2</httpclient.version>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -97,6 +97,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-auth</artifactId>
+            <scope>${hadoop.scope}</scope>
         </dependency>
 
         <dependency>
@@ -108,6 +109,7 @@
                     <artifactId>servlet-api</artifactId>
                 </exclusion>
             </exclusions>
+            <scope>${hadoop.scope}</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
- Default to compile.
- Users who want to exclude Hadoop jars in their Livy build can set it to provided.