### PR TITLE
LIVY-271. Fixed repl session to return traceback as a JSON list in error cases.

### DIFF
--- a/repl/src/main/scala/com/cloudera/livy/repl/Session.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/Session.scala
@@ -132,7 +132,8 @@ class Session(interpreter: Interpreter, stateChangedCallback: SessionState => Un
           (STATUS -> ERROR) ~
           (EXECUTION_COUNT -> executionCount) ~
           (ENAME -> "Error") ~
-          (EVALUE -> "incomplete statement")
+          (EVALUE -> "incomplete statement") ~
+          (TRACEBACK -> Seq.empty[String])
 
         case Interpreter.ExecuteError(ename, evalue, traceback) =>
           transitToIdle()
@@ -149,7 +150,8 @@ class Session(interpreter: Interpreter, stateChangedCallback: SessionState => Un
           (STATUS -> ERROR) ~
           (EXECUTION_COUNT -> executionCount) ~
           (ENAME -> "Error") ~
-          (EVALUE -> f"Interpreter died:\n$message")
+          (EVALUE -> f"Interpreter died:\n$message") ~
+          (TRACEBACK -> Seq.empty[String])
       }
     } catch {
       case e: Throwable =>
@@ -160,7 +162,8 @@ class Session(interpreter: Interpreter, stateChangedCallback: SessionState => Un
         (STATUS -> ERROR) ~
         (EXECUTION_COUNT -> executionCount) ~
         (ENAME -> f"Internal Error: ${e.getClass.getName}") ~
-        (EVALUE -> e.getMessage)
+        (EVALUE -> e.getMessage) ~
+        (TRACEBACK -> Seq.empty[String])
     }
 
     compact(render(resultInJson))

--- a/repl/src/main/scala/com/cloudera/livy/repl/Session.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/Session.scala
@@ -132,8 +132,7 @@ class Session(interpreter: Interpreter, stateChangedCallback: SessionState => Un
           (STATUS -> ERROR) ~
           (EXECUTION_COUNT -> executionCount) ~
           (ENAME -> "Error") ~
-          (EVALUE -> "incomplete statement") ~
-          (TRACEBACK -> List())
+          (EVALUE -> "incomplete statement")
 
         case Interpreter.ExecuteError(ename, evalue, traceback) =>
           transitToIdle()
@@ -150,8 +149,7 @@ class Session(interpreter: Interpreter, stateChangedCallback: SessionState => Un
           (STATUS -> ERROR) ~
           (EXECUTION_COUNT -> executionCount) ~
           (ENAME -> "Error") ~
-          (EVALUE -> f"Interpreter died:\n$message") ~
-          (TRACEBACK -> List())
+          (EVALUE -> f"Interpreter died:\n$message")
       }
     } catch {
       case e: Throwable =>
@@ -162,8 +160,7 @@ class Session(interpreter: Interpreter, stateChangedCallback: SessionState => Un
         (STATUS -> ERROR) ~
         (EXECUTION_COUNT -> executionCount) ~
         (ENAME -> f"Internal Error: ${e.getClass.getName}") ~
-        (EVALUE -> e.getMessage) ~
-        (TRACEBACK -> List())
+        (EVALUE -> e.getMessage)
     }
 
     compact(render(resultInJson))


### PR DESCRIPTION
traceback could be json list or json object which is misleading. So this PR would not include traceback when it is null. 

Tested manually. 