### PR TITLE
LIVY-243. ZooKeeperStateStore ignores settings for RetryPolicy

### DIFF
--- a/server/src/main/scala/com/cloudera/livy/server/recovery/ZooKeeperStateStore.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/recovery/ZooKeeperStateStore.scala
@@ -52,7 +52,7 @@ class ZooKeeperStateStore(
   private val retryValue = livyConf.get(ZK_RETRY_CONF)
   // a regex to match patterns like "m, n" where m and n both are integer values
   private val retryPattern = """\s*(\d+)\s*,\s*(\d+)\s*""".r
-  private val retryPolicy = retryValue match {
+  private[recovery] val retryPolicy = retryValue match {
     case retryPattern(n, sleepMs) => new RetryNTimes(n.toInt, sleepMs.toInt)
     case _ => throw new IllegalArgumentException(
       s"$ZK_KEY_PREFIX_CONF contains bad value: $retryValue. " +

--- a/server/src/main/scala/com/cloudera/livy/server/recovery/ZooKeeperStateStore.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/recovery/ZooKeeperStateStore.scala
@@ -19,6 +19,7 @@ package com.cloudera.livy.server.recovery
 
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
+import scala.util.Try
 
 import org.apache.curator.framework.{CuratorFramework, CuratorFrameworkFactory}
 import org.apache.curator.framework.api.UnhandledErrorListener
@@ -48,16 +49,17 @@ class ZooKeeperStateStore(
   private val zkAddress = livyConf.get(LivyConf.RECOVERY_STATE_STORE_URL)
   require(!zkAddress.isEmpty, s"Please config ${LivyConf.RECOVERY_STATE_STORE_URL.key}.")
   private val zkKeyPrefix = livyConf.get(ZK_KEY_PREFIX_CONF)
-  private val curatorClient = mockCuratorClient.getOrElse {
-    val retryValue = livyConf.get(ZK_RETRY_CONF)
-    val retryPattern = """\s*(\d+)\s*,\s*(\d+)\s*""".r
-    val retryPolicy = retryValue match {
-      case retryPattern(n, sleepMs) => new RetryNTimes(5, 100)
-      case _ => throw new IllegalArgumentException(
-        s"$ZK_KEY_PREFIX_CONF contains bad value: $retryValue. " +
-          "Correct format is <max retry count>,<sleep ms between retry>. e.g. 5,100")
-    }
+  private val retryValue = livyConf.get(ZK_RETRY_CONF)
+  // a regex to match patterns like "m, n" where m and n both are integer values
+  private val retryPattern = """\s*(\d+)\s*,\s*(\d+)\s*""".r
+  private val retryPolicy = retryValue match {
+    case retryPattern(n, sleepMs) => new RetryNTimes(n.toInt, sleepMs.toInt)
+    case _ => throw new IllegalArgumentException(
+      s"$ZK_KEY_PREFIX_CONF contains bad value: $retryValue. " +
+        "Correct format is <max retry count>,<sleep ms between retry>. e.g. 5,100")
+  }
 
+  private val curatorClient = mockCuratorClient.getOrElse {
     CuratorFrameworkFactory.newClient(zkAddress, retryPolicy)
   }
 

--- a/server/src/test/scala/com/cloudera/livy/server/recovery/ZooKeeperStateStoreSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/recovery/ZooKeeperStateStoreSpec.scala
@@ -96,6 +96,16 @@ class ZooKeeperStateStoreSpec extends FunSpec with LivyBaseUnitTestSuite {
       }
     }
 
+    it("get should retrieve retry policy configs") {
+      conf.set(com.cloudera.livy.server.recovery.ZooKeeperStateStore.ZK_RETRY_CONF, "11,77")
+        withMock { f =>
+        mockExistsBuilder(f.curatorClient, true)
+
+        f.stateStore.retryPolicy should not be null
+        f.stateStore.retryPolicy.getN shouldBe 11
+      }
+    }
+
     it("get should retrieve data from curatorClient") {
       withMock { f =>
         mockExistsBuilder(f.curatorClient, true)


### PR DESCRIPTION
Use the retry times value the sleep time value specified in the config
to create the retry policy for the curator client.

Also elevates `retryPolicy` from a local val into a field that can be
used in other places in the same class.

Task-url: https://issues.cloudera.org/browse/LIVY-243