### PR TITLE
LIVY-270. %table shouldn't treat None as its own type.

### DIFF
--- a/repl/src/main/resources/fake_shell.py
+++ b/repl/src/main/resources/fake_shell.py
@@ -426,11 +426,14 @@ def magic_table(name):
                 }
                 headers[name] = header
             else:
-                # Reject columns that have a different type.
-                if header['type'] != col_type:
-                    exc_type = Exception
-                    exc_value = 'table rows have different types'
-                    return execute_reply_error(exc_type, exc_value, None)
+                # Reject columns that have a different type. (allow none value)
+                if col_type is not "NULL_TYPE" and header['type'] != col_type:
+                    if header['type'] is "NULL_TYPE":
+                        header['type'] = col_type
+                    else:
+                        exc_type = Exception
+                        exc_value = 'table rows have different types'
+                        return execute_reply_error(exc_type, exc_value, None)
 
             cols.append(col)
 

--- a/repl/src/test/scala/com/cloudera/livy/repl/PythonInterpreterSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/PythonInterpreterSpec.scala
@@ -142,6 +142,26 @@ abstract class PythonBaseInterpreterSpec extends BaseInterpreterSpec {
     ))
   }
 
+  it should "do table magic with None type Row" in withInterpreter { interpreter =>
+    val response = interpreter.execute(
+      """x = [{"a":None, "b":None}, {"a":"2", "b":2}]
+        |%table x
+      """.stripMargin)
+
+    response should equal(Interpreter.ExecuteSuccess(
+      APPLICATION_LIVY_TABLE_JSON -> (
+        ("headers" -> List(
+          ("type" -> "STRING_TYPE") ~ ("name" -> "a"),
+          ("type" -> "INT_TYPE") ~ ("name" -> "b")
+        )) ~
+          ("data" -> List(
+            List[JValue](JNull, JNull),
+            List[JValue]("2", 2)
+          ))
+        )
+    ))
+  }
+
   it should "allow magic inside statements" in withInterpreter { interpreter =>
     val response = interpreter.execute(
       """x = [[1, 'a'], [3, 'b']]

--- a/repl/src/test/scala/com/cloudera/livy/repl/PythonInterpreterSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/PythonInterpreterSpec.scala
@@ -19,7 +19,7 @@
 package com.cloudera.livy.repl
 
 import org.apache.spark.SparkConf
-import org.json4s.{DefaultFormats, JValue}
+import org.json4s.{DefaultFormats, JValue, JNull}
 import org.json4s.JsonDSL._
 import org.scalatest._
 
@@ -117,6 +117,26 @@ abstract class PythonBaseInterpreterSpec extends BaseInterpreterSpec {
           ("data" -> List(
             List[JValue](1, "a"),
             List[JValue](3, "b")
+          ))
+        )
+    ))
+  }
+
+  it should "do table magic with None type value" in withInterpreter { interpreter =>
+    val response = interpreter.execute(
+      """x = [{"a":"1", "b":None}, {"a":"2", "b":2}]
+        |%table x
+      """.stripMargin)
+
+    response should equal(Interpreter.ExecuteSuccess(
+      APPLICATION_LIVY_TABLE_JSON -> (
+        ("headers" -> List(
+          ("type" -> "STRING_TYPE") ~ ("name" -> "a"),
+          ("type" -> "INT_TYPE") ~ ("name" -> "b")
+        )) ~
+          ("data" -> List(
+            List[JValue]("1", JNull),
+            List[JValue]("2", 2)
           ))
         )
     ))


### PR DESCRIPTION
```
x = [{"name":"a", "value":None}, {"name":"b", "value":2}]
%table x
```
return error `table rows have different types`
if input value is list, tuple. dict type, need to be allow None value.
