### PR TITLE
LIVY-165. Added session heartbeat to help notebooks to prevent leakage.

### DIFF
--- a/integration-test/src/main/scala/com/cloudera/livy/test/framework/LivyRestClient.scala
+++ b/integration-test/src/main/scala/com/cloudera/livy/test/framework/LivyRestClient.scala
@@ -220,10 +220,14 @@ class LivyRestClient(val httpClient: AsyncHttpClient, val livyEndpoint: String) 
     new BatchSession(id)
   }
 
-  def startSession(kind: Kind, sparkConf: Map[String, String]): InteractiveSession = {
+  def startSession(
+      kind: Kind,
+      sparkConf: Map[String, String],
+      heartbeatTimeoutInSecond: Int): InteractiveSession = {
     val r = new CreateInteractiveRequest()
     r.kind = kind
     r.conf = sparkConf
+    r.heartbeatTimeoutInSecond = heartbeatTimeoutInSecond
 
     val id = start(INTERACTIVE_TYPE, mapper.writeValueAsString(r))
     new InteractiveSession(id)

--- a/integration-test/src/main/scala/com/cloudera/livy/test/framework/MiniCluster.scala
+++ b/integration-test/src/main/scala/com/cloudera/livy/test/framework/MiniCluster.scala
@@ -157,6 +157,7 @@ object MiniLivyMain extends MiniClusterBase {
       LivyConf.LIVY_SPARK_MASTER.key -> "yarn",
       LivyConf.LIVY_SPARK_DEPLOY_MODE.key -> "cluster",
       LivyConf.LIVY_SPARK_SCALA_VERSION.key -> getSparkScalaVersion(),
+      LivyConf.HEARTBEAT_WATCHDOG_INTERVAL.key -> "1s",
       LivyConf.YARN_POLL_INTERVAL.key -> "500ms",
       LivyConf.RECOVERY_MODE.key -> "recovery",
       LivyConf.RECOVERY_STATE_STORE.key -> "filesystem",

--- a/integration-test/src/test/scala/com/cloudera/livy/test/InteractiveIT.scala
+++ b/integration-test/src/test/scala/com/cloudera/livy/test/InteractiveIT.scala
@@ -148,6 +148,17 @@ class InteractiveIT extends BaseIntegrationTestSuite {
     }
   }
 
+  test("heartbeat should kill expired session") {
+    // Set it to 2s because verifySessionIdle() is calling GET every second.
+    val heartbeatTimeout = Duration.create("2s")
+    withNewSession(Spark(), Map.empty, true, heartbeatTimeout.toSeconds.toInt) { s =>
+      // If the test reaches here, that means verifySessionIdle() is successfully keeping the
+      // session alive. Now verify heartbeat is killing expired session.
+      Thread.sleep(heartbeatTimeout.toMillis * 2)
+      s.verifySessionDoesNotExist()
+    }
+  }
+
   test("recover interactive session") {
     withNewSession(Spark()) { s =>
       val stmt1 = s.run("1")
@@ -179,10 +190,13 @@ class InteractiveIT extends BaseIntegrationTestSuite {
     }
   }
 
-  private def withNewSession[R]
-    (kind: Kind, sparkConf: Map[String, String] = Map.empty, waitForIdle: Boolean = true)
+  private def withNewSession[R] (
+      kind: Kind,
+      sparkConf: Map[String, String] = Map.empty,
+      waitForIdle: Boolean = true,
+      heartbeatTimeoutInSecond: Int = 0)
     (f: (LivyRestClient#InteractiveSession) => R): R = {
-    withSession(livyClient.startSession(kind, sparkConf)) { s =>
+    withSession(livyClient.startSession(kind, sparkConf, heartbeatTimeoutInSecond)) { s =>
       if (waitForIdle) {
         s.verifySessionIdle()
       }

--- a/server/src/main/scala/com/cloudera/livy/LivyConf.scala
+++ b/server/src/main/scala/com/cloudera/livy/LivyConf.scala
@@ -71,6 +71,8 @@ object LivyConf {
   val AUTH_KERBEROS_KEYTAB = Entry("livy.server.auth.kerberos.keytab", null)
   val AUTH_KERBEROS_NAME_RULES = Entry("livy.server.auth.kerberos.name_rules", "DEFAULT")
 
+  val HEARTBEAT_WATCHDOG_INTERVAL = Entry("livy.server.heartbeat-watchdog.interval", "1m")
+
   val LAUNCH_KERBEROS_PRINCIPAL =
     LivyConf.Entry("livy.server.launch.kerberos.principal", null)
   val LAUNCH_KERBEROS_KEYTAB =

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/CreateInteractiveRequest.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/CreateInteractiveRequest.scala
@@ -21,7 +21,6 @@ package com.cloudera.livy.server.interactive
 import com.cloudera.livy.sessions.{Kind, Spark}
 
 class CreateInteractiveRequest {
-
   var kind: Kind = Spark()
   var proxyUser: Option[String] = None
   var jars: List[String] = List()
@@ -36,5 +35,5 @@ class CreateInteractiveRequest {
   var queue: Option[String] = None
   var name: Option[String] = None
   var conf: Map[String, String] = Map()
-
+  var heartbeatTimeoutInSecond: Int = 0
 }

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSessionServlet.scala
@@ -44,6 +44,7 @@ class InteractiveSessionServlet(
     sessionStore: SessionStore,
     livyConf: LivyConf)
   extends SessionServlet(sessionManager, livyConf)
+  with SessionHeartbeatNotifier[InteractiveSession, InteractiveRecoveryMetadata]
   with FileUploadSupport
 {
 

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/SessionHeartbeat.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/SessionHeartbeat.scala
@@ -1,0 +1,114 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cloudera.livy.server.interactive
+
+import java.util.Date
+
+import scala.concurrent.duration.{Deadline, Duration, FiniteDuration}
+
+import com.cloudera.livy.sessions.Session.RecoveryMetadata
+import com.cloudera.livy.LivyConf
+import com.cloudera.livy.server.SessionServlet
+import com.cloudera.livy.sessions.{Session, SessionManager}
+
+/**
+  * A session trait to provide heartbeat expiration check.
+  * Note: Session will not expire if heartbeat() was never called.
+  */
+trait SessionHeartbeat {
+  protected val heartbeatTimeout: FiniteDuration
+
+  private var _lastHeartbeat: Date = _ // For reporting purpose
+  private var heartbeatDeadline: Option[Deadline] = None
+
+  def heartbeat(): Unit = synchronized {
+    if (heartbeatTimeout > Duration.Zero) {
+      heartbeatDeadline = Some(heartbeatTimeout.fromNow)
+    }
+
+    _lastHeartbeat = new Date()
+  }
+
+  def lastHeartbeat: Date = synchronized { _lastHeartbeat }
+
+  def heartbeatExpired: Boolean = synchronized { heartbeatDeadline.exists(_.isOverdue()) }
+}
+
+/**
+  * Servlet can mixin this trait to update session's heartbeat
+  * whenever a /sessions/:id REST call is made. e.g. GET /sessions/:id
+  * Note: GET /sessions doesn't update heartbeats.
+  */
+trait SessionHeartbeatNotifier[S <: Session with SessionHeartbeat, R <: RecoveryMetadata]
+  extends SessionServlet[S, R] {
+
+  abstract override protected def withUnprotectedSession(fn: (S => Any)): Any = {
+    super.withUnprotectedSession { s =>
+      s.heartbeat()
+      fn(s)
+    }
+  }
+
+  abstract override protected def withSession(fn: (S => Any)): Any = {
+    super.withSession { s =>
+      s.heartbeat()
+      fn(s)
+    }
+  }
+}
+
+/**
+  * A SessionManager trait.
+  * It will create a thread that periodically deletes sessions with expired heartbeat.
+  */
+trait SessionHeartbeatWatchdog[S <: Session with SessionHeartbeat, R <: RecoveryMetadata] {
+  self: SessionManager[S, R] =>
+
+  private val watchdogThread = new Thread(s"HeartbeatWatchdog-${self.getClass.getName}") {
+    override def run(): Unit = {
+      val interval = livyConf.getTimeAsMs(LivyConf.HEARTBEAT_WATCHDOG_INTERVAL)
+      info("Heartbeat watchdog thread started.")
+      while (true) {
+        deleteExpiredSessions()
+        Thread.sleep(interval)
+      }
+    }
+  }
+
+  protected def start(): Unit = {
+    assert(!watchdogThread.isAlive())
+
+    watchdogThread.setDaemon(true)
+    watchdogThread.start()
+  }
+
+  private[interactive] def deleteExpiredSessions(): Unit = {
+    // Delete takes time. If we use .filter().foreach() here, the time difference between we check
+    // expiration and the time we delete the session might be huge. To avoid that, check expiration
+    // inside the foreach block.
+    sessions.values.foreach { s =>
+      if (s.heartbeatExpired) {
+        info(s"Session ${s.id} expired. Last heartbeat is at ${s.lastHeartbeat}.")
+        try { delete(s) } catch {
+          case t: Throwable =>
+            warn(s"Exception was thrown when deleting expired session ${s.id}", t)
+        }
+      }
+    }
+  }
+}

--- a/server/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
+++ b/server/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
@@ -29,7 +29,7 @@ import scala.util.control.NonFatal
 
 import com.cloudera.livy.{LivyConf, Logging}
 import com.cloudera.livy.server.batch.{BatchRecoveryMetadata, BatchSession}
-import com.cloudera.livy.server.interactive.{InteractiveRecoveryMetadata, InteractiveSession}
+import com.cloudera.livy.server.interactive.{InteractiveRecoveryMetadata, InteractiveSession, SessionHeartbeatWatchdog}
 import com.cloudera.livy.server.recovery.SessionStore
 import com.cloudera.livy.sessions.Session.RecoveryMetadata
 
@@ -56,9 +56,13 @@ class InteractiveSessionManager(
     sessionStore,
     "interactive",
     mockSessions)
+  with SessionHeartbeatWatchdog[InteractiveSession, InteractiveRecoveryMetadata]
+  {
+    start()
+  }
 
 class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
-    livyConf: LivyConf,
+    protected val livyConf: LivyConf,
     sessionRecovery: R => S,
     sessionStore: SessionStore,
     sessionType: String,

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionSpec.scala
@@ -196,7 +196,8 @@ class InteractiveSessionSpec extends FunSpec
       val mockClient = mock[RSCClient]
       when(mockClient.submit(any(classOf[PingJob]))).thenReturn(mock[JobHandle[Void]])
       val m =
-        InteractiveRecoveryMetadata(78, None, "appTag", Spark(), null, None, Some(URI.create("")))
+        InteractiveRecoveryMetadata(
+          78, None, "appTag", Spark(), 0, null, None, Some(URI.create("")))
       val s = InteractiveSession.recover(m, conf, sessionStore, None, Some(mockClient))
 
       s.state shouldBe a[SessionState.Recovering]
@@ -209,7 +210,8 @@ class InteractiveSessionSpec extends FunSpec
     it("should recover session to dead state if rscDriverUri is unknown") {
       val conf = new LivyConf()
       val sessionStore = mock[SessionStore]
-      val m = InteractiveRecoveryMetadata(78, Some("appId"), "appTag", Spark(), null, None, None)
+      val m = InteractiveRecoveryMetadata(
+        78, Some("appId"), "appTag", Spark(), 0, null, None, None)
       val s = InteractiveSession.recover(m, conf, sessionStore, None)
 
       s.state shouldBe a[SessionState.Dead]

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/SessionHeartbeatSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/SessionHeartbeatSpec.scala
@@ -1,0 +1,88 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.server.interactive
+
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+import org.mockito.Mockito.{never, verify, when}
+import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.concurrent.Eventually._
+import org.scalatest.mock.MockitoSugar.mock
+
+import com.cloudera.livy.LivyConf
+import com.cloudera.livy.server.recovery.SessionStore
+import com.cloudera.livy.sessions.{Session, SessionManager}
+import com.cloudera.livy.sessions.Session.RecoveryMetadata
+
+class SessionHeartbeatSpec extends FunSpec with Matchers {
+  describe("SessionHeartbeat") {
+    class TestHeartbeat(override val heartbeatTimeout: FiniteDuration) extends SessionHeartbeat {}
+
+    it("should not expire if heartbeat was never called.") {
+      val t = new TestHeartbeat(Duration.Zero)
+      t.heartbeatExpired shouldBe false
+    }
+
+    it("should expire if time has elapsed.") {
+      val t = new TestHeartbeat(Duration.fromNanos(1))
+      t.heartbeat()
+      eventually(timeout(2 nano), interval(1 nano)) {
+        t.heartbeatExpired shouldBe true
+      }
+    }
+
+    it("should not expire if time hasn't elapsed.") {
+      val t = new TestHeartbeat(Duration.create(1, DAYS))
+      t.heartbeat()
+      t.heartbeatExpired shouldBe false
+    }
+  }
+
+  describe("SessionHeartbeatWatchdog") {
+    abstract class TestSession extends Session(0, null, null) with SessionHeartbeat {}
+    class TestWatchdog(conf: LivyConf)
+      extends SessionManager[TestSession, RecoveryMetadata](
+        conf,
+        { _ => assert(false).asInstanceOf[TestSession] },
+        mock[SessionStore],
+        "test",
+        Some(Seq.empty))
+        with SessionHeartbeatWatchdog[TestSession, RecoveryMetadata] {}
+
+    it("should delete only expired sessions") {
+      val expiredSession: TestSession = mock[TestSession]
+      when(expiredSession.id).thenReturn(0)
+      when(expiredSession.heartbeatExpired).thenReturn(true)
+
+      val nonExpiredSession: TestSession = mock[TestSession]
+      when(nonExpiredSession.id).thenReturn(1)
+      when(nonExpiredSession.heartbeatExpired).thenReturn(false)
+
+      val n = new TestWatchdog(new LivyConf())
+
+      n.register(expiredSession)
+      n.register(nonExpiredSession)
+      n.deleteExpiredSessions()
+
+      verify(expiredSession).stop()
+      verify(nonExpiredSession, never).stop()
+    }
+  }
+}


### PR DESCRIPTION
Notebook applications like Jupyter might crash while livy is running. No one will clean up its corresponding Livy session and will be leaked.
Heartbeat is added to address this. To keep a session alive, the notebook application must continously make GET requests to the interactive session. If no GET request is made within the heartbeat interval, livy-server will delete the session regardless to its state (busy, idle).

Heartbeat is per session and is controlled by session property "heartbeatTimeoutInSecond". Its default is 0 and it means heartbeat is disabled. To enable heartbeat, please create the session with non-zero "heartbeatTimeoutInSecond" in the create request.