### PR TITLE
LIVY-260. repl is stuck in busy state if Scala interpreter returns some specific error.

### DIFF
--- a/repl/scala-2.10/src/test/scala/com/cloudera/livy/repl/SparkInterpreterSpec.scala
+++ b/repl/scala-2.10/src/test/scala/com/cloudera/livy/repl/SparkInterpreterSpec.scala
@@ -1,0 +1,87 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.repl
+
+import org.scalatest._
+
+import com.cloudera.livy.LivyBaseUnitTestSuite
+
+class SparkInterpreterSpec extends FunSpec with Matchers with LivyBaseUnitTestSuite {
+  describe("SparkInterpreter") {
+    val interpreter = new SparkInterpreter(null)
+
+    it("should parse Scala compile error.") {
+      // Regression test for LIVY-.
+      val error =
+        """<console>:27: error: type mismatch;
+          | found   : Int
+          | required: String
+          |       sc.setJobGroup(groupName, groupName, true)
+          |                      ^
+          |<console>:27: error: type mismatch;
+          | found   : Int
+          | required: String
+          |       sc.setJobGroup(groupName, groupName, true)
+          |                                 ^
+          |""".stripMargin
+
+      val expectedTraceback = AbstractSparkInterpreter.KEEP_NEWLINE_REGEX.split(
+        """ found   : Int
+          | required: String
+          |       sc.setJobGroup(groupName, groupName, true)
+          |                      ^
+          |<console>:27: error: type mismatch;
+          | found   : Int
+          | required: String
+          |       sc.setJobGroup(groupName, groupName, true)
+          |                                 ^
+          |""".stripMargin)
+
+      val (ename, traceback) = interpreter.parseError(error)
+      ename shouldBe "<console>:27: error: type mismatch;"
+      traceback shouldBe expectedTraceback
+    }
+
+    it("should parse Scala runtime error and remove internal frames.") {
+      val error =
+        """java.lang.RuntimeException: message
+          |        at $iwC$$iwC$$iwC$$iwC$$iwC.error(<console>:25)
+          |        at $iwC$$iwC$$iwC.error2(<console>:27)
+          |        at $iwC$$iwC.<init>(<console>:41)
+          |        at $iwC.<init>(<console>:43)
+          |        at <init>(<console>:45)
+          |        at .<init>(<console>:49)
+          |        at .<clinit>(<console>)
+          |        at .<init>(<console>:7)
+          |        at .<clinit>(<console>)
+          |        at $print(<console>)
+          |        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+          |""".stripMargin
+
+      val expectedTraceback = AbstractSparkInterpreter.KEEP_NEWLINE_REGEX.split(
+        """        at <user code>.error(<console>:25)
+          |        at <user code>.error2(<console>:27)
+          |""".stripMargin)
+
+      val (ename, traceback) = interpreter.parseError(error)
+      ename shouldBe "java.lang.RuntimeException: message"
+      traceback shouldBe expectedTraceback
+    }
+  }
+}

--- a/repl/scala-2.10/src/test/scala/com/cloudera/livy/repl/SparkInterpreterSpec.scala
+++ b/repl/scala-2.10/src/test/scala/com/cloudera/livy/repl/SparkInterpreterSpec.scala
@@ -27,7 +27,7 @@ class SparkInterpreterSpec extends FunSpec with Matchers with LivyBaseUnitTestSu
     val interpreter = new SparkInterpreter(null)
 
     it("should parse Scala compile error.") {
-      // Regression test for LIVY-.
+      // Regression test for LIVY-260.
       val error =
         """<console>:27: error: type mismatch;
           | found   : Int

--- a/repl/scala-2.11/src/test/scala/com/cloudera/livy/repl/SparkInterpreterSpec.scala
+++ b/repl/scala-2.11/src/test/scala/com/cloudera/livy/repl/SparkInterpreterSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.repl
+
+import org.scalatest._
+
+import com.cloudera.livy.LivyBaseUnitTestSuite
+
+class SparkInterpreterSpec extends FunSpec with Matchers with LivyBaseUnitTestSuite {
+  describe("SparkInterpreter") {
+    val interpreter = new SparkInterpreter(null)
+
+    it("should parse Scala compile error.") {
+      // Regression test for LIVY-.
+      val error =
+        """<console>:27: error: type mismatch;
+          | found   : Int
+          | required: String
+          |       sc.setJobGroup(groupName, groupName, true)
+          |                      ^
+          |<console>:27: error: type mismatch;
+          | found   : Int
+          | required: String
+          |       sc.setJobGroup(groupName, groupName, true)
+          |                                 ^
+          |""".stripMargin
+
+      val parsedError = AbstractSparkInterpreter.KEEP_NEWLINE_REGEX.split(error)
+
+      val expectedTraceback = parsedError.tail
+
+      val (ename, traceback) = interpreter.parseError(error)
+      ename shouldBe "<console>:27: error: type mismatch;"
+      traceback shouldBe expectedTraceback
+    }
+
+    it("should parse Scala runtime error.") {
+      val error =
+        """java.lang.RuntimeException: message
+          |    ... 48 elided
+          |
+          |Tailing message""".stripMargin
+
+      val parsedError = AbstractSparkInterpreter.KEEP_NEWLINE_REGEX.split(error)
+
+      val expectedTraceback = parsedError.tail
+
+      val (ename, traceback) = interpreter.parseError(error)
+      ename shouldBe "java.lang.RuntimeException: message"
+      traceback shouldBe expectedTraceback
+    }
+  }
+}

--- a/repl/src/main/scala/com/cloudera/livy/repl/AbstractSparkInterpreter.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/AbstractSparkInterpreter.scala
@@ -31,10 +31,8 @@ import org.json4s.JsonDSL._
 import com.cloudera.livy.Logging
 
 object AbstractSparkInterpreter {
-  private val EXCEPTION_STACK_TRACE_REGEX = """(.+?)\n((?:[  |\t].+?\n?)*)""".r
-  private val KEEP_NEWLINE_REGEX = """(?=\n)""".r
+  private[repl] val KEEP_NEWLINE_REGEX = """(?<=\n)""".r
   private val MAGIC_REGEX = "^%(\\w+)\\W*(.*)".r
-  val USER_CODE_FRAME_NAME = "<user code>"
 }
 
 abstract class AbstractSparkInterpreter extends Interpreter with Logging {
@@ -225,28 +223,31 @@ abstract class AbstractSparkInterpreter extends Interpreter with Logging {
               )
             case Results.Incomplete => Interpreter.ExecuteIncomplete()
             case Results.Error =>
-              def parseStdout(stdout: String): (String, Seq[String]) = {
-                stdout match {
-                  case EXCEPTION_STACK_TRACE_REGEX(ename, tracebackLines) =>
-                    var traceback = KEEP_NEWLINE_REGEX.pattern.split(tracebackLines)
-                    val interpreterFrameIdx = traceback.indexWhere(_.contains("$iwC$$iwC.<init>"))
-                    if (interpreterFrameIdx >= 0) {
-                      traceback = traceback
-                        // Remove Interpreter frames
-                        .take(interpreterFrameIdx)
-                        // Replace weird internal class name
-                        .map(_.replaceAll("(\\$iwC\\$)*\\$iwC", "<user code>"))
-                      // TODO Proper translate line number in stack trace for $iwC$$iwC.
-                    }
-                    (ename.trim, traceback)
-                  case _ => (stdout, Seq.empty)
-                }
-              }
-              val (ename, traceback) = parseStdout(readStdout())
+              val (ename, traceback) = parseError(readStdout())
               Interpreter.ExecuteError("Error", ename, traceback)
           }
         }
     }
+  }
+
+  protected[repl] def parseError(stdout: String): (String, Seq[String]) = {
+    // An example of Scala compile error message:
+    // <console>:27: error: type mismatch;
+    //  found   : Int
+    //  required: Boolean
+
+    // An example of Scala runtime exception error message:
+    // java.lang.RuntimeException: message
+    //   at .error(<console>:11)
+    //   ... 32 elided
+
+    // Return the first line as ename. Lines following as traceback.
+
+    val lines = KEEP_NEWLINE_REGEX.split(stdout)
+    val ename = lines.headOption.map(_.trim).getOrElse("unknown error")
+    val traceback = lines.tail
+
+    (ename, traceback)
   }
 
   protected def restoreContextClassLoader[T](fn: => T): T = {


### PR DESCRIPTION
- Instead of using regex, parse for internal frames manually.
- Repl in Scala 2.11 cleans internal frames internally. Skip internal frames cleaning.