### PR TITLE
LIVY-212. Implemented session recovery for interactive session. Only work with YARN.

### DIFF
--- a/client-http/src/test/scala/com/cloudera/livy/client/http/HttpClientSpec.scala
+++ b/client-http/src/test/scala/com/cloudera/livy/client/http/HttpClientSpec.scala
@@ -40,7 +40,8 @@ import com.cloudera.livy.client.common.{BufferUtils, Serializer}
 import com.cloudera.livy.client.common.HttpMessages._
 import com.cloudera.livy.server.WebServer
 import com.cloudera.livy.server.interactive.{InteractiveSession, InteractiveSessionServlet}
-import com.cloudera.livy.sessions.{SessionState, Spark}
+import com.cloudera.livy.server.recovery.SessionStore
+import com.cloudera.livy.sessions.{InteractiveSessionManager, SessionState, Spark}
 import com.cloudera.livy.test.jobs.Echo
 import com.cloudera.livy.utils.AppInfo
 
@@ -264,7 +265,10 @@ private class HttpClientTestBootstrap extends LifeCycle {
   private implicit def executor: ExecutionContext = ExecutionContext.global
 
   override def init(context: ServletContext): Unit = {
-    val servlet = new InteractiveSessionServlet(new LivyConf()) {
+    val conf = new LivyConf()
+    val stateStore = mock(classOf[SessionStore])
+    val sessionManager = new InteractiveSessionManager(conf, stateStore, Some(Seq.empty))
+    val servlet = new InteractiveSessionServlet(sessionManager, stateStore, conf) {
       override protected def createSession(req: HttpServletRequest): InteractiveSession = {
         val session = mock(classOf[InteractiveSession])
         val id = sessionManager.nextId()

--- a/integration-test/src/main/scala/com/cloudera/livy/test/framework/BaseIntegrationTestSuite.scala
+++ b/integration-test/src/main/scala/com/cloudera/livy/test/framework/BaseIntegrationTestSuite.scala
@@ -91,7 +91,11 @@ abstract class BaseIntegrationTestSuite extends FunSuite with Matchers with Befo
         } catch { case NonFatal(_) => }
         throw e
     } finally {
-      try { s.stop() } catch { case NonFatal(_) => }
+      try {
+        s.stop()
+      } catch {
+        case NonFatal(e) => alert(s"Failed to stop session: $e")
+      }
     }
   }
 

--- a/integration-test/src/main/scala/com/cloudera/livy/test/framework/LivyRestClient.scala
+++ b/integration-test/src/main/scala/com/cloudera/livy/test/framework/LivyRestClient.scala
@@ -145,8 +145,10 @@ class LivyRestClient(val httpClient: AsyncHttpClient, val livyEndpoint: String) 
               val data = output("data").asInstanceOf[Map[String, Any]]
               Left(data("text/plain").asInstanceOf[String])
             case Some("error") => Right(mapper.convertValue(output, classOf[StatementError]))
-            case Some(status) => throw new Exception(s"Unknown statement $stmtId status: $status")
-            case None => throw new Exception(s"Unknown statement $stmtId output: $newStmt")
+            case Some(status) =>
+              throw new IllegalStateException(s"Unknown statement $stmtId status: $status")
+            case None =>
+              throw new IllegalStateException(s"Unknown statement $stmtId output: $newStmt")
           }
         }
       }

--- a/integration-test/src/main/scala/com/cloudera/livy/test/framework/LivyRestClient.scala
+++ b/integration-test/src/main/scala/com/cloudera/livy/test/framework/LivyRestClient.scala
@@ -99,7 +99,7 @@ class LivyRestClient(val httpClient: AsyncHttpClient, val livyEndpoint: String) 
       // Keeping the original timeout to avoid slowing down local development.
       eventually(timeout(t), interval(1 second)) {
         val s = snapshot().state
-        assert(strStates.contains(s), s"Session state $s doesn't equal one of $strStates")
+        assert(strStates.contains(s), s"Session $id state $s doesn't equal one of $strStates")
       }
     }
 
@@ -145,8 +145,8 @@ class LivyRestClient(val httpClient: AsyncHttpClient, val livyEndpoint: String) 
               val data = output("data").asInstanceOf[Map[String, Any]]
               Left(data("text/plain").asInstanceOf[String])
             case Some("error") => Right(mapper.convertValue(output, classOf[StatementError]))
-            case Some(status) => throw new Exception(s"Unknown statement status: $status")
-            case None => throw new Exception(s"Unknown statement output: $newStmt")
+            case Some(status) => throw new Exception(s"Unknown statement $stmtId status: $status")
+            case None => throw new Exception(s"Unknown statement $stmtId output: $newStmt")
           }
         }
       }
@@ -158,7 +158,7 @@ class LivyRestClient(val httpClient: AsyncHttpClient, val livyEndpoint: String) 
               matchStrings(result, expectedRegex)
             }
           case Right(error) =>
-            assert(false, s"Got error from statement $code: ${error.evalue}")
+            assert(false, s"Got error from statement $stmtId $code: ${error.evalue}")
         }
       }
 
@@ -166,7 +166,7 @@ class LivyRestClient(val httpClient: AsyncHttpClient, val livyEndpoint: String) 
           ename: String = null, evalue: String = null, stackTrace: String = null): Unit = {
         result() match {
           case Left(result) =>
-            assert(false, s"Statement `$code` expected to fail, but succeeded.")
+            assert(false, s"Statement $stmtId `$code` expected to fail, but succeeded.")
           case Right(error) =>
             val remoteStack = Option(error.stackTrace).getOrElse(Nil).mkString("\n")
             Seq(error.ename -> ename, error.evalue -> evalue, remoteStack -> stackTrace).foreach {

--- a/server/src/main/scala/com/cloudera/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/SessionServlet.scala
@@ -27,6 +27,7 @@ import org.scalatra._
 
 import com.cloudera.livy.{LivyConf, Logging}
 import com.cloudera.livy.sessions.{Session, SessionManager}
+import com.cloudera.livy.sessions.Session.RecoveryMetadata
 
 object SessionServlet extends Logging
 
@@ -37,8 +38,8 @@ object SessionServlet extends Logging
  * Type parameters:
  *  S: the session type
  */
-abstract class SessionServlet[S <: Session](
-    private[livy] val sessionManager: SessionManager[S],
+abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
+    private[livy] val sessionManager: SessionManager[S, R],
     livyConf: LivyConf)
   extends JsonServlet
   with ApiVersioningSupport

--- a/server/src/main/scala/com/cloudera/livy/server/batch/BatchSessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/batch/BatchSessionServlet.scala
@@ -23,7 +23,7 @@ import javax.servlet.http.HttpServletRequest
 import com.cloudera.livy.LivyConf
 import com.cloudera.livy.server.SessionServlet
 import com.cloudera.livy.server.recovery.SessionStore
-import com.cloudera.livy.sessions.SessionManager
+import com.cloudera.livy.sessions.BatchSessionManager
 import com.cloudera.livy.utils.AppInfo
 
 case class BatchSessionView(
@@ -34,10 +34,10 @@ case class BatchSessionView(
   log: Seq[String])
 
 class BatchSessionServlet(
-    sessionManager: SessionManager[BatchSession],
+    sessionManager: BatchSessionManager,
     sessionStore: SessionStore,
     livyConf: LivyConf)
-  extends SessionServlet[BatchSession](sessionManager, livyConf)
+  extends SessionServlet(sessionManager, livyConf)
 {
 
   override protected def createSession(req: HttpServletRequest): BatchSession = {

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
@@ -124,10 +124,10 @@ object InteractiveSession extends Logging {
       sessionStore: SessionStore,
       mockApp: Option[SparkApp] = None,
       mockClient: Option[RSCClient] = None): InteractiveSession = {
-    val client = mockClient orElse metadata.rscDriverUri.map { uri =>
+    val client = mockClient.orElse(metadata.rscDriverUri.map { uri =>
       val builder = new LivyClientBuilder().setURI(uri)
       builder.build().asInstanceOf[RSCClient]
-    }
+    })
 
     new InteractiveSession(
       metadata.id,
@@ -325,7 +325,7 @@ object InteractiveSession extends Logging {
 
 class InteractiveSession(
     id: Int,
-    appId: Option[String],
+    appIdHint: Option[String],
     appTag: String,
     client: Option[RSCClient],
     initialState: SessionState,
@@ -346,7 +346,9 @@ class InteractiveSession(
   private val operationCounter = new AtomicLong(0)
   private var rscDriverUri: Option[URI] = None
   private var sessionLog: IndexedSeq[String] = IndexedSeq.empty
+  private val sessionSaveLock = new Object()
 
+  _appId = appIdHint
   sessionStore.save(RECOVERY_SESSION_TYPE, recoveryMetadata)
 
   private val app = mockApp.orElse {
@@ -379,7 +381,9 @@ class InteractiveSession(
 
       override def onJobSucceeded(job: JobHandle[Void], result: Void): Unit = {
         rscDriverUri = Option(client.get.getServerUri.get())
-        sessionStore.save(RECOVERY_SESSION_TYPE, recoveryMetadata)
+        sessionSaveLock.synchronized {
+          sessionStore.save(RECOVERY_SESSION_TYPE, recoveryMetadata)
+        }
         transition(SessionState.Idle())
       }
 
@@ -549,7 +553,9 @@ class InteractiveSession(
 
   override def appIdKnown(appId: String): Unit = {
     _appId = Option(appId)
-    sessionStore.save(RECOVERY_SESSION_TYPE, recoveryMetadata)
+    sessionSaveLock.synchronized {
+      sessionStore.save(RECOVERY_SESSION_TYPE, recoveryMetadata)
+    }
   }
 
   override def stateChanged(oldState: SparkApp.State, newState: SparkApp.State): Unit = {

--- a/server/src/main/scala/com/cloudera/livy/server/recovery/ZooKeeperStateStore.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/recovery/ZooKeeperStateStore.scala
@@ -23,6 +23,7 @@ import scala.reflect.ClassTag
 import org.apache.curator.framework.{CuratorFramework, CuratorFrameworkFactory}
 import org.apache.curator.framework.api.UnhandledErrorListener
 import org.apache.curator.retry.RetryNTimes
+import org.apache.zookeeper.KeeperException.NoNodeException
 
 import com.cloudera.livy.{LivyConf, Logging}
 import com.cloudera.livy.LivyConf.Entry
@@ -105,7 +106,11 @@ class ZooKeeperStateStore(
   }
 
   override def remove(key: String): Unit = {
-    curatorClient.delete().guaranteed().forPath(prefixKey(key))
+    try {
+      curatorClient.delete().guaranteed().forPath(prefixKey(key))
+    } catch {
+      case _: NoNodeException =>
+    }
   }
 
   private def prefixKey(key: String) = s"/$zkKeyPrefix/$key"

--- a/server/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
+++ b/server/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
@@ -45,7 +45,6 @@ class BatchSessionManager(
     mockSessions: Option[Seq[BatchSession]] = None)
   extends SessionManager[BatchSession, BatchRecoveryMetadata] (
     livyConf, BatchSession.recover(_, livyConf, sessionStore), sessionStore, "batch", mockSessions)
-  { }
 
 class InteractiveSessionManager(
   livyConf: LivyConf,
@@ -57,7 +56,6 @@ class InteractiveSessionManager(
     sessionStore,
     "interactive",
     mockSessions)
-  { }
 
 class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
     livyConf: LivyConf,

--- a/server/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
+++ b/server/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
@@ -24,10 +24,14 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.mutable
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration.Duration
+import scala.reflect.ClassTag
+import scala.util.control.NonFatal
 
 import com.cloudera.livy.{LivyConf, Logging}
 import com.cloudera.livy.server.batch.{BatchRecoveryMetadata, BatchSession}
+import com.cloudera.livy.server.interactive.{InteractiveRecoveryMetadata, InteractiveSession}
 import com.cloudera.livy.server.recovery.SessionStore
+import com.cloudera.livy.sessions.Session.RecoveryMetadata
 
 object SessionManager {
   val SESSION_RECOVERY_MODE_OFF = "off"
@@ -35,65 +39,35 @@ object SessionManager {
   val SESSION_TIMEOUT = LivyConf.Entry("livy.server.session.timeout", "1h")
 }
 
-// TODO Replace SessionManager with this class when interactive sessions support recovery.
 class BatchSessionManager(
     livyConf: LivyConf,
     sessionStore: SessionStore,
     mockSessions: Option[Seq[BatchSession]] = None)
-  extends SessionManager[BatchSession](livyConf) {
+  extends SessionManager[BatchSession, BatchRecoveryMetadata] (
+    livyConf, BatchSession.recover(_, livyConf, sessionStore), sessionStore, "batch", mockSessions)
+  { }
+
+class InteractiveSessionManager(
+  livyConf: LivyConf,
+  sessionStore: SessionStore,
+  mockSessions: Option[Seq[InteractiveSession]] = None)
+  extends SessionManager[InteractiveSession, InteractiveRecoveryMetadata] (
+    livyConf,
+    InteractiveSession.recover(_, livyConf, sessionStore),
+    sessionStore,
+    "interactive",
+    mockSessions)
+  { }
+
+class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
+    livyConf: LivyConf,
+    sessionRecovery: R => S,
+    sessionStore: SessionStore,
+    sessionType: String,
+    mockSessions: Option[Seq[S]] = None)
+  extends Logging {
 
   import SessionManager._
-
-  private val sessionType: String = "batch"
-
-  mockSessions.getOrElse(recover()).foreach(register)
-
-  override def nextId(): Int = synchronized {
-    val id = idCounter.getAndIncrement()
-    sessionStore.saveNextSessionId(sessionType, idCounter.get())
-    id
-  }
-
-  override def delete(session: BatchSession): Future[Unit] = {
-    session.stop().map { case _ =>
-      sessionStore.remove(sessionType, session.id)
-      synchronized {
-        sessions.remove(session.id)
-      }
-    }
-  }
-
-  override def shutdown(): Unit = {
-    val recoveryEnabled = livyConf.get(LivyConf.RECOVERY_MODE) != SESSION_RECOVERY_MODE_OFF
-    if (!recoveryEnabled) {
-      super.shutdown()
-    }
-  }
-
-  private def recover(): Seq[BatchSession] = {
-    // Recover next session id from state store and create SessionManager.
-    idCounter.set(sessionStore.getNextSessionId(sessionType))
-
-    // Retrieve session recovery metadata from state store.
-    val sessionMetadata = sessionStore.getAllSessions[BatchRecoveryMetadata](sessionType)
-
-    // Recover session from session recovery metadata.
-    val recoveredSessions = sessionMetadata.flatMap(_.toOption).map(
-      BatchSession.recover(_, livyConf, sessionStore))
-
-    info(s"Recovered ${recoveredSessions.length} $sessionType sessions." +
-      s" Next session id: $idCounter")
-
-    // Print recovery error.
-    val recoveryFailure = sessionMetadata.filter(_.isFailure).map(_.failed.get)
-    recoveryFailure.foreach(ex => error(ex.getMessage, ex.getCause))
-
-    recoveredSessions
-  }
-}
-
-class SessionManager[S <: Session](private val livyConf: LivyConf)
-  extends Logging {
 
   protected implicit def executor: ExecutionContext = ExecutionContext.global
 
@@ -103,9 +77,14 @@ class SessionManager[S <: Session](private val livyConf: LivyConf)
   private[this] final val sessionTimeout =
     TimeUnit.MILLISECONDS.toNanos(livyConf.getTimeAsMs(SessionManager.SESSION_TIMEOUT))
 
+  mockSessions.getOrElse(recover()).foreach(register)
   new GarbageCollector().start()
 
-  def nextId(): Int = idCounter.getAndIncrement()
+  def nextId(): Int = synchronized {
+    val id = idCounter.getAndIncrement()
+    sessionStore.saveNextSessionId(sessionType, idCounter.get())
+    id
+  }
 
   def register(session: S): S = {
     info(s"Registering new session ${session.id}")
@@ -127,15 +106,25 @@ class SessionManager[S <: Session](private val livyConf: LivyConf)
 
   def delete(session: S): Future[Unit] = {
     session.stop().map { case _ =>
-      synchronized {
-        sessions.remove(session.id)
+      try {
+        sessionStore.remove(sessionType, session.id)
+        synchronized {
+          sessions.remove(session.id)
+        }
+      } catch {
+        case NonFatal(e) =>
+          error("Exception was thrown during stop session:", e)
+          throw e
       }
     }
   }
 
   def shutdown(): Unit = {
-    sessions.values.map(_.stop).foreach { future =>
-      Await.ready(future, Duration.Inf)
+    val recoveryEnabled = livyConf.get(LivyConf.RECOVERY_MODE) != SESSION_RECOVERY_MODE_OFF
+    if (!recoveryEnabled) {
+      sessions.values.map(_.stop).foreach { future =>
+        Await.ready(future, Duration.Inf)
+      }
     }
   }
 
@@ -146,6 +135,26 @@ class SessionManager[S <: Session](private val livyConf: LivyConf)
     }
 
     Future.sequence(all().filter(expired).map(delete))
+  }
+
+  private def recover(): Seq[S] = {
+    // Recover next session id from state store and create SessionManager.
+    idCounter.set(sessionStore.getNextSessionId(sessionType))
+
+    // Retrieve session recovery metadata from state store.
+    val sessionMetadata = sessionStore.getAllSessions[R](sessionType)
+
+    // Recover session from session recovery metadata.
+    val recoveredSessions = sessionMetadata.flatMap(_.toOption).map(sessionRecovery)
+
+    info(s"Recovered ${recoveredSessions.length} $sessionType sessions." +
+      s" Next session id: $idCounter")
+
+    // Print recovery error.
+    val recoveryFailure = sessionMetadata.filter(_.isFailure).map(_.failed.get)
+    recoveryFailure.foreach(ex => error(ex.getMessage, ex.getCause))
+
+    recoveredSessions
   }
 
   private class GarbageCollector extends Thread("session gc thread") {

--- a/server/src/test/scala/com/cloudera/livy/server/BaseSessionServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/BaseSessionServletSpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.BeforeAndAfterAll
 
 import com.cloudera.livy.LivyConf
 import com.cloudera.livy.sessions.Session
+import com.cloudera.livy.sessions.Session.RecoveryMetadata
 
 object BaseSessionServletSpec {
 
@@ -32,7 +33,7 @@ object BaseSessionServletSpec {
 
 }
 
-abstract class BaseSessionServletSpec[S <: Session]
+abstract class BaseSessionServletSpec[S <: Session, R <: RecoveryMetadata]
   extends BaseJsonServletSpec
   with BeforeAndAfterAll {
 
@@ -62,7 +63,7 @@ abstract class BaseSessionServletSpec[S <: Session]
     servlet.shutdown()
   }
 
-  def createServlet(): SessionServlet[S]
+  def createServlet(): SessionServlet[S, R]
 
   protected val servlet = createServlet()
 
@@ -73,7 +74,7 @@ abstract class BaseSessionServletSpec[S <: Session]
 }
 
 trait RemoteUserOverride {
-  this: SessionServlet[_] =>
+  this: SessionServlet[_, _] =>
 
   override protected def remoteUser(req: HttpServletRequest): String = {
     req.getHeader(BaseSessionServletSpec.REMOTE_USER_HEADER)

--- a/server/src/test/scala/com/cloudera/livy/server/batch/BatchServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/batch/BatchServletSpec.scala
@@ -32,10 +32,10 @@ import org.scalatest.mock.MockitoSugar.mock
 import com.cloudera.livy.Utils
 import com.cloudera.livy.server.BaseSessionServletSpec
 import com.cloudera.livy.server.recovery.SessionStore
-import com.cloudera.livy.sessions.{SessionManager, SessionState}
+import com.cloudera.livy.sessions.{BatchSessionManager, SessionState}
 import com.cloudera.livy.utils.AppInfo
 
-class BatchServletSpec extends BaseSessionServletSpec[BatchSession] {
+class BatchServletSpec extends BaseSessionServletSpec[BatchSession, BatchRecoveryMetadata] {
 
   val script: Path = {
     val script = Files.createTempFile("livy-test", ".py")
@@ -54,9 +54,10 @@ class BatchServletSpec extends BaseSessionServletSpec[BatchSession] {
 
   override def createServlet(): BatchSessionServlet = {
     val livyConf = createConf()
+    val sessionStore = mock[SessionStore]
     new BatchSessionServlet(
-      new SessionManager[BatchSession](livyConf),
-      mock[SessionStore],
+      new BatchSessionManager(livyConf, sessionStore, Some(Seq.empty)),
+      sessionStore,
       livyConf)
   }
 

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/BaseInteractiveServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/BaseInteractiveServletSpec.scala
@@ -29,7 +29,8 @@ import com.cloudera.livy.rsc.RSCConf
 import com.cloudera.livy.server.BaseSessionServletSpec
 import com.cloudera.livy.sessions.{Kind, SessionKindModule, Spark}
 
-abstract class BaseInteractiveServletSpec extends BaseSessionServletSpec[InteractiveSession] {
+abstract class BaseInteractiveServletSpec
+  extends BaseSessionServletSpec[InteractiveSession, InteractiveRecoveryMetadata] {
 
   mapper.registerModule(new SessionKindModule())
 
@@ -49,7 +50,7 @@ abstract class BaseInteractiveServletSpec extends BaseSessionServletSpec[Interac
     }
     super.createConf()
       .set(LivyConf.SESSION_STAGING_DIR, tempDir.toURI().toString())
-      .set(InteractiveSession.LivyReplJars, "")
+      .set(InteractiveSession.LIVY_REPL_JARS, "")
       .set(LivyConf.LIVY_SPARK_VERSION, "1.6.0")
       .set(LivyConf.LIVY_SPARK_SCALA_VERSION, "2.10.5")
   }

--- a/server/src/test/scala/com/cloudera/livy/sessions/SessionManagerSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/sessions/SessionManagerSpec.scala
@@ -31,13 +31,19 @@ import org.scalatest.mock.MockitoSugar.mock
 import com.cloudera.livy.{LivyBaseUnitTestSuite, LivyConf}
 import com.cloudera.livy.server.batch.{BatchRecoveryMetadata, BatchSession}
 import com.cloudera.livy.server.recovery.SessionStore
+import com.cloudera.livy.sessions.Session.RecoveryMetadata
 
 class SessionManagerSpec extends FunSpec with Matchers with LivyBaseUnitTestSuite {
   describe("SessionManager") {
     it("should garbage collect old sessions") {
       val livyConf = new LivyConf()
       livyConf.set(SessionManager.SESSION_TIMEOUT, "100ms")
-      val manager = new SessionManager[MockSession](livyConf)
+      val manager = new SessionManager[MockSession, RecoveryMetadata](
+        livyConf,
+        { _ => assert(false).asInstanceOf[MockSession] },
+        mock[SessionStore],
+        "test",
+        Some(Seq.empty))
       val session = manager.register(new MockSession(manager.nextId(), null, livyConf))
       manager.get(session.id).isDefined should be(true)
       eventually(timeout(5 seconds), interval(100 millis)) {


### PR DESCRIPTION
livy-server can now recover interactive sessions after restart.
There are some special cases:
- If livy-server crashes while an interactive session is starting, there's a chance the session is unrecoverable, depending on timing (whether livy-repl has registered to livy-server).
- If livy-server is down longer than the value of server.idle_timeout (default: 10min), livy-repl will timeout and quit.

Note: All previous statements are lost after recovery. This will be fixed in a different commit.