### PR TITLE
LIVY-219. Support Scala-2.11 integration test for Livy IT.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ dist: trusty
 language: scala
 
 env:
-  - MVN_FLAG=
-  - MVN_FLAG=-Dminicluster-2.10.spark.version=2.0.1 -Dminicluster-2.11.spark.version=1.6.2
+  - MVN_FLAG=-Pspark-1.6
+  - MVN_FLAG=-Pspark-2.0
 
 jdk:
   - oraclejdk7
@@ -30,7 +30,7 @@ before_install:
   - pip3 install --user cloudpickle
 
 install:
-  - mvn install -Dskip -DskipTests -DskipITs -Dmaven.javadoc.skip=true -B -V
+  - mvn $MVN_FLAG install -Dskip -DskipTests -DskipITs -Dmaven.javadoc.skip=true -B -V
 
 before_script:
   - pip install --user requests pytest flaky flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ sudo: required
 dist: trusty
 language: scala
 
+env:
+  - MVN_FLAG=
+  - MVN_FLAG=-Dminicluster-2.10.spark.version=2.0.1 -Dminicluster-2.11.spark.version=1.6.2
+
 jdk:
   - oraclejdk7
 
@@ -33,7 +37,7 @@ before_script:
   - pip3 install --user requests pytest flaky
 
 script:
-  - mvn verify -e
+  - mvn $MVN_FLAG verify -e
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/integration-test/minicluster-dependencies/pom.xml
+++ b/integration-test/minicluster-dependencies/pom.xml
@@ -29,12 +29,11 @@
     <relativePath>../../scala/pom.xml</relativePath>
     <version>0.3.0-SNAPSHOT</version>
   </parent>
-  <artifactId>livy-integration-test-minicluster-dependencies-parent</artifactId>
+  <artifactId>minicluster-dependencies-parent</artifactId>
   <version>0.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <properties>
     <skipDeploy>true</skipDeploy>
-    <minicluster.spark.version></minicluster.spark.version>
   </properties>
   <dependencies>
     <dependency>
@@ -80,32 +79,32 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
-      <version>${minicluster.spark.version}</version>
+      <version>${spark.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_${scala.binary.version}</artifactId>
-      <version>${minicluster.spark.version}</version>
+      <version>${spark.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-streaming_${scala.binary.version}</artifactId>
-      <version>${minicluster.spark.version}</version>
+      <version>${spark.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-hive_${scala.binary.version}</artifactId>
-      <version>${minicluster.spark.version}</version>
+      <version>${spark.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-repl_${scala.binary.version}</artifactId>
-      <version>${minicluster.spark.version}</version>
+      <version>${spark.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-yarn_${scala.binary.version}</artifactId>
-      <version>${minicluster.spark.version}</version>
+      <version>${spark.version}</version>
     </dependency>
     <dependency>
       <groupId>org.objenesis</groupId>

--- a/integration-test/minicluster-dependencies/pom.xml
+++ b/integration-test/minicluster-dependencies/pom.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Licensed to Cloudera, Inc. under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  Cloudera, Inc. licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<!-- This module is created to generate classpath for MiniCluster to run integration test with different
+     Scala version -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.cloudera.livy</groupId>
+    <artifactId>multi-scala-project-root</artifactId>
+    <relativePath>../../scala/pom.xml</relativePath>
+    <version>0.3.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>livy-integration-test-minicluster-dependencies-parent</artifactId>
+  <version>0.3.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <properties>
+    <skipDeploy>true</skipDeploy>
+    <minicluster.spark.version></minicluster.spark.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.5</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs</artifactId>
+      <version>${hadoop.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-yarn-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <version>${minicluster.spark.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_${scala.binary.version}</artifactId>
+      <version>${minicluster.spark.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+      <version>${minicluster.spark.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-hive_${scala.binary.version}</artifactId>
+      <version>${minicluster.spark.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-repl_${scala.binary.version}</artifactId>
+      <version>${minicluster.spark.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-yarn_${scala.binary.version}</artifactId>
+      <version>${minicluster.spark.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.objenesis</groupId>
+      <artifactId>objenesis</artifactId>
+      <version>1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals><goal>build-classpath</goal></goals>
+            <configuration>
+              <outputFile>target/classpath</outputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/integration-test/minicluster-dependencies/scala-2.10/pom.xml
+++ b/integration-test/minicluster-dependencies/scala-2.10/pom.xml
@@ -19,13 +19,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.cloudera.livy</groupId>
-  <artifactId>livy-integration-test-minicluster-dependencies_2.10</artifactId>
+  <artifactId>minicluster-dependencies_2.10</artifactId>
   <version>0.3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>com.cloudera.livy</groupId>
-    <artifactId>livy-integration-test-minicluster-dependencies-parent</artifactId>
+    <artifactId>minicluster-dependencies-parent</artifactId>
     <version>0.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
@@ -33,6 +33,5 @@
   <properties>
     <scala.version>${scala-2.10.version}</scala.version>
     <scala.binary.version>2.10</scala.binary.version>
-    <minicluster.spark.version>${minicluster-2.10.spark.version}</minicluster.spark.version>
   </properties>
 </project>

--- a/integration-test/minicluster-dependencies/scala-2.10/pom.xml
+++ b/integration-test/minicluster-dependencies/scala-2.10/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to Cloudera, Inc. under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  Cloudera, Inc. licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.cloudera.livy</groupId>
+  <artifactId>livy-integration-test-minicluster-dependencies_2.10</artifactId>
+  <version>0.3.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <parent>
+    <groupId>com.cloudera.livy</groupId>
+    <artifactId>livy-integration-test-minicluster-dependencies-parent</artifactId>
+    <version>0.3.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <properties>
+    <scala.version>${scala-2.10.version}</scala.version>
+    <scala.binary.version>2.10</scala.binary.version>
+    <minicluster.spark.version>${minicluster-2.10.spark.version}</minicluster.spark.version>
+  </properties>
+</project>

--- a/integration-test/minicluster-dependencies/scala-2.11/pom.xml
+++ b/integration-test/minicluster-dependencies/scala-2.11/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to Cloudera, Inc. under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  Cloudera, Inc. licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.cloudera.livy</groupId>
+  <artifactId>livy-integration-test-minicluster-dependencies_2.11</artifactId>
+  <version>0.3.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <parent>
+    <groupId>com.cloudera.livy</groupId>
+    <artifactId>livy-integration-test-minicluster-dependencies-parent</artifactId>
+    <version>0.3.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <properties>
+    <scala.version>${scala-2.11.version}</scala.version>
+    <scala.binary.version>2.11</scala.binary.version>
+    <minicluster.spark.version>${minicluster-2.11.spark.version}</minicluster.spark.version>
+  </properties>
+</project>

--- a/integration-test/minicluster-dependencies/scala-2.11/pom.xml
+++ b/integration-test/minicluster-dependencies/scala-2.11/pom.xml
@@ -19,13 +19,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.cloudera.livy</groupId>
-  <artifactId>livy-integration-test-minicluster-dependencies_2.11</artifactId>
+  <artifactId>minicluster-dependencies_2.11</artifactId>
   <version>0.3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>com.cloudera.livy</groupId>
-    <artifactId>livy-integration-test-minicluster-dependencies-parent</artifactId>
+    <artifactId>minicluster-dependencies-parent</artifactId>
     <version>0.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
@@ -33,6 +33,5 @@
   <properties>
     <scala.version>${scala-2.11.version}</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
-    <minicluster.spark.version>${minicluster-2.11.spark.version}</minicluster.spark.version>
   </properties>
 </project>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -39,6 +39,8 @@
     -->
     <cluster.spec>default</cluster.spec>
     <skipDeploy>true</skipDeploy>
+    <skipITs-2.10>false</skipITs-2.10>
+    <skipITs-2.11>false</skipITs-2.11>
   </properties>
 
   <dependencies>
@@ -47,6 +49,30 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>livy-core_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>livy-repl_2.10</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>livy-repl_2.11</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -63,6 +89,33 @@
     </dependency>
 
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>livy-integration-test-minicluster-dependencies_2.10</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>livy-integration-test-minicluster-dependencies_2.11</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+
       <groupId>${project.groupId}</groupId>
       <artifactId>livy-test-lib</artifactId>
       <version>${project.version}</version>
@@ -207,11 +260,30 @@
             <phase>none</phase>
           </execution>
           <execution>
-            <id>integration-test</id>
+            <id>integration-test-scala-2.10</id>
             <phase>integration-test</phase>
             <goals>
               <goal>test</goal>
             </goals>
+            <configuration>
+              <environmentVariables>
+                <LIVY_SPARK_SCALA_VERSION>2.10</LIVY_SPARK_SCALA_VERSION>
+              </environmentVariables>
+              <skipTests>${skipITs-2.10}</skipTests>
+            </configuration>
+          </execution>
+          <execution>
+            <id>integration-test-scala-2.11</id>
+            <phase>integration-test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <environmentVariables>
+                <LIVY_SPARK_SCALA_VERSION>2.11</LIVY_SPARK_SCALA_VERSION>
+              </environmentVariables>
+              <skipTests>${skipITs-2.11}</skipTests>
+            </configuration>
           </execution>
         </executions>
         <configuration>
@@ -239,6 +311,19 @@
       </activation>
       <properties>
         <spark.home>${real.spark.home}</spark.home>
+      </properties>
+    </profile>
+    <profile>
+    <id>skip-integration-test</id>
+      <activation>
+        <property>
+          <name>skipITs</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <properties>
+        <skipITs-2.10>true</skipITs-2.10>
+        <skipITs-2.11>true</skipITs-2.11>
       </properties>
     </profile>
   </profiles>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -53,30 +53,6 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>livy-repl_2.10</artifactId>
-      <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>livy-repl_2.11</artifactId>
-      <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>livy-server</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -90,7 +66,7 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>livy-integration-test-minicluster-dependencies_2.10</artifactId>
+      <artifactId>minicluster-dependencies_2.10</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
       <exclusions>
@@ -103,7 +79,7 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>livy-integration-test-minicluster-dependencies_2.11</artifactId>
+      <artifactId>minicluster-dependencies_2.11</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
       <exclusions>
@@ -115,7 +91,6 @@
     </dependency>
 
     <dependency>
-
       <groupId>${project.groupId}</groupId>
       <artifactId>livy-test-lib</artifactId>
       <version>${project.version}</version>
@@ -313,6 +288,7 @@
         <spark.home>${real.spark.home}</spark.home>
       </properties>
     </profile>
+
     <profile>
     <id>skip-integration-test</id>
       <activation>

--- a/integration-test/src/main/scala/com/cloudera/livy/test/framework/MiniCluster.scala
+++ b/integration-test/src/main/scala/com/cloudera/livy/test/framework/MiniCluster.scala
@@ -57,9 +57,9 @@ sealed trait MiniClusterUtils extends ClusterUtils {
   private val livySparkScalaVersionEnvVarName = "LIVY_SPARK_SCALA_VERSION"
 
   protected def getSparkScalaVersion(): String = {
-    sys.env.get(livySparkScalaVersionEnvVarName).getOrElse {
+    sys.env.getOrElse(livySparkScalaVersionEnvVarName, {
       throw new RuntimeException(s"Please specify env var $livySparkScalaVersionEnvVarName.")
-    }
+    })
   }
 
   protected def saveConfig(conf: Configuration, dest: File): Unit = {
@@ -249,8 +249,8 @@ class MiniCluster(config: Map[String, String]) extends Cluster with MiniClusterU
     val extraCp = if (!isRealSpark()) {
       val dummyJar = Files.createTempFile(Paths.get(tempDir.toURI), "dummy", "jar").toFile
       Map(
-        SparkLauncher.DRIVER_EXTRA_CLASSPATH -> childClasspath,
-        SparkLauncher.EXECUTOR_EXTRA_CLASSPATH -> childClasspath,
+        SparkLauncher.DRIVER_EXTRA_CLASSPATH -> sparkClassPath,
+        SparkLauncher.EXECUTOR_EXTRA_CLASSPATH -> sparkClassPath,
         // Used for Spark 2.0. Spark 2.0 will upload specified jars to distributed cache in yarn
         // mode, if not specified it will check jars folder. Here since jars folder is not
         // existed, so it will throw exception.

--- a/integration-test/src/main/scala/com/cloudera/livy/test/framework/MiniCluster.scala
+++ b/integration-test/src/main/scala/com/cloudera/livy/test/framework/MiniCluster.scala
@@ -19,6 +19,7 @@
 package com.cloudera.livy.test.framework
 
 import java.io._
+import java.nio.charset.Charset
 import java.nio.file.{Files, Paths}
 import javax.servlet.http.HttpServletResponse
 
@@ -53,6 +54,13 @@ private class MiniClusterConfig(val config: Map[String, String]) {
 }
 
 sealed trait MiniClusterUtils extends ClusterUtils {
+  private val livySparkScalaVersionEnvVarName = "LIVY_SPARK_SCALA_VERSION"
+
+  protected def getSparkScalaVersion(): String = {
+    sys.env.get(livySparkScalaVersionEnvVarName).getOrElse {
+      throw new RuntimeException(s"Please specify env var $livySparkScalaVersionEnvVarName.")
+    }
+  }
 
   protected def saveConfig(conf: Configuration, dest: File): Unit = {
     val redacted = new Configuration(conf)
@@ -148,6 +156,7 @@ object MiniLivyMain extends MiniClusterBase {
     var livyConf = Map(
       LivyConf.LIVY_SPARK_MASTER.key -> "yarn",
       LivyConf.LIVY_SPARK_DEPLOY_MODE.key -> "cluster",
+      LivyConf.LIVY_SPARK_SCALA_VERSION.key -> getSparkScalaVersion(),
       LivyConf.YARN_POLL_INTERVAL.key -> "500ms",
       LivyConf.RECOVERY_MODE.key -> "recovery",
       LivyConf.RECOVERY_STATE_STORE.key -> "filesystem",
@@ -188,7 +197,6 @@ private case class ProcessInfo(process: Process, logFile: File)
  * TODO: add support for MiniKdc.
  */
 class MiniCluster(config: Map[String, String]) extends Cluster with MiniClusterUtils with Logging {
-
   private val tempDir = new File(s"${sys.props("java.io.tmpdir")}/livy-int-test")
   private var sparkConfDir: File = _
   private var _configDir: File = _
@@ -228,6 +236,14 @@ class MiniCluster(config: Map[String, String]) extends Cluster with MiniClusterU
     }
     assert(tempDir.mkdir(), "Cannot create temp test dir.")
     sparkConfDir = mkdir("spark-conf")
+
+    val sparkScalaVersion = getSparkScalaVersion()
+    val classPathFile =
+      new File(s"minicluster-dependencies/scala-$sparkScalaVersion/target/classpath")
+    assert(classPathFile.isFile,
+      s"Cannot read MiniCluster classpath file: ${classPathFile.getCanonicalPath}")
+    val sparkClassPath =
+      FileUtils.readFileToString(classPathFile, Charset.defaultCharset())
 
     // When running a real Spark cluster, don't set the classpath.
     val extraCp = if (!isRealSpark()) {

--- a/integration-test/src/test/scala/com/cloudera/livy/test/InteractiveIT.scala
+++ b/integration-test/src/test/scala/com/cloudera/livy/test/InteractiveIT.scala
@@ -33,9 +33,9 @@ import com.cloudera.livy.test.framework.{BaseIntegrationTestSuite, LivyRestClien
 class InteractiveIT extends BaseIntegrationTestSuite {
   test("basic interactive session") {
     withNewSession(Spark()) { s =>
+      s.run("val sparkVersion = sc.version").result().left.foreach(info(_))
       s.run("1+1").verifyResult("res0: Int = 2")
       s.run("""sc.getConf.get("spark.executor.instances")""").verifyResult("res1: String = 1")
-      s.run("sqlContext").verifyResult(startsWith("res2: org.apache.spark.sql.hive.HiveContext"))
       s.run("val sql = new org.apache.spark.sql.SQLContext(sc)").verifyResult(
         ".*" + Pattern.quote(
         "sql: org.apache.spark.sql.SQLContext = org.apache.spark.sql.SQLContext") + ".*")

--- a/integration-test/src/test/scala/com/cloudera/livy/test/InteractiveIT.scala
+++ b/integration-test/src/test/scala/com/cloudera/livy/test/InteractiveIT.scala
@@ -43,6 +43,12 @@ class InteractiveIT extends BaseIntegrationTestSuite {
       s.run("throw new IllegalStateException()")
         .verifyError(evalue = ".*java\\.lang\\.IllegalStateException.*")
 
+      // Verify Livy internal configurations are not exposed.
+      // TODO separate all these checks to different sub tests after merging new IT code.
+      s.run("""sc.getConf.getAll.exists(_._1.startsWith("spark.__livy__."))""")
+        .verifyResult(".*false")
+      s.run("""sys.props.exists(_._1.startsWith("spark.__livy__."))""").verifyResult(".*false")
+
       // Make sure appInfo is reported correctly.
       val state = s.snapshot()
       state.appInfo.driverLogUrl.value should include ("containerlogs")

--- a/integration-test/src/test/scala/com/cloudera/livy/test/JobApiIT.scala
+++ b/integration-test/src/test/scala/com/cloudera/livy/test/JobApiIT.scala
@@ -190,23 +190,6 @@ class JobApiIT extends BaseIntegrationTestSuite with BeforeAndAfterAll with Logg
     assert(result === "foo")
   }
 
-  test("ensure Livy internal configurations are not exposed") {
-    assume(client2 != null, "Client not active.")
-
-    val job = new Job[Boolean] {
-      override def call(jc: JobContext): Boolean = {
-        val sc = jc.sc()
-        val livyConfExisted = sc.getConf.getAll.exists(_._1.startsWith("spark.__livy__."))
-        val livyConfExistedInProps = sys.props.exists(_._1.startsWith("spark.__livy__."))
-
-        livyConfExisted || livyConfExistedInProps
-      }
-    }
-
-    val result = waitFor(client2.submit(job))
-    assert(result === false)
-  }
-
   test("destroy the session") {
     assume(client2 != null, "Client not active.")
     client2.stop(true)

--- a/pom.xml
+++ b/pom.xml
@@ -72,10 +72,6 @@
     <execution.root>${user.dir}</execution.root>
     <spark.home>${execution.root}/dev/spark</spark.home>
 
-    <!-- Spark version integration test should use. -->
-    <minicluster-2.10.spark.version>1.6.2</minicluster-2.10.spark.version>
-    <minicluster-2.11.spark.version>2.0.1</minicluster-2.11.spark.version>
-
     <!-- Set this to "true" to skip R tests. -->
     <skipRTests>false</skipRTests>
 
@@ -1002,7 +998,7 @@
         </property>
       </activation>
       <properties>
-        <spark.version>2.0.0</spark.version>
+        <spark.version>2.0.1</spark.version>
       </properties>
     </profile>
   </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,10 @@
     <execution.root>${user.dir}</execution.root>
     <spark.home>${execution.root}/dev/spark</spark.home>
 
+    <!-- Spark version integration test should use. -->
+    <minicluster-2.10.spark.version>1.6.2</minicluster-2.10.spark.version>
+    <minicluster-2.11.spark.version>2.0.1</minicluster-2.11.spark.version>
+
     <!-- Set this to "true" to skip R tests. -->
     <skipRTests>false</skipRTests>
 
@@ -189,6 +193,8 @@
     <module>scala-api</module>
     <module>server</module>
     <module>test-lib</module>
+    <module>integration-test/minicluster-dependencies/scala-2.10</module>
+    <module>integration-test/minicluster-dependencies/scala-2.11</module>
     <module>integration-test</module>
   </modules>
 

--- a/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
@@ -88,10 +88,13 @@ class LivyServer extends Logging {
         }
     }
 
+    // TODO Create a new class to pass variables from LivyServer to sessions and remove these
+    // internal LivyConfs.
     // Set formatted Spark and Scala version into livy configuration, this will be used by
     // session creation.
     livyConf.set(LIVY_SPARK_VERSION.key, formattedSparkVersion.productIterator.mkString("."))
-    livyConf.set(LIVY_SPARK_SCALA_VERSION.key,
+    // Integration test sets spark scala version.
+    livyConf.setIfMissing(LIVY_SPARK_SCALA_VERSION.key,
       formatScalaVersion(scalaVersion, formattedSparkVersion))
 
     testRecovery(livyConf)

--- a/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
@@ -66,7 +66,7 @@ class LivyServer extends Logging {
     testSparkHome(livyConf)
 
     // Test spark-submit and get Spark Scala version accordingly.
-    val (sparkVersion, scalaVersion) = sparkSubmitVersion(livyConf)
+    val (sparkVersion, scalaVersionFromSparkSubmit) = sparkSubmitVersion(livyConf)
     testSparkVersion(sparkVersion)
 
     // If Spark and Scala version is set manually, should verify if they're consistent with
@@ -78,24 +78,13 @@ class LivyServer extends Logging {
           "got from spark-submit -version")
     }
 
-    if (!scalaVersion.isEmpty && Option(livyConf.get(LIVY_SPARK_SCALA_VERSION)).isDefined) {
-      Option(livyConf.get(LIVY_SPARK_SCALA_VERSION))
-        .map(s => formatScalaVersion(s, formattedSparkVersion))
-        .foreach { version =>
-          require(version == scalaVersion,
-            s"Configured Scala version $version is not equal to Scala version $scalaVersion got " +
-              "from spark-submit -version")
-        }
-    }
-
-    // TODO Create a new class to pass variables from LivyServer to sessions and remove these
-    // internal LivyConfs.
     // Set formatted Spark and Scala version into livy configuration, this will be used by
     // session creation.
+    // TODO Create a new class to pass variables from LivyServer to sessions and remove these
+    // internal LivyConfs.
     livyConf.set(LIVY_SPARK_VERSION.key, formattedSparkVersion.productIterator.mkString("."))
-    // Integration test sets spark scala version.
-    livyConf.setIfMissing(LIVY_SPARK_SCALA_VERSION.key,
-      formatScalaVersion(scalaVersion, formattedSparkVersion))
+    livyConf.set(LIVY_SPARK_SCALA_VERSION.key,
+      sparkScalaVersion(formattedSparkVersion, scalaVersionFromSparkSubmit, livyConf))
 
     testRecovery(livyConf)
 


### PR DESCRIPTION
- Added Maven submodules (minicluster-dependencies) to write Spark classpath of different Scala version to files for MiniCluster.
- Writing classpath to a file instead of Maven properties to maintain ability to run integration tests from IDEs.
- MiniCluster picks and reads the correct Spark classpath and pass it to MiniLivy via spark-default.conf.
- Dependency changes to make sure both repl is built when Maven runs integration-test.
- Verify "ensure Livy internal configurations are not exposed" in InteractiveIT instead of JobsApiIT to avoid job incompatibility issue between Scala 2.10 and 2.11.
- Changed Maven pom.xml to start integration tests in 2.10 and 2.11.
- MiniCluster sets env. var. to tell LivyServer what Spark Scala version it should use.
- Changed Travis to launch 2 builds for Spark 1.6 and Spark 2.0 with Scala 2.10 and 2.11.
- During development, to skip integration test for a Scala version, use `-DskipITs-2.10` or `-DskipITs-2.11`. `-DskipITs` will skip both.
- Fixed JaCoCo EOFException by disabling JaCoCo for `InteractiveIT.should kill RSCDriver if it doesn't respond to end session`.