### PR TITLE
LIVY-232. Remove Max Spark version cap in LivyServer

### DIFF
--- a/client-http/src/test/scala/com/cloudera/livy/client/http/HttpClientSpec.scala
+++ b/client-http/src/test/scala/com/cloudera/livy/client/http/HttpClientSpec.scala
@@ -89,7 +89,7 @@ class HttpClientSpec extends FunSpecLike with BeforeAndAfterAll with LivyBaseUni
   describe("HTTP client library") {
 
     it("should create clients") {
-      // WebServer does this internally instad of respecting "0.0.0.0", so try to use the same
+      // WebServer does this internally instead of respecting "0.0.0.0", so try to use the same
       // address.
       val uri = s"http://${InetAddress.getLocalHost.getHostAddress}:${server.port}/"
       client = new LivyClientBuilder(false).setURI(new URI(uri)).build()

--- a/server/src/test/scala/com/cloudera/livy/utils/LivySparkUtilsSuite.scala
+++ b/server/src/test/scala/com/cloudera/livy/utils/LivySparkUtilsSuite.scala
@@ -65,10 +65,6 @@ class LivySparkUtilsSuite extends FunSuite with Matchers with LivyBaseUnitTestSu
     intercept[IllegalArgumentException] { testSparkVersion("1.5.0") }
     intercept[IllegalArgumentException] { testSparkVersion("1.5.1") }
     intercept[IllegalArgumentException] { testSparkVersion("1.5.2") }
-
-    intercept[IllegalArgumentException] { testSparkVersion("2.1.0") }
-    intercept[IllegalArgumentException] { testSparkVersion("2.1.2") }
-    intercept[IllegalArgumentException] { testSparkVersion("2.2.1") }
   }
 
   test("should fail on bad version") {


### PR DESCRIPTION
With this change, if Spark version detected from `spark-submit` is greater than the specified one, Livy will log warning instead of throwing the exception. Also change the Scala version check with the same way.