### PR TITLE
LIVY-248. Clean up how PySpark python interpreters are set.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,7 +124,6 @@ The configuration files used by Livy are:
 * ``log4j.properties``: configuration for Livy logging. Defines log levels and where log messages
   will be written to. The default configuration will print log messages to stderr.
 
-
 Upgrade from Livy 0.1
 =====================
 
@@ -733,15 +732,37 @@ Session State
 Session Kind
 ^^^^^^^^^^^^
 
-+---------+----------------------------------+
-| value   | description                      |
-+=========+==================================+
-| spark   | Interactive Scala Spark session  |
-+---------+----------------------------------+
-| pyspark | Interactive Python Spark session |
-+---------+----------------------------------+
-| sparkr  | Interactive R Spark session      |
-+---------+----------------------------------+
++-------------+------------------------------------+
+| value       | description                        |
++=============+====================================+
+| spark       | Interactive Scala  Spark session   |
++-------------+------------------------------------+
+| `pyspark`_  | Interactive Python 2 Spark session |
++-------------+------------------------------------+
+| `pyspark3`_ | Interactive Python 3 Spark session |
++-------------+------------------------------------+
+| sparkr      | Interactive R Spark session        |
++-------------+------------------------------------+
+
+pyspark
+^^^^^^^
+To change the Python executable the session uses, Livy reads the path from environment variable
+``PYSPARK_PYTHON`` (Same as pyspark).
+
+Like pyspark, if Livy is running in ``local`` mode, just set the environment variable.
+If the session is running in ``yarn-cluster`` mode, please set
+``spark.yarn.appMasterEnv.PYSPARK_PYTHON`` in SparkConf so the environment variable is passed to
+the driver.
+
+pyspark3
+^^^^^^^^
+To change the Python executable the session uses, Livy reads the path from environment variable
+``PYSPARK3_PYTHON``.
+
+Like pyspark, if Livy is running in ``local`` mode, just set the environment variable.
+If the session is running in ``yarn-cluster`` mode, please set
+``spark.yarn.appMasterEnv.PYSPARK3_PYTHON`` in SparkConf so the environment variable is passed to
+the driver.
 
 Statement
 ---------

--- a/repl/src/main/scala/com/cloudera/livy/repl/PythonInterpreter.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/PythonInterpreter.scala
@@ -47,8 +47,9 @@ object PythonInterpreter extends Logging {
 
   def apply(conf: SparkConf, kind: Kind): Interpreter = {
     val pythonExec = kind match {
-        case PySpark3() => sys.env.getOrElse("PYSPARK3_DRIVER_PYTHON", "python3")
-        case PySpark() => sys.env.getOrElse("PYSPARK_DRIVER_PYTHON", "python")
+        case PySpark() => sys.env.getOrElse("PYSPARK_PYTHON", "python")
+        case PySpark3() => sys.env.getOrElse("PYSPARK3_PYTHON", "python3")
+        case _ => throw new IllegalArgumentException(s"Unknown kind: $kind")
     }
 
     val gatewayServer = new GatewayServer(null, 0)


### PR DESCRIPTION
Also added documentation for pyspark.