### PR TITLE
LIVY-242. Shorten the time to get RSC driver URI

### DIFF
--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
@@ -371,8 +371,6 @@ class InteractiveSession(
   } else {
     val uriFuture = future { client.get.getServerUri.get() }
 
-    info(s"current time: ${System.currentTimeMillis()}")
-
     uriFuture onSuccess { case url =>
       rscDriverUri = Option(url)
       sessionSaveLock.synchronized {
@@ -382,8 +380,6 @@ class InteractiveSession(
     uriFuture onFailure { case e =>
       throw new IllegalStateException("Fail to get rsc uri", e)
     }
-
-    info(s"current time: ${System.currentTimeMillis()}")
 
     // Send a dummy job that will return once the client is ready to be used, and set the
     // state to "idle" at that point.

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
@@ -377,9 +377,7 @@ class InteractiveSession(
         sessionStore.save(RECOVERY_SESSION_TYPE, recoveryMetadata)
       }
     }
-    uriFuture onFailure { case e =>
-      throw new IllegalStateException("Fail to get rsc uri", e)
-    }
+    uriFuture onFailure { case e => warn("Fail to get rsc uri", e) }
 
     // Send a dummy job that will return once the client is ready to be used, and set the
     // state to "idle" at that point.


### PR DESCRIPTION
Currently RSC driver URI is gotten when `PingJob` is finished, which means only when SparkContext and other Spark entry point are fully started and job are finished we could get the RSC driver URI. This unnecessarily prolong the intermediate state of recovery metadata, if LivyServer is failed at this time period, it will never talk the RSC application again.

So we should shorten the time to get RSC driver URI ASAP to mitigate the intermediate state of recovery metadata, that will make session recovery more robust.