### PR TITLE
LIVY-250. Change livy.repl.jars to work with different scala interpreter

### DIFF
--- a/conf/livy.conf
+++ b/conf/livy.conf
@@ -29,9 +29,9 @@
 
 # Comma-separated list of Livy REPL jars. By default Livy will upload jars from its installation
 # directory every time a session is started. By caching these files in HDFS, for example, startup
-# time of sessions on YARN can be reduced. Please list all the repl dependencies including
+# time of sessions on YARN can be reduced. Please list all the repl dependencies include
 # livy-repl_2.10 and livy-repl_2.11 jars, Livy will automatically pick the right dependencies in
-# session creation. Also you could specify with glob path like <LIVY_HOME>/repl_2.11-jars/*.jar
+# session creation.
 # livy.repl.jars =
 
 # Location of PySpark archives. By default Livy will upload the file from SPARK_HOME, but

--- a/conf/livy.conf
+++ b/conf/livy.conf
@@ -29,7 +29,7 @@
 
 # Comma-separated list of Livy REPL jars. By default Livy will upload jars from its installation
 # directory every time a session is started. By caching these files in HDFS, for example, startup
-# time of sessions on YARN can be reduced. Please list all the repl dependencies include
+# time of sessions on YARN can be reduced. Please list all the repl dependencies including
 # livy-repl_2.10 and livy-repl_2.11 jars, Livy will automatically pick the right dependencies in
 # session creation.
 # livy.repl.jars =

--- a/conf/livy.conf
+++ b/conf/livy.conf
@@ -29,9 +29,9 @@
 
 # Comma-separated list of Livy REPL jars. By default Livy will upload jars from its installation
 # directory every time a session is started. By caching these files in HDFS, for example, startup
-# time of sessions on YARN can be reduced. Please list all the repl dependencies include
+# time of sessions on YARN can be reduced. Please list all the repl dependencies including
 # livy-repl_2.10 and livy-repl_2.11 jars, Livy will automatically pick the right dependencies in
-# session creation.
+# session creation. Also you could specify with glob path like <LIVY_HOME>/repl_2.11-jars/*.jar
 # livy.repl.jars =
 
 # Location of PySpark archives. By default Livy will upload the file from SPARK_HOME, but

--- a/conf/livy.conf
+++ b/conf/livy.conf
@@ -29,7 +29,9 @@
 
 # Comma-separated list of Livy REPL jars. By default Livy will upload jars from its installation
 # directory every time a session is started. By caching these files in HDFS, for example, startup
-# time of sessions on YARN can be reduced.
+# time of sessions on YARN can be reduced. Please list all the repl dependencies include
+# livy-repl_2.10 and livy-repl_2.11 jars, Livy will automatically pick the right dependencies in
+# session creation.
 # livy.repl.jars =
 
 # Location of PySpark archives. By default Livy will upload the file from SPARK_HOME, but

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
@@ -155,9 +155,9 @@ object InteractiveSession extends Logging {
       Option(livyConf.get(LIVY_REPL_JARS)).map { jars =>
         val regex = """[\w-]+_(\d\.\d\d).*\.jar""".r
         jars.split(",").filter { name => new Path(name).getName match {
-              // Filter out unmatched scala jars
+            // Filter out unmatched scala jars
             case regex(ver) => ver == scalaVersion
-              // Keep all the java jars end with ".jar"
+            // Keep all the java jars end with ".jar"
             case _ => name.endsWith(".jar")
           }
         }.toList

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
@@ -31,7 +31,7 @@ import scala.util.Random
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.google.common.annotations.VisibleForTesting
-import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.hadoop.fs.Path
 import org.apache.spark.launcher.SparkLauncher
 
 import com.cloudera.livy._
@@ -154,24 +154,13 @@ object InteractiveSession extends Logging {
     def livyJars(livyConf: LivyConf, scalaVersion: String): List[String] = {
       Option(livyConf.get(LIVY_REPL_JARS)).map { jars =>
         val regex = """[\w-]+_(\d\.\d\d).*\.jar""".r
-        jars.split(",").flatMap { n =>
-          val trimmed = n.trim
-          if (!trimmed.startsWith("local")) {
-            // expand the glob path for file and hdfs scheme
-            val path = new Path(toURI(trimmed))
-            val pathFs = FileSystem.get(path.toUri, livyConf.hadoopConf)
-            pathFs.globStatus(path).filter(_.isFile).map(_.getPath)
-          } else {
-            Array(new Path(trimmed))
-          }
-        }.filter { p =>
-          p.getName match {
-            // Filter out unmatched scala jars
+        jars.split(",").filter { name => new Path(name).getName match {
+              // Filter out unmatched scala jars
             case regex(ver) => ver == scalaVersion
-            // Keep all the java jars end with ".jar"
-            case _ => p.getName.endsWith(".jar")
+              // Keep all the java jars end with ".jar"
+            case _ => name.endsWith(".jar")
           }
-        }.map(_.toString).toList
+        }.toList
       }.getOrElse {
         val home = sys.env("LIVY_HOME")
         val jars = Option(new File(home, s"repl_$scalaVersion-jars"))

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
@@ -30,6 +30,8 @@ import scala.concurrent.Future
 import scala.util.Random
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.google.common.annotations.VisibleForTesting
+import org.apache.hadoop.fs.Path
 import org.apache.spark.launcher.SparkLauncher
 
 import com.cloudera.livy._
@@ -140,7 +142,8 @@ object InteractiveSession extends Logging {
       mockApp)
   }
 
-  private def prepareBuilderProp(
+  @VisibleForTesting
+  private[interactive] def prepareBuilderProp(
     conf: Map[String, String],
     kind: Kind,
     livyConf: LivyConf): mutable.Map[String, String] = {
@@ -149,7 +152,16 @@ object InteractiveSession extends Logging {
     builderProperties ++= conf
 
     def livyJars(livyConf: LivyConf, scalaVersion: String): List[String] = {
-      Option(livyConf.get(LIVY_REPL_JARS)).map(_.split(",").toList).getOrElse {
+      Option(livyConf.get(LIVY_REPL_JARS)).map { jars =>
+        val regex = """[\w-]+_(\d\.\d\d).*\.jar""".r
+        jars.split(",").filter { name => new Path(name).getName match {
+              // Filter out unmatched scala jars
+            case regex(ver) => ver == scalaVersion
+              // Keep all the java jars end with ".jar"
+            case _ => name.endsWith(".jar")
+          }
+        }.toList
+      }.getOrElse {
         val home = sys.env("LIVY_HOME")
         val jars = Option(new File(home, s"repl_$scalaVersion-jars"))
           .filter(_.isDirectory())

--- a/server/src/main/scala/com/cloudera/livy/sessions/Session.scala
+++ b/server/src/main/scala/com/cloudera/livy/sessions/Session.scala
@@ -18,7 +18,7 @@
 
 package com.cloudera.livy.sessions
 
-import java.io.{File, InputStream}
+import java.io.InputStream
 import java.net.{URI, URISyntaxException}
 import java.security.PrivilegedExceptionAction
 import java.util.UUID
@@ -130,31 +130,6 @@ object Session {
     }
 
     resolved
-  }
-
-  /**
-   * Return a well-formed URI for the file described by a user input string.
-   *
-   * If the supplied path does not contain a scheme, or is a relative path, it will be
-   * converted into an absolute path with a file:// scheme.
-   */
-  def toURI(path: String): URI = {
-    try {
-      val uri = new URI(path)
-      if (uri.getScheme != null) {
-        return uri
-      }
-      // make sure to handle if the path has a fragment (applies to yarn
-      // distributed cache)
-      if (uri.getFragment != null) {
-        val absoluteURI = new File(uri.getPath).getAbsoluteFile.toURI
-        return new URI(absoluteURI.getScheme, absoluteURI.getHost, absoluteURI.getPath,
-          uri.getFragment)
-      }
-    } catch {
-      case e: URISyntaxException =>
-    }
-    new File(path).getAbsoluteFile.toURI
   }
 }
 

--- a/server/src/main/scala/com/cloudera/livy/sessions/Session.scala
+++ b/server/src/main/scala/com/cloudera/livy/sessions/Session.scala
@@ -18,7 +18,7 @@
 
 package com.cloudera.livy.sessions
 
-import java.io.InputStream
+import java.io.{File, InputStream}
 import java.net.{URI, URISyntaxException}
 import java.security.PrivilegedExceptionAction
 import java.util.UUID
@@ -130,6 +130,31 @@ object Session {
     }
 
     resolved
+  }
+
+  /**
+   * Return a well-formed URI for the file described by a user input string.
+   *
+   * If the supplied path does not contain a scheme, or is a relative path, it will be
+   * converted into an absolute path with a file:// scheme.
+   */
+  def toURI(path: String): URI = {
+    try {
+      val uri = new URI(path)
+      if (uri.getScheme != null) {
+        return uri
+      }
+      // make sure to handle if the path has a fragment (applies to yarn
+      // distributed cache)
+      if (uri.getFragment != null) {
+        val absoluteURI = new File(uri.getPath).getAbsoluteFile.toURI
+        return new URI(absoluteURI.getScheme, absoluteURI.getHost, absoluteURI.getPath,
+          uri.getFragment)
+      }
+    } catch {
+      case e: URISyntaxException =>
+    }
+    new File(path).getAbsoluteFile.toURI
   }
 }
 

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/BaseInteractiveServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/BaseInteractiveServletSpec.scala
@@ -50,7 +50,7 @@ abstract class BaseInteractiveServletSpec
     }
     super.createConf()
       .set(LivyConf.SESSION_STAGING_DIR, tempDir.toURI().toString())
-      .set(InteractiveSession.LIVY_REPL_JARS, "")
+      .set(InteractiveSession.LIVY_REPL_JARS, "dummy.jar")
       .set(LivyConf.LIVY_SPARK_VERSION, "1.6.0")
       .set(LivyConf.LIVY_SPARK_SCALA_VERSION, "2.10.5")
   }

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/BaseInteractiveServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/BaseInteractiveServletSpec.scala
@@ -19,7 +19,7 @@
 package com.cloudera.livy.server.interactive
 
 import java.io.File
-import java.nio.file.{Files, Paths}
+import java.nio.file.Files
 
 import org.apache.commons.io.FileUtils
 import org.apache.spark.launcher.SparkLauncher
@@ -48,11 +48,9 @@ abstract class BaseInteractiveServletSpec
     if (tempDir == null) {
       tempDir = Files.createTempDirectory("client-test").toFile()
     }
-    val dummyJar =
-      Files.createTempFile(Paths.get(sys.props("java.io.tmpdir")), "dummy", "jar").toFile
     super.createConf()
       .set(LivyConf.SESSION_STAGING_DIR, tempDir.toURI().toString())
-      .set(InteractiveSession.LIVY_REPL_JARS, dummyJar.getAbsolutePath)
+      .set(InteractiveSession.LIVY_REPL_JARS, "dummy.jar")
       .set(LivyConf.LIVY_SPARK_VERSION, "1.6.0")
       .set(LivyConf.LIVY_SPARK_SCALA_VERSION, "2.10.5")
   }

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/BaseInteractiveServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/BaseInteractiveServletSpec.scala
@@ -19,7 +19,7 @@
 package com.cloudera.livy.server.interactive
 
 import java.io.File
-import java.nio.file.Files
+import java.nio.file.{Files, Paths}
 
 import org.apache.commons.io.FileUtils
 import org.apache.spark.launcher.SparkLauncher
@@ -48,9 +48,11 @@ abstract class BaseInteractiveServletSpec
     if (tempDir == null) {
       tempDir = Files.createTempDirectory("client-test").toFile()
     }
+    val dummyJar =
+      Files.createTempFile(Paths.get(sys.props("java.io.tmpdir")), "dummy", "jar").toFile
     super.createConf()
       .set(LivyConf.SESSION_STAGING_DIR, tempDir.toURI().toString())
-      .set(InteractiveSession.LIVY_REPL_JARS, "dummy.jar")
+      .set(InteractiveSession.LIVY_REPL_JARS, dummyJar.getAbsolutePath)
       .set(LivyConf.LIVY_SPARK_VERSION, "1.6.0")
       .set(LivyConf.LIVY_SPARK_SCALA_VERSION, "2.10.5")
   }

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionSpec.scala
@@ -18,7 +18,9 @@
 
 package com.cloudera.livy.server.interactive
 
+import java.io.File
 import java.net.URI
+import java.nio.file.{Files, Paths}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -44,8 +46,9 @@ import com.cloudera.livy.utils.{AppInfo, SparkApp}
 class InteractiveSessionSpec extends FunSpec
     with Matchers with BeforeAndAfterAll with LivyBaseUnitTestSuite {
 
+  val dummyJar = Files.createTempFile(Paths.get(sys.props("java.io.tmpdir")), "dummy", "jar")
   private val livyConf = new LivyConf()
-  livyConf.set(InteractiveSession.LIVY_REPL_JARS, "dummy.jar")
+  livyConf.set(InteractiveSession.LIVY_REPL_JARS, dummyJar.toFile.getAbsolutePath)
     .set(LivyConf.LIVY_SPARK_VERSION, "1.6.0")
     .set(LivyConf.LIVY_SPARK_SCALA_VERSION, "2.10.5")
 
@@ -102,30 +105,58 @@ class InteractiveSessionSpec extends FunSpec
   describe("A spark session") {
 
     it("should get scala version matched jars with livy.repl.jars") {
+      val tmpDir = Files.createTempDirectory(Paths.get(sys.props("java.io.tmpdir")), "test").toFile
+
       val testedJars = Seq(
-        "test_2.10-0.1.jar",
-        "local://dummy-path/test/test1_2.10-1.0.jar",
-        "file:///dummy-path/test/test2_2.11-1.0-SNAPSHOT.jar",
-        "hdfs:///dummy-path/test/test3.jar",
-        "non-jar",
-        "dummy.jar"
-      )
+        "test_2.10.jar",
+        "test1_2.10-1.0.jar",
+        "test2_2.11-1.0-SNAPSHOT.jar",
+        "test3.jar",
+        "non-jar")
+      testedJars.foreach(n => new File(tmpDir, n).createNewFile())
+
+      // Test glob path
       val livyConf = new LivyConf(false)
-        .set(InteractiveSession.LIVY_REPL_JARS, testedJars.mkString(","))
+        .set(InteractiveSession.LIVY_REPL_JARS, tmpDir.getAbsolutePath + "/*")
         .set(LivyConf.LIVY_SPARK_VERSION, "1.6.2")
         .set(LivyConf.LIVY_SPARK_SCALA_VERSION, "2.10")
       val properties = InteractiveSession.prepareBuilderProp(Map.empty, Spark(), livyConf)
-      assert(properties(LivyConf.SPARK_JARS).split(",").toSet === Set("test_2.10-0.1.jar",
-        "local://dummy-path/test/test1_2.10-1.0.jar",
-        "hdfs:///dummy-path/test/test3.jar",
-        "dummy.jar"))
+      assert(properties(LivyConf.SPARK_JARS).split(",").toSet ===
+        Set(
+          "test_2.10.jar",
+          "test1_2.10-1.0.jar",
+          "test3.jar").map(new File(tmpDir, _).getAbsoluteFile.toURI.toString))
 
+      // Test 2.11
       livyConf.set(LivyConf.LIVY_SPARK_SCALA_VERSION, "2.11")
       val properties1 = InteractiveSession.prepareBuilderProp(Map.empty, Spark(), livyConf)
-      assert(properties1(LivyConf.SPARK_JARS).split(",").toSet === Set(
-        "file:///dummy-path/test/test2_2.11-1.0-SNAPSHOT.jar",
-        "hdfs:///dummy-path/test/test3.jar",
-        "dummy.jar"))
+      assert(properties1(LivyConf.SPARK_JARS).split(",").toSet ===
+        Set(
+          "test2_2.11-1.0-SNAPSHOT.jar",
+          "test3.jar").map(new File(tmpDir, _).getAbsoluteFile.toURI.toString))
+
+      // Test local scheme
+      val localJars = testedJars.map(new File(tmpDir, _).getAbsoluteFile.toURI).map { i =>
+        new URI("local", i.getHost, i.getPath, i.getFragment)
+      }
+      livyConf.set(InteractiveSession.LIVY_REPL_JARS, localJars.map(_.toString).mkString(","))
+        .set(LivyConf.LIVY_SPARK_SCALA_VERSION, "2.10")
+      val properties2 = InteractiveSession.prepareBuilderProp(Map.empty, Spark(), livyConf)
+      assert(properties2(LivyConf.SPARK_JARS).split(",").toSet ===
+        Set(
+          s"local:${tmpDir.getAbsolutePath}/test_2.10.jar",
+          s"local:${tmpDir.getAbsolutePath}/test1_2.10-1.0.jar",
+          s"local:${tmpDir.getAbsolutePath}/test3.jar"))
+
+      // Test without Scheme
+      livyConf.set(InteractiveSession.LIVY_REPL_JARS,
+        testedJars.map(new File(tmpDir, _).getAbsolutePath).mkString(","))
+      val properties3 = InteractiveSession.prepareBuilderProp(Map.empty, Spark(), livyConf)
+      assert(properties3(LivyConf.SPARK_JARS).split(",").toSet ===
+        Set(
+          "test_2.10.jar",
+          "test1_2.10-1.0.jar",
+          "test3.jar").map(new File(tmpDir, _).getAbsoluteFile.toURI.toString))
     }
 
     it("should start in the idle state") {


### PR DESCRIPTION
Current `livy.repl.jars` cannot automatically pick jars according to different scala interpreter. So here propose one way to address this issue. 

User could list all the dependencies to `livy.repl.jars`, including `livy-repl_2.10` and `livy-repl_2.11`, Livy automatically pick the right jars according to Spark's scala version and scala jar convention.

\cc @tc0312 .