### PR TITLE
LIVY-219. Follow-up. Some follow-up works for Cross integration test

### DIFF
--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -167,31 +167,25 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_${scala.binary.version}</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-hive_${scala.binary.version}</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-repl_${scala.binary.version}</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-yarn_${scala.binary.version}</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/integration-test/src/test/scala/com/cloudera/livy/test/JobApiIT.scala
+++ b/integration-test/src/test/scala/com/cloudera/livy/test/JobApiIT.scala
@@ -22,11 +22,11 @@ import java.io.{File, InputStream}
 import java.net.URI
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.{Files, StandardCopyOption}
-import java.util.concurrent.{Future => JFuture, TimeUnit}
+import java.util.concurrent.{TimeUnit, Future => JFuture}
 import javax.servlet.http.HttpServletResponse
 
 import scala.collection.JavaConverters._
-import scala.util.Try
+import scala.util.{Properties, Try}
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
@@ -37,6 +37,7 @@ import com.cloudera.livy.client.common.HttpMessages._
 import com.cloudera.livy.sessions.SessionKindModule
 import com.cloudera.livy.test.framework.BaseIntegrationTestSuite
 import com.cloudera.livy.test.jobs._
+import com.cloudera.livy.utils.LivySparkUtils
 
 // Proper type representing the return value of "GET /sessions". At some point we should make
 // SessionServlet use something like this.
@@ -157,7 +158,7 @@ class JobApiIT extends BaseIntegrationTestSuite with BeforeAndAfterAll with Logg
     assert(result === "hello")
   }
 
-  test("run scala jobs") {
+  scalaTest("run scala jobs") {
     assume(client2 != null, "Client not active.")
 
     val jobs = Seq(
@@ -172,6 +173,15 @@ class JobApiIT extends BaseIntegrationTestSuite with BeforeAndAfterAll with Logg
     jobs.foreach { job =>
       val result = waitFor(client2.submit(job))
       assert(result === job.value)
+    }
+  }
+
+  protected def scalaTest(desc: String)(testFn: => Unit): Unit = {
+    test(desc) {
+      assume(sys.env("LIVY_SPARK_SCALA_VERSION") ==
+        LivySparkUtils.formatScalaVersion(Properties.versionNumberString),
+        s"Scala test can only be run with ${Properties.versionString}")
+      testFn
     }
   }
 

--- a/integration-test/src/test/scala/com/cloudera/livy/test/JobApiIT.scala
+++ b/integration-test/src/test/scala/com/cloudera/livy/test/JobApiIT.scala
@@ -22,7 +22,7 @@ import java.io.{File, InputStream}
 import java.net.URI
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.{Files, StandardCopyOption}
-import java.util.concurrent.{TimeUnit, Future => JFuture}
+import java.util.concurrent.{Future => JFuture, TimeUnit}
 import javax.servlet.http.HttpServletResponse
 
 import scala.collection.JavaConverters._


### PR DESCRIPTION
1. Update the pom to restrict the scope and remove some unnecessary dependencies.
2. Rewrite `ScalaEcho` test with Java one. Because test-lib will be run under Scala 2.10 and 2.11 environments, while it is built against with Scala 2.10, to avoid potential problems, propose to rewrite with Java.