### PR TITLE
LIVY-227. Include both repl-2.10 and repl-2.11 bundles in Livy assembly.

### DIFF
--- a/assembly/assembly.xml
+++ b/assembly/assembly.xml
@@ -30,7 +30,7 @@
     </fileSet>
     <fileSet>
       <directory>${project.parent.basedir}/repl/scala-2.10/target/jars</directory>
-      <outputDirectory>${assembly.name}/repl-jars</outputDirectory>
+      <outputDirectory>${assembly.name}/repl_2.10-jars</outputDirectory>
       <includes>
         <include>*</include>
       </includes>

--- a/assembly/assembly.xml
+++ b/assembly/assembly.xml
@@ -29,8 +29,15 @@
       </includes>
     </fileSet>
     <fileSet>
-      <directory>${project.parent.basedir}/${repl.dir}/target/jars</directory>
+      <directory>${project.parent.basedir}/repl/scala-2.10/target/jars</directory>
       <outputDirectory>${assembly.name}/repl-jars</outputDirectory>
+      <includes>
+        <include>*</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.parent.basedir}/repl/scala-2.11/target/jars</directory>
+      <outputDirectory>${assembly.name}/repl_2.11-jars</outputDirectory>
       <includes>
         <include>*</include>
       </includes>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -119,6 +119,30 @@
         </dependency>
       </dependencies>
     </profile>
+
+    <profile>
+      <id>scala-both</id>
+      <activation>
+        <property>
+          <name>scala-both</name>
+        </property>
+      </activation>
+      <properties>
+        <repl.dir>repl/scala-2.1*</repl.dir>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>livy-repl_2.10</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>livy-repl_2.11</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
 </project>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -33,13 +33,24 @@
     <assembly.name>livy-server-${project.version}</assembly.name>
     <assembly.format>zip</assembly.format>
     <skipDeploy>true</skipDeploy>
-    <repl.dir>repl/scala-2.10</repl.dir>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>livy-rsc</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>livy-repl_2.10</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>livy-repl_2.11</artifactId>
       <version>${project.version}</version>
     </dependency>
 
@@ -83,65 +94,6 @@
       <properties>
         <assembly.format>tar.gz</assembly.format>
       </properties>
-    </profile>
-
-    <profile>
-      <id>scala-2.10</id>
-      <activation>
-        <property>
-          <name>!scala-2.11</name>
-        </property>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>livy-repl_2.10</artifactId>
-          <version>${project.version}</version>
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <profile>
-      <id>scala-2.11</id>
-      <activation>
-        <property>
-          <name>scala-2.11</name>
-        </property>
-      </activation>
-      <properties>
-        <repl.dir>repl/scala-2.11</repl.dir>
-      </properties>
-      <dependencies>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>livy-repl_2.11</artifactId>
-          <version>${project.version}</version>
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <profile>
-      <id>scala-both</id>
-      <activation>
-        <property>
-          <name>scala-both</name>
-        </property>
-      </activation>
-      <properties>
-        <repl.dir>repl/scala-2.1*</repl.dir>
-      </properties>
-      <dependencies>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>livy-repl_2.10</artifactId>
-          <version>${project.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>livy-repl_2.11</artifactId>
-          <version>${project.version}</version>
-        </dependency>
-      </dependencies>
     </profile>
   </profiles>
 

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -45,13 +45,6 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>livy-assembly</artifactId>
-      <version>${project.version}</version>
-      <type>pom</type>
-    </dependency>
-
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>livy-core_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/server/src/main/scala/com/cloudera/livy/LivyConf.scala
+++ b/server/src/main/scala/com/cloudera/livy/LivyConf.scala
@@ -41,6 +41,8 @@ object LivyConf {
   val SPARK_HOME = Entry("livy.server.spark-home", null)
   val LIVY_SPARK_MASTER = Entry("livy.spark.master", "local")
   val LIVY_SPARK_DEPLOY_MODE = Entry("livy.spark.deployMode", null)
+  val LIVY_SPARK_SCALA_VERSION = Entry("livy.spark.scalaVersion", null)
+  val LIVY_SPARK_VERSION = Entry("livy.spark.version", null)
 
   val SESSION_STAGING_DIR = Entry("livy.session.staging-dir", null)
   val FILE_UPLOAD_MAX_SIZE = Entry("livy.file.upload.max.size", 100L * 1024 * 1024)

--- a/server/src/main/scala/com/cloudera/livy/LivyConf.scala
+++ b/server/src/main/scala/com/cloudera/livy/LivyConf.scala
@@ -41,6 +41,11 @@ object LivyConf {
   val SPARK_HOME = Entry("livy.server.spark-home", null)
   val LIVY_SPARK_MASTER = Entry("livy.spark.master", "local")
   val LIVY_SPARK_DEPLOY_MODE = Entry("livy.spark.deployMode", null)
+
+  // Two configurations to specify Spark and related Scala version. These are internal
+  // configurations will be set by LivyServer and used in session creation. It is not required to
+  // set usually unless running with unofficial Spark + Scala versions
+  // (like Spark 2.0 + Scala 2.10, Spark 1.6 + Scala 2.11)
   val LIVY_SPARK_SCALA_VERSION = Entry("livy.spark.scalaVersion", null)
   val LIVY_SPARK_VERSION = Entry("livy.spark.version", null)
 

--- a/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
@@ -64,7 +64,16 @@ class LivyServer extends Logging {
 
     // Make sure the `spark-submit` program exists, otherwise much of livy won't work.
     testSparkHome(livyConf)
-    testSparkSubmit(livyConf)
+
+    // Test spark-submit and get Spark Scala version accordingly.
+    val (sparkVersion, scalaVersion) = sparkSubmitVersion(livyConf)
+    testSparkVersion(sparkVersion)
+    // If Spark and Scala version is not set, set into livy configuration, this will be used by
+    // session creation.
+    livyConf.setIfMissing(LIVY_SPARK_VERSION.key,
+      formatSparkVersion(sparkVersion).productIterator.mkString("."))
+    livyConf.setIfMissing(LIVY_SPARK_SCALA_VERSION.key,
+      formatScalaVersion(scalaVersion, formatSparkVersion(sparkVersion)))
 
     testRecovery(livyConf)
 

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/CreateInteractiveRequest.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/CreateInteractiveRequest.scala
@@ -36,6 +36,5 @@ class CreateInteractiveRequest {
   var queue: Option[String] = None
   var name: Option[String] = None
   var conf: Map[String, String] = Map()
-  var scalaVersion: Option[String] = None
 
 }

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/CreateInteractiveRequest.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/CreateInteractiveRequest.scala
@@ -36,5 +36,6 @@ class CreateInteractiveRequest {
   var queue: Option[String] = None
   var name: Option[String] = None
   var conf: Map[String, String] = Map()
+  var scalaVersion: Option[String] = None
 
 }

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
@@ -124,15 +124,16 @@ class InteractiveSession(
     require(livyConf.get(LivyConf.LIVY_SPARK_VERSION) != null)
     require(livyConf.get(LivyConf.LIVY_SPARK_SCALA_VERSION) != null)
 
-    val sparkVersion = LivySparkUtils.formatSparkVersion(livyConf.get(LivyConf.LIVY_SPARK_VERSION))
+    val (sparkMajorVersion, _) =
+      LivySparkUtils.formatSparkVersion(livyConf.get(LivyConf.LIVY_SPARK_VERSION))
     val scalaVersion = livyConf.get(LivyConf.LIVY_SPARK_SCALA_VERSION)
 
     mergeConfList(livyJars(livyConf, scalaVersion), LivyConf.SPARK_JARS)
     val enableHiveContext = livyConf.getBoolean(LivyConf.ENABLE_HIVE_CONTEXT)
     // pass spark.livy.spark_major_version to driver
-    builderProperties.put("spark.livy.spark_major_version", sparkVersion._1.toString)
+    builderProperties.put("spark.livy.spark_major_version", sparkMajorVersion.toString)
 
-    if (sparkVersion._1 <= 1) {
+    if (sparkMajorVersion <= 1) {
       builderProperties.put("spark.repl.enableHiveContext",
         livyConf.getBoolean(LivyConf.ENABLE_HIVE_CONTEXT).toString)
     } else {
@@ -141,7 +142,7 @@ class InteractiveSession(
     }
 
     if (enableHiveContext) {
-      mergeHiveSiteAndHiveDeps(sparkVersion._1)
+      mergeHiveSiteAndHiveDeps(sparkMajorVersion)
     }
 
     val userOpts: Map[String, Option[String]] = Map(

--- a/server/src/main/scala/com/cloudera/livy/utils/LivySparkUtils.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/LivySparkUtils.scala
@@ -137,13 +137,13 @@ object LivySparkUtils {
    * Return Scala binary version, if it cannot be parsed from input version string, it will
    * pick default Scala version related to Spark version.
    *
-   * @param version Scala binary version String
+   * @param scalaVersion Scala binary version String
    * @param sparkVersion formatted Spark version.
    * @return Scala binary version String based on Spark version and livy conf.
    */
-  def formatScalaVersion(version: String, sparkVersion: (Int, Int)): String = {
+  def formatScalaVersion(scalaVersion: String, sparkVersion: (Int, Int)): String = {
     val versionPattern = """(\d)+\.(\d+)+.*""".r
-    version match {
+    scalaVersion match {
       case versionPattern(major, minor) =>
         major + "." + minor
       case _ =>

--- a/server/src/main/scala/com/cloudera/livy/utils/LivySparkUtils.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/LivySparkUtils.scala
@@ -27,6 +27,21 @@ import com.cloudera.livy.util.LineBufferedProcess
 
 object LivySparkUtils {
 
+  // For each Spark version we supported, we need to add this mapping relation in case Scala
+  // version cannot be detected from "spark-submit --version".
+  private val defaultSparkScalaVersion = Map(
+    // Spark 2.0 + Scala 2.11
+    (2, 0) -> (2, 11),
+    // Spark 1.6 + Scala 2.10
+    (1, 6) -> (2, 10))
+
+  // Supported Spark version
+  private val MIN_VERSION = (1, 6)
+  private val MAX_VERSION = (2, 1)
+
+  private val sparkVersionRegex = """version (.*)""".r.unanchored
+  private val scalaVersionRegex = """Scala version (.*), Java""".r.unanchored
+
   /**
    * Test that Spark home is configured and configured Spark home is a directory.
    */
@@ -45,7 +60,7 @@ object LivySparkUtils {
    */
    def testSparkSubmit(livyConf: LivyConf): Unit = {
     try {
-      testSparkVersion(sparkSubmitVersion(livyConf))
+      testSparkVersion(sparkSubmitVersion(livyConf)._1)
     } catch {
       case e: IOException =>
         throw new IOException("Failed to run spark-submit executable", e)
@@ -57,25 +72,21 @@ object LivySparkUtils {
    * @param version Spark version
    */
   def testSparkVersion(version: String): Unit = {
-    // This is exclusive. Version which equals to this will be rejected.
-    val maxVersion = (2, 1)
-    val minVersion = (1, 6)
-
     val supportedVersion = formatSparkVersion(version) match {
       case v: (Int, Int) =>
-        v >= minVersion && v < maxVersion
+        v >= MIN_VERSION && v < MAX_VERSION
       case _ => false
     }
     require(supportedVersion, s"Unsupported Spark version $version.")
   }
 
   /**
-   * Return the version of the configured `spark-submit` version.
+   * Return the Spark and Scala version of the configured `spark-submit` version.
    *
    * @param livyConf
-   * @return the version
+   * @return Tuple with Spark and Scala version
    */
-  def sparkSubmitVersion(livyConf: LivyConf): String = {
+  def sparkSubmitVersion(livyConf: LivyConf): (String, String) = {
     val sparkSubmit = livyConf.sparkSubmit()
     val pb = new ProcessBuilder(sparkSubmit, "--version")
     pb.redirectErrorStream(true)
@@ -89,20 +100,28 @@ object LivySparkUtils {
     val exitCode = process.waitFor()
     val output = process.inputIterator.mkString("\n")
 
-    val regex = """version (.*)""".r.unanchored
-
+    var sparkVersion = ""
     output match {
-      case regex(version) => version
+      case sparkVersionRegex(version) => sparkVersion = version
       case _ =>
         throw new IOException(f"Unable to determine spark-submit version [$exitCode]:\n$output")
     }
+
+    var scalaVersion = ""
+    output match {
+      case scalaVersionRegex(version) => scalaVersion = version
+      case _ =>
+    }
+
+    (sparkVersion, scalaVersion)
   }
 
   /**
-    * Return formatted Spark version.
-    * @param version Spark version
-    * @return Two element tuple, one is major version and the other is minor version
-    */
+   * Return formatted Spark version.
+   *
+   * @param version Spark version
+   * @return Two element tuple, one is major version and the other is minor version
+   */
   def formatSparkVersion(version: String): (Int, Int) = {
     val versionPattern = """(\d)+\.(\d)+(?:[\.-]\d*)*""".r
     version match {
@@ -110,6 +129,25 @@ object LivySparkUtils {
         (major.toInt, minor.toInt)
       case _ =>
         throw new IllegalArgumentException(s"Fail to parse Spark version from $version")
+    }
+  }
+
+  /**
+   * Return formatted Scala version, if it cannot be parsed from input version string, it will
+   * pick default Scala version related to Spark version.
+   *
+   * @param version Scala version String
+   * @param sparkVersion formatted Spark version.
+   * @return Tuple of Scala version, one is major version and the other is minor version.
+   */
+  def formatScalaVersion(version: String, sparkVersion: (Int, Int)): (Int, Int) = {
+    val versionPattern = """(\d)+\.(\d+)+.*""".r
+    version match {
+      case versionPattern(major, minor) =>
+        (major.toInt, minor.toInt)
+      case _ =>
+        defaultSparkScalaVersion.getOrElse(sparkVersion,
+          throw new IllegalArgumentException(s"Fail to get Scala version from Spark $sparkVersion"))
     }
   }
 }

--- a/server/src/main/scala/com/cloudera/livy/utils/LivySparkUtils.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/LivySparkUtils.scala
@@ -31,9 +31,10 @@ object LivySparkUtils {
   // version cannot be detected from "spark-submit --version".
   private val defaultSparkScalaVersion = Map(
     // Spark 2.0 + Scala 2.11
-    (2, 0) -> (2, 11),
+    (2, 0) -> "2.11",
     // Spark 1.6 + Scala 2.10
-    (1, 6) -> (2, 10))
+    (1, 6) -> "2.10"
+  )
 
   // Supported Spark version
   private val MIN_VERSION = (1, 6)
@@ -133,18 +134,18 @@ object LivySparkUtils {
   }
 
   /**
-   * Return formatted Scala version, if it cannot be parsed from input version string, it will
+   * Return Scala binary version, if it cannot be parsed from input version string, it will
    * pick default Scala version related to Spark version.
    *
-   * @param version Scala version String
+   * @param version Scala binary version String
    * @param sparkVersion formatted Spark version.
-   * @return Tuple of Scala version, one is major version and the other is minor version.
+   * @return Scala binary version String based on Spark version and livy conf.
    */
-  def formatScalaVersion(version: String, sparkVersion: (Int, Int)): (Int, Int) = {
+  def formatScalaVersion(version: String, sparkVersion: (Int, Int)): String = {
     val versionPattern = """(\d)+\.(\d+)+.*""".r
     version match {
       case versionPattern(major, minor) =>
-        (major.toInt, minor.toInt)
+        major + "." + minor
       case _ =>
         defaultSparkScalaVersion.getOrElse(sparkVersion,
           throw new IllegalArgumentException(s"Fail to get Scala version from Spark $sparkVersion"))

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/BaseInteractiveServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/BaseInteractiveServletSpec.scala
@@ -50,6 +50,8 @@ abstract class BaseInteractiveServletSpec extends BaseSessionServletSpec[Interac
     super.createConf()
       .set(LivyConf.SESSION_STAGING_DIR, tempDir.toURI().toString())
       .set(InteractiveSession.LivyReplJars, "")
+      .set(LivyConf.LIVY_SPARK_VERSION, "1.6.0")
+      .set(LivyConf.LIVY_SPARK_SCALA_VERSION, "2.10.5")
   }
 
   protected def createRequest(

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionSpec.scala
@@ -38,6 +38,8 @@ class InteractiveSessionSpec extends FunSpec
 
   private val livyConf = new LivyConf()
   livyConf.set(InteractiveSession.LivyReplJars, "")
+    .set(LivyConf.LIVY_SPARK_VERSION, "1.6.0")
+    .set(LivyConf.LIVY_SPARK_SCALA_VERSION, "2.10.5")
 
   implicit val formats = DefaultFormats
 

--- a/server/src/test/scala/com/cloudera/livy/utils/LivySparkUtilsSuite.scala
+++ b/server/src/test/scala/com/cloudera/livy/utils/LivySparkUtilsSuite.scala
@@ -43,6 +43,7 @@ class LivySparkUtilsSuite extends FunSuite with Matchers with LivyBaseUnitTestSu
     testSparkVersion("1.6.1")
     testSparkVersion("1.6.2")
     testSparkVersion("1.6")
+    testSparkVersion("1.6.3.2.5.0-12")
   }
 
   test("should support Spark 2.0.x") {

--- a/server/src/test/scala/com/cloudera/livy/utils/LivySparkUtilsSuite.scala
+++ b/server/src/test/scala/com/cloudera/livy/utils/LivySparkUtilsSuite.scala
@@ -42,6 +42,7 @@ class LivySparkUtilsSuite extends FunSuite with Matchers with LivyBaseUnitTestSu
     testSparkVersion("1.6.0")
     testSparkVersion("1.6.1")
     testSparkVersion("1.6.2")
+    testSparkVersion("1.6")
   }
 
   test("should support Spark 2.0.x") {
@@ -49,6 +50,7 @@ class LivySparkUtilsSuite extends FunSuite with Matchers with LivyBaseUnitTestSu
     testSparkVersion("2.0.1")
     testSparkVersion("2.0.2")
     testSparkVersion("2.0.0.2.5.1.0-56") // LIVY-229
+    testSparkVersion("2.0")
   }
 
   test("should not support Spark older than 1.6 or newer than 2.0") {
@@ -75,14 +77,14 @@ class LivySparkUtilsSuite extends FunSuite with Matchers with LivyBaseUnitTestSu
   }
 
   test("get correct Scala version") {
-    formatScalaVersion("2.10.8", formatSparkVersion("2.0.0")) should be ((2, 10))
-    formatScalaVersion("2.11.4", formatSparkVersion("1.6.0")) should be ((2, 11))
-    formatScalaVersion("2.10", formatSparkVersion("2.0.0")) should be ((2, 10))
-    formatScalaVersion("2.10.x.x.x.x", formatSparkVersion("2.0.0")) should be ((2, 10))
+    formatScalaVersion("2.10.8", formatSparkVersion("2.0.0")) should be ("2.10")
+    formatScalaVersion("2.11.4", formatSparkVersion("1.6.0")) should be ("2.11")
+    formatScalaVersion("2.10", formatSparkVersion("2.0.0")) should be ("2.10")
+    formatScalaVersion("2.10.x.x.x.x", formatSparkVersion("2.0.0")) should be ("2.10")
 
     // Will pick default Spark Scala version if the input Scala version string is not correct.
-    formatScalaVersion("", formatSparkVersion("2.0.0")) should be ((2, 11))
-    formatScalaVersion("xxx", formatSparkVersion("1.6.1")) should be ((2, 10))
+    formatScalaVersion("", formatSparkVersion("2.0.0")) should be ("2.11")
+    formatScalaVersion("xxx", formatSparkVersion("1.6.1")) should be ("2.10")
 
     // Throw exception for unsupported Spark version.
     intercept[IllegalArgumentException] {

--- a/server/src/test/scala/com/cloudera/livy/utils/LivySparkUtilsSuite.scala
+++ b/server/src/test/scala/com/cloudera/livy/utils/LivySparkUtilsSuite.scala
@@ -19,11 +19,12 @@
 package com.cloudera.livy.utils
 
 import org.scalatest.FunSuite
+import org.scalatest.Matchers
 
 import com.cloudera.livy.{LivyBaseUnitTestSuite, LivyConf}
 import com.cloudera.livy.server.LivyServer
 
-class LivySparkUtilsSuite extends FunSuite with LivyBaseUnitTestSuite {
+class LivySparkUtilsSuite extends FunSuite with Matchers with LivyBaseUnitTestSuite {
 
   import LivySparkUtils._
 
@@ -71,5 +72,21 @@ class LivySparkUtilsSuite extends FunSuite with LivyBaseUnitTestSuite {
     livyConf.set(LivyConf.RECOVERY_MODE, "recovery")
     val s = new LivyServer()
     intercept[IllegalArgumentException] { s.testRecovery(livyConf) }
+  }
+
+  test("get correct Scala version") {
+    formatScalaVersion("2.10.8", formatSparkVersion("2.0.0")) should be ((2, 10))
+    formatScalaVersion("2.11.4", formatSparkVersion("1.6.0")) should be ((2, 11))
+    formatScalaVersion("2.10", formatSparkVersion("2.0.0")) should be ((2, 10))
+    formatScalaVersion("2.10.x.x.x.x", formatSparkVersion("2.0.0")) should be ((2, 10))
+
+    // Will pick default Spark Scala version if the input Scala version string is not correct.
+    formatScalaVersion("", formatSparkVersion("2.0.0")) should be ((2, 11))
+    formatScalaVersion("xxx", formatSparkVersion("1.6.1")) should be ((2, 10))
+
+    // Throw exception for unsupported Spark version.
+    intercept[IllegalArgumentException] {
+      formatScalaVersion("xxx", formatSparkVersion("1.5.0"))
+    }
   }
 }


### PR DESCRIPTION
With this change, Livy's assembly package will have two REPL bundles: `repl_2.10-jars` and `repl_2.11-jars`. Livy will pick the right jars based on:

1. If Scala version can be detected automatically by Livy.
2. If User specify Scala major version in `CreateInteractiveSession`.
3. If Livy could figure out default Scala version for Spark.

Please review and suggest, thanks a lot.

CC @tc0312 .