### PR TITLE
LIVY-265. spark.matser can not be overridden

### DIFF
--- a/server/src/main/scala/com/cloudera/livy/sessions/Session.scala
+++ b/server/src/main/scala/com/cloudera/livy/sessions/Session.scala
@@ -92,7 +92,7 @@ object Session {
     val masterConfList = Map(LivyConf.SPARK_MASTER -> livyConf.sparkMaster()) ++
       livyConf.sparkDeployMode().map(LivyConf.SPARK_DEPLOY_MODE -> _).toMap
 
-    conf ++ masterConfList ++ merged
+    masterConfList ++ conf ++ merged
   }
 
   /**


### PR DESCRIPTION
Straightforward change to allow spark.master to be overridden when it is excluded in blacklist. 