### PR TITLE
LIVY-240. Aggressively clean the obsolete session metadata

### DIFF
--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
@@ -346,10 +346,8 @@ class InteractiveSession(
   private val operationCounter = new AtomicLong(0)
   private var rscDriverUri: Option[URI] = None
   private var sessionLog: IndexedSeq[String] = IndexedSeq.empty
-  private val sessionSaveLock = new Object()
 
   _appId = appIdHint
-  sessionStore.save(RECOVERY_SESSION_TYPE, recoveryMetadata)
 
   private val app = mockApp.orElse {
     if (livyConf.isRunningOnYarn()) {
@@ -381,9 +379,7 @@ class InteractiveSession(
 
       override def onJobSucceeded(job: JobHandle[Void], result: Void): Unit = {
         rscDriverUri = Option(client.get.getServerUri.get())
-        sessionSaveLock.synchronized {
-          sessionStore.save(RECOVERY_SESSION_TYPE, recoveryMetadata)
-        }
+        sessionStore.save(RECOVERY_SESSION_TYPE, recoveryMetadata)
         transition(SessionState.Idle())
       }
 
@@ -553,9 +549,6 @@ class InteractiveSession(
 
   override def appIdKnown(appId: String): Unit = {
     _appId = Option(appId)
-    sessionSaveLock.synchronized {
-      sessionStore.save(RECOVERY_SESSION_TYPE, recoveryMetadata)
-    }
   }
 
   override def stateChanged(oldState: SparkApp.State, newState: SparkApp.State): Unit = {

--- a/server/src/main/scala/com/cloudera/livy/sessions/Session.scala
+++ b/server/src/main/scala/com/cloudera/livy/sessions/Session.scala
@@ -152,12 +152,7 @@ abstract class Session(val id: Int, val owner: String, val livyConf: LivyConf)
 
   var appInfo: AppInfo = AppInfo()
 
-  def lastActivity: Long = state match {
-    case SessionState.Error(time) => time
-    case SessionState.Dead(time) => time
-    case SessionState.Success(time) => time
-    case _ => _lastActivity
-  }
+  def lastActivity: Long = _lastActivity
 
   def logLines(): IndexedSeq[String]
 

--- a/server/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
+++ b/server/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
@@ -131,9 +131,13 @@ class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
       case SessionState.Dead(_) => true
       case SessionState.Error(_) => true
       case SessionState.Success(_) => true
-      case _ =>
-        val currentTime = System.nanoTime()
-        currentTime - session.lastActivity > math.max(sessionTimeout, session.timeout)
+      case _  =>
+        if (session.isInstanceOf[InteractiveSession]) {
+          val currentTime = System.nanoTime()
+          currentTime - session.lastActivity > math.max(sessionTimeout, session.timeout)
+        } else {
+          false
+        }
     }
 
     Future.sequence(all().filter(expired).map(delete))

--- a/server/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
+++ b/server/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
@@ -131,12 +131,12 @@ class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
       case SessionState.Dead(_) => true
       case SessionState.Error(_) => true
       case SessionState.Success(_) => true
-      case _  =>
-        if (session.isInstanceOf[InteractiveSession]) {
+      case _ =>
+        if (session.isInstanceOf[BatchSession]) {
+          false
+        } else {
           val currentTime = System.nanoTime()
           currentTime - session.lastActivity > math.max(sessionTimeout, session.timeout)
-        } else {
-          false
         }
     }
 

--- a/server/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
+++ b/server/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
@@ -127,9 +127,13 @@ class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
   }
 
   def collectGarbage(): Future[Iterable[Unit]] = {
-    def expired(session: Session): Boolean = {
-      val currentTime = System.nanoTime()
-      currentTime - session.lastActivity > math.max(sessionTimeout, session.timeout)
+    def expired(session: Session): Boolean = session.state match {
+      case SessionState.Dead(_) => true
+      case SessionState.Error(_) => true
+      case SessionState.Success(_) => true
+      case _ =>
+        val currentTime = System.nanoTime()
+        currentTime - session.lastActivity > math.max(sessionTimeout, session.timeout)
     }
 
     Future.sequence(all().filter(expired).map(delete))

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionSpec.scala
@@ -94,7 +94,7 @@ class InteractiveSessionSpec extends FunSpec
       session.state should (be(a[SessionState.Starting]) or be(a[SessionState.Idle]))
     }
 
-    it("should update appId and appInfo and session store") {
+    it("should update appId and appInfo") {
       val mockApp = mock[SparkApp]
       val sessionStore = mock[SessionStore]
       val session = createSession(sessionStore, Some(mockApp))
@@ -106,9 +106,6 @@ class InteractiveSessionSpec extends FunSpec
       val expectedAppInfo = AppInfo(Some("DRIVER LOG URL"), Some("SPARK UI URL"))
       session.infoChanged(expectedAppInfo)
       session.appInfo shouldEqual expectedAppInfo
-
-      verify(sessionStore, atLeastOnce()).save(
-        MockitoMatchers.eq(InteractiveSession.RECOVERY_SESSION_TYPE), anyObject())
     }
 
     withSession("should execute `1 + 2` == 3") { session =>
@@ -165,10 +162,6 @@ class InteractiveSessionSpec extends FunSpec
       val s = InteractiveSession.recover(m, conf, sessionStore, None, Some(mockClient))
 
       s.state shouldBe a[SessionState.Recovering]
-
-      s.appIdKnown("appId")
-      verify(sessionStore, atLeastOnce()).save(
-        MockitoMatchers.eq(InteractiveSession.RECOVERY_SESSION_TYPE), anyObject())
     }
 
     it("should recover session to dead state if rscDriverUri is unknown") {

--- a/server/src/test/scala/com/cloudera/livy/sessions/MockSession.scala
+++ b/server/src/test/scala/com/cloudera/livy/sessions/MockSession.scala
@@ -23,13 +23,19 @@ import com.cloudera.livy.LivyConf
 class MockSession(id: Int, owner: String, conf: LivyConf) extends Session(id, owner, conf) {
   case class RecoveryMetadata(id: Int) extends Session.RecoveryMetadata()
 
+  private var _state: SessionState = SessionState.Idle()
+
   override val proxyUser = None
 
   override protected def stopSession(): Unit = ()
 
   override def logLines(): IndexedSeq[String] = IndexedSeq()
 
-  override def state: SessionState = SessionState.Idle()
+  override def state: SessionState = _state
+
+  def setState(s: SessionState): Unit = {
+    _state = s
+  }
 
   override val timeout: Long = 0L
 


### PR DESCRIPTION
Current `SessionManager` will only clean the session in a timely triggered GC mechanism, and the default timeout is 1hr, which means the session metadata will be in memory for 1hr, this is OK without recovery enabled.

But with session recovery enabled, stored session data will also only be cleaned out after timeout, this will unnecessarily prolong the metadata persisted in the external storage. If Livy server is failed in this time period, though session is already inactive, recovered Livy server will recover and mark as inactive again, and the TTL will again set to 1hr. To the extreme, if Livy server always fails within this time period, the persisted metadata will never get a chance to clean up.

So here propose to aggressively clean the metadata. For those obsolete sessions, no matter the TTL is reached or not, metadata should be cleaned up once gc is triggered .
