### PR TITLE
LIVY-225. Fix two issues running integration test with Spark 2.0

### DIFF
--- a/integration-test/src/test/scala/com/cloudera/livy/test/InteractiveIT.scala
+++ b/integration-test/src/test/scala/com/cloudera/livy/test/InteractiveIT.scala
@@ -48,9 +48,9 @@ class InteractiveIT extends BaseIntegrationTestSuite with BeforeAndAfter {
     dumpLogOnFailure(sessionId) {
       matchResult("1+1", "res0: Int = 2")
       matchResult("""sc.getConf.get("spark.executor.instances")""", "res1: String = 1")
-      matchResult("sqlContext", startsWith("res2: org.apache.spark.sql.hive.HiveContext"))
       matchResult("val sql = new org.apache.spark.sql.SQLContext(sc)",
-        startsWith("sql: org.apache.spark.sql.SQLContext = org.apache.spark.sql.SQLContext"))
+        ".*" + Pattern.quote(
+          "sql: org.apache.spark.sql.SQLContext = org.apache.spark.sql.SQLContext") + ".*")
 
       matchError("abcde", evalue = ".*?:[0-9]+: error: not found: value abcde.*")
       matchError("throw new IllegalStateException()",


### PR DESCRIPTION
1. Create a dummy jar to let Spark yarn#client correctly launch the application.
2. Since `SQLContext` is deprecated in Spark 2.0, so additional information will be printed out when creating, so here change the regex pattern.