### PR TITLE
LIVY-229. Spark version check fails when it's used with HDP built Spark.

### DIFF
--- a/server/src/main/scala/com/cloudera/livy/utils/LivySparkUtils.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/LivySparkUtils.scala
@@ -104,7 +104,7 @@ object LivySparkUtils {
     * @return Two element tuple, one is major version and the other is minor version
     */
   def formatSparkVersion(version: String): (Int, Int) = {
-    val versionPattern = """(\d)+\.(\d)+(?:\.\d*)?""".r
+    val versionPattern = """(\d)+\.(\d)+(?:[\.-]\d*)*""".r
     version match {
       case versionPattern(major, minor) =>
         (major.toInt, minor.toInt)

--- a/server/src/test/scala/com/cloudera/livy/utils/LivySparkUtilsSuite.scala
+++ b/server/src/test/scala/com/cloudera/livy/utils/LivySparkUtilsSuite.scala
@@ -47,10 +47,10 @@ class LivySparkUtilsSuite extends FunSuite with LivyBaseUnitTestSuite {
     testSparkVersion("2.0.0")
     testSparkVersion("2.0.1")
     testSparkVersion("2.0.2")
+    testSparkVersion("2.0.0.2.5.1.0-56") // LIVY-229
   }
 
   test("should not support Spark older than 1.6 or newer than 2.0") {
-    val s = new LivyServer()
     intercept[IllegalArgumentException] { testSparkVersion("1.4.0") }
     intercept[IllegalArgumentException] { testSparkVersion("1.5.0") }
     intercept[IllegalArgumentException] { testSparkVersion("1.5.1") }
@@ -59,6 +59,10 @@ class LivySparkUtilsSuite extends FunSuite with LivyBaseUnitTestSuite {
     intercept[IllegalArgumentException] { testSparkVersion("2.1.0") }
     intercept[IllegalArgumentException] { testSparkVersion("2.1.2") }
     intercept[IllegalArgumentException] { testSparkVersion("2.2.1") }
+  }
+
+  test("should fail on bad version") {
+    intercept[IllegalArgumentException] { testSparkVersion("not a version") }
   }
 
   test("should error out if recovery is turned on but master isn't yarn") {


### PR DESCRIPTION
Fixed Spark version regex to support version like 2.0.0.2.5.1.0-56.