### PR TITLE
LIVY-234. Support Scala 2.11 for Livy Scala api

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>com.cloudera.livy</groupId>
-            <artifactId>livy-scala-api</artifactId>
+            <artifactId>livy-scala-api_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,8 @@
     <module>repl/scala-2.10</module>
     <module>repl/scala-2.11</module>
     <module>rsc</module>
-    <module>scala-api</module>
+    <module>scala-api/scala-2.10</module>
+    <module>scala-api/scala-2.11</module>
     <module>server</module>
     <module>test-lib</module>
     <module>integration-test</module>

--- a/scala-api/pom.xml
+++ b/scala-api/pom.xml
@@ -23,14 +23,14 @@
 
     <parent>
         <groupId>com.cloudera.livy</groupId>
-        <artifactId>livy-main</artifactId>
+        <artifactId>multi-scala-project-root</artifactId>
         <version>0.3.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../scala/pom.xml</relativePath>
     </parent>
 
-    <groupId>com.cloudera.livy</groupId>
-    <artifactId>livy-scala-api</artifactId>
+    <artifactId>livy-scala-api-parent</artifactId>
     <version>0.3.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
 
     <dependencies>
         <dependency>

--- a/scala-api/scala-2.10/pom.xml
+++ b/scala-api/scala-2.10/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to Cloudera, Inc. under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  Cloudera, Inc. licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.cloudera.livy</groupId>
+  <artifactId>livy-scala-api_2.10</artifactId>
+  <version>0.3.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <parent>
+    <groupId>com.cloudera.livy</groupId>
+    <artifactId>livy-scala-api-parent</artifactId>
+    <version>0.3.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <properties>
+    <scala.version>${scala-2.10.version}</scala.version>
+    <scala.binary.version>2.10</scala.binary.version>
+  </properties>
+</project>

--- a/scala-api/scala-2.11/pom.xml
+++ b/scala-api/scala-2.11/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to Cloudera, Inc. under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  Cloudera, Inc. licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.cloudera.livy</groupId>
+  <artifactId>livy-scala-api_2.11</artifactId>
+  <version>0.3.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <parent>
+    <groupId>com.cloudera.livy</groupId>
+    <artifactId>livy-scala-api-parent</artifactId>
+    <version>0.3.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <properties>
+    <scala.version>${scala-2.11.version}</scala.version>
+    <scala.binary.version>2.11</scala.binary.version>
+  </properties>
+</project>


### PR DESCRIPTION
Separate livy-scala-api build to scala-2.10 and scala-2.11, which will make job api support Scala 2.11 build of Spark.