### PR TITLE
LIVY-236. Fix NPE issue in Job API when return value is Void

### DIFF
--- a/client-http/src/main/java/com/cloudera/livy/client/http/JobHandleImpl.java
+++ b/client-http/src/main/java/com/cloudera/livy/client/http/JobHandleImpl.java
@@ -235,9 +235,11 @@ class JobHandleImpl<T> extends AbstractJobHandle<T> {
 
         switch (status.state) {
           case SUCCEEDED:
-            @SuppressWarnings("unchecked")
-            T localResult = (T) serializer.deserialize(ByteBuffer.wrap(status.result));
-            result = localResult;
+            if (status.result != null) {
+              @SuppressWarnings("unchecked")
+              T localResult = (T) serializer.deserialize(ByteBuffer.wrap(status.result));
+              result = localResult;
+            }
             finished = true;
             break;
 

--- a/integration-test/src/test/scala/com/cloudera/livy/test/JobApiIT.scala
+++ b/integration-test/src/test/scala/com/cloudera/livy/test/JobApiIT.scala
@@ -190,6 +190,19 @@ class JobApiIT extends BaseIntegrationTestSuite with BeforeAndAfterAll with Logg
     assert(result === "foo")
   }
 
+  test("return null should not throw NPE") {
+    assume(client2 != null, "Client not active")
+
+    val job = new Job[Void] {
+      override def call(jc: JobContext): Void = {
+        null
+      }
+    }
+
+    val result = waitFor(client2.submit(job))
+    assert(result === null)
+  }
+
   test("destroy the session") {
     assume(client2 != null, "Client not active.")
     client2.stop(true)

--- a/integration-test/src/test/scala/com/cloudera/livy/test/JobApiIT.scala
+++ b/integration-test/src/test/scala/com/cloudera/livy/test/JobApiIT.scala
@@ -193,13 +193,7 @@ class JobApiIT extends BaseIntegrationTestSuite with BeforeAndAfterAll with Logg
   test("return null should not throw NPE") {
     assume(client2 != null, "Client not active")
 
-    val job = new Job[Void] {
-      override def call(jc: JobContext): Void = {
-        null
-      }
-    }
-
-    val result = waitFor(client2.submit(job))
+    val result = waitFor(client2.submit(new VoidJob()))
     assert(result === null)
   }
 

--- a/test-lib/src/main/java/com/cloudera/livy/test/jobs/VoidJob.java
+++ b/test-lib/src/main/java/com/cloudera/livy/test/jobs/VoidJob.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.test.jobs;
+
+import com.cloudera.livy.Job;
+import com.cloudera.livy.JobContext;
+
+public class VoidJob implements Job<Void> {
+  @Override
+  public Void call(JobContext jc) {
+    return null;
+  }
+}


### PR DESCRIPTION
to reproduce this issue:

```
val job = new Job[Void] {
      override def call(jc: JobContext): Void = {
        jc.sc().map(xxx).saveAsTextFile(xxx)
        null
      }
    }

    val result = waitFor(client2.submit(job))
```

We should also consider return value explicitly set as Void not to throw exception.
