### PR TITLE
LIVY-237. Fixed JaCoCo is randomly throwing EOFException on Travis.

### DIFF
--- a/rsc/src/main/java/com/cloudera/livy/rsc/ContextLauncher.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/ContextLauncher.java
@@ -183,7 +183,10 @@ class ContextLauncher {
     // of "small" Java processes lingering on the Livy server node.
     conf.set("spark.yarn.submit.waitAppCompletion", "false");
 
-    if (!conf.getBoolean(CLIENT_IN_PROCESS)) {
+    if (!conf.getBoolean(CLIENT_IN_PROCESS) &&
+        // For tests which doesn't shutdown RscDriver gracefully, JaCoCo exec isn't dumped properly.
+        // Disable JaCoCo for this case.
+        !conf.getBoolean(TEST_STUCK_END_SESSION)) {
       // For testing; propagate jacoco settings so that we also do coverage analysis
       // on the launched driver. We replace the name of the main file ("main.exec")
       // so that we don't end up fighting with the main test launcher.


### PR DESCRIPTION
- Disabled JaCoCo for `InteractiveIT.should kill RSCDriver if it doesn't respond to end session`. This test doesn't shutdown RSCDriver's JVM gracefully. JaCoCo might generate a corrupted exec dump and cause EOFException.