### PR TITLE
LIVY-267. Honor fixed port number for PRC server

### DIFF
--- a/rsc/src/main/java/com/cloudera/livy/rsc/RSCClientFactory.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/RSCClientFactory.java
@@ -86,7 +86,7 @@ public final class RSCClientFactory implements LivyClientFactory {
     Utils.checkState(server == null, "Server already running but ref count is 0.");
     if (server == null) {
       try {
-        server = new RpcServer(config);
+        server = new RpcServer(config, true);
       } catch (InterruptedException ie) {
         throw Utils.propagate(ie);
       }

--- a/rsc/src/main/java/com/cloudera/livy/rsc/RSCConf.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/RSCConf.java
@@ -60,7 +60,7 @@ public class RSCConf extends ClientConf<RSCConf> {
 
     PROXY_USER("proxy_user", null),
 
-    RPC_SERVER_ADDRESS("rpc.server.address", null),
+    RPC_SERVER_PORT("rpc.server.port", -1),
     RPC_CLIENT_HANDSHAKE_TIMEOUT("server.connect.timeout", "90s"),
     RPC_CLIENT_CONNECT_TIMEOUT("client.connect.timeout", "10s"),
     RPC_CHANNEL_LOG_LEVEL("channel.log.level", null),
@@ -105,7 +105,7 @@ public class RSCConf extends ClientConf<RSCConf> {
     return opts;
   }
 
-  public String findLocalAddress() throws IOException {
+  public String findLocalAddress(boolean isLauncher) throws IOException {
     InetAddress address = InetAddress.getLocalHost();
     if (address.isLoopbackAddress()) {
       // Address resolves to something like 127.0.1.1, which happens on Debian;
@@ -122,8 +122,10 @@ public class RSCConf extends ClientConf<RSCConf> {
             LOG.warn("Your hostname, {}, resolves to a loopback address; using {} "
                 + " instead (on interface {})", address.getHostName(), addr.getHostAddress(),
                 ni.getName());
-            LOG.warn("Set '{}' if you need to bind to another address.",
-              Entry.RPC_SERVER_ADDRESS.key);
+            if (isLauncher) {
+              LOG.warn("Set '{}' if you need to bind to another address.",
+                Entry.LAUNCHER_ADDRESS.key);
+            }
             return addr.getHostAddress();
           }
         }
@@ -132,8 +134,9 @@ public class RSCConf extends ClientConf<RSCConf> {
 
     LOG.warn("Your hostname, {}, resolves to a loopback address, but we couldn't find "
         + "any external IP address!", address.getCanonicalHostName());
-    LOG.warn("Set {} if you need to bind to another address.",
-      Entry.RPC_SERVER_ADDRESS.key);
+    if (isLauncher) {
+      LOG.warn("Set {} if you need to bind to another address.", Entry.LAUNCHER_ADDRESS.key);
+    }
     return address.getCanonicalHostName();
   }
 

--- a/rsc/src/main/java/com/cloudera/livy/rsc/RSCConf.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/RSCConf.java
@@ -53,14 +53,14 @@ public class RSCConf extends ClientConf<RSCConf> {
 
     // Address for the RSC driver to connect back with it's connection info.
     LAUNCHER_ADDRESS("launcher.address", null),
-    LAUNCHER_PORT("launcher.port", -1),
+    LAUNCHER_PORT("launcher.port", 0),
 
     // How long will the RSC wait for a connection for a Livy server before shutting itself down.
     SERVER_IDLE_TIMEOUT("server.idle_timeout", "10m"),
 
     PROXY_USER("proxy_user", null),
 
-    RPC_SERVER_PORT("rpc.server.port", -1),
+    RPC_SERVER_PORT("rpc.server.port", 0),
     RPC_CLIENT_HANDSHAKE_TIMEOUT("server.connect.timeout", "90s"),
     RPC_CLIENT_CONNECT_TIMEOUT("client.connect.timeout", "10s"),
     RPC_CHANNEL_LOG_LEVEL("channel.log.level", null),
@@ -105,7 +105,7 @@ public class RSCConf extends ClientConf<RSCConf> {
     return opts;
   }
 
-  public String findLocalAddress(boolean isLauncher) throws IOException {
+  public String findLocalAddress() throws IOException {
     InetAddress address = InetAddress.getLocalHost();
     if (address.isLoopbackAddress()) {
       // Address resolves to something like 127.0.1.1, which happens on Debian;
@@ -122,10 +122,6 @@ public class RSCConf extends ClientConf<RSCConf> {
             LOG.warn("Your hostname, {}, resolves to a loopback address; using {} "
                 + " instead (on interface {})", address.getHostName(), addr.getHostAddress(),
                 ni.getName());
-            if (isLauncher) {
-              LOG.warn("Set '{}' if you need to bind to another address.",
-                Entry.LAUNCHER_ADDRESS.key);
-            }
             return addr.getHostAddress();
           }
         }
@@ -134,9 +130,6 @@ public class RSCConf extends ClientConf<RSCConf> {
 
     LOG.warn("Your hostname, {}, resolves to a loopback address, but we couldn't find "
         + "any external IP address!", address.getCanonicalHostName());
-    if (isLauncher) {
-      LOG.warn("Set {} if you need to bind to another address.", Entry.LAUNCHER_ADDRESS.key);
-    }
     return address.getCanonicalHostName();
   }
 

--- a/rsc/src/main/java/com/cloudera/livy/rsc/driver/RSCDriver.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/driver/RSCDriver.java
@@ -172,7 +172,7 @@ public class RSCDriver extends BaseProtocol {
 
     // Bring up the RpcServer an register the secret provided by the Livy server as a client.
     LOG.info("Starting RPC server...");
-    this.server = new RpcServer(livyConf, false);
+    this.server = new RpcServer(livyConf, null, livyConf.getInt(RPC_SERVER_PORT));
     server.registerClient(clientId, secret, new RpcServer.ClientCallback() {
       @Override
       public RpcDispatcher onNewClient(Rpc client) {

--- a/rsc/src/main/java/com/cloudera/livy/rsc/driver/RSCDriver.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/driver/RSCDriver.java
@@ -172,7 +172,7 @@ public class RSCDriver extends BaseProtocol {
 
     // Bring up the RpcServer an register the secret provided by the Livy server as a client.
     LOG.info("Starting RPC server...");
-    this.server = new RpcServer(livyConf, null, livyConf.getInt(RPC_SERVER_PORT));
+    this.server = new RpcServer(livyConf, livyConf.getInt(RPC_SERVER_PORT));
     server.registerClient(clientId, secret, new RpcServer.ClientCallback() {
       @Override
       public RpcDispatcher onNewClient(Rpc client) {

--- a/rsc/src/main/java/com/cloudera/livy/rsc/driver/RSCDriver.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/driver/RSCDriver.java
@@ -157,12 +157,6 @@ public class RSCDriver extends BaseProtocol {
 
     LOG.info("Connecting to: {}:{}", launcherAddress, launcherPort);
 
-    // We need to unset this configuration since it doesn't really apply for the driver side.
-    // If the driver runs on a multi-homed machine, this can lead to issues where the Livy
-    // server cannot connect to the auto-detected address, but since the driver can run anywhere
-    // on the cluster, it would be tricky to solve that problem in a generic way.
-    livyConf.set(RPC_SERVER_ADDRESS, null);
-
     if (livyConf.getBoolean(TEST_STUCK_START_DRIVER)) {
       // Test flag is turned on so we will just infinite loop here. It should cause
       // timeout and we should still see yarn application being cleaned up.
@@ -178,7 +172,7 @@ public class RSCDriver extends BaseProtocol {
 
     // Bring up the RpcServer an register the secret provided by the Livy server as a client.
     LOG.info("Starting RPC server...");
-    this.server = new RpcServer(livyConf);
+    this.server = new RpcServer(livyConf, false);
     server.registerClient(clientId, secret, new RpcServer.ClientCallback() {
       @Override
       public RpcDispatcher onNewClient(Rpc client) {

--- a/rsc/src/main/java/com/cloudera/livy/rsc/rpc/RpcServer.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/rpc/RpcServer.java
@@ -34,6 +34,7 @@ import javax.security.sasl.Sasl;
 import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
@@ -67,11 +68,35 @@ public class RpcServer implements Closeable {
   private final ConcurrentMap<String, ClientInfo> pendingClients;
   private final RSCConf config;
 
-  public RpcServer(RSCConf lconf) throws IOException, InterruptedException {
+  @VisibleForTesting
+  RpcServer(RSCConf lconf) throws IOException, InterruptedException {
+    this(lconf, false);
+  }
+
+  public RpcServer(RSCConf lconf, boolean isLauncher) throws IOException, InterruptedException {
     this.config = lconf;
     this.group = new NioEventLoopGroup(
         this.config.getInt(RPC_MAX_THREADS),
         Utils.newDaemonThreadFactory("RPC-Handler-%d"));
+
+    final InetSocketAddress socketAddress;
+    if (isLauncher) {
+      if (lconf.get(LAUNCHER_ADDRESS) != null && lconf.getInt(LAUNCHER_PORT) > 0) {
+        socketAddress =
+          new InetSocketAddress(lconf.get(LAUNCHER_ADDRESS), lconf.getInt(LAUNCHER_PORT));
+      } else if (lconf.getInt(LAUNCHER_PORT) > 0) {
+        socketAddress = new InetSocketAddress(lconf.getInt(LAUNCHER_PORT));
+      } else {
+        socketAddress = new InetSocketAddress(0);
+      }
+    } else {
+      if (lconf.getInt(RPC_SERVER_PORT) > 0) {
+        socketAddress = new InetSocketAddress(lconf.getInt(RPC_SERVER_PORT));
+      } else {
+        socketAddress = new InetSocketAddress(0);
+      }
+    }
+
     this.channel = new ServerBootstrap()
       .group(group)
       .channel(NioServerSocketChannel.class)
@@ -97,15 +122,15 @@ public class RpcServer implements Closeable {
       .option(ChannelOption.SO_BACKLOG, 1)
       .option(ChannelOption.SO_REUSEADDR, true)
       .childOption(ChannelOption.SO_KEEPALIVE, true)
-      .bind(0)
+      .bind(socketAddress)
       .sync()
       .channel();
     this.port = ((InetSocketAddress) channel.localAddress()).getPort();
     this.pendingClients = new ConcurrentHashMap<>();
 
-    String address = config.get(RPC_SERVER_ADDRESS);
+    String address = isLauncher ? config.get(LAUNCHER_ADDRESS) : null;
     if (address == null) {
-      address = config.findLocalAddress();
+      address = config.findLocalAddress(isLauncher);
     }
     this.address = address;
   }

--- a/rsc/src/main/java/com/cloudera/livy/rsc/rpc/RpcServer.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/rpc/RpcServer.java
@@ -70,7 +70,11 @@ public class RpcServer implements Closeable {
 
   @VisibleForTesting
   RpcServer(RSCConf lconf) throws IOException, InterruptedException {
-    this(lconf, null, 0);
+    this(lconf, 0);
+  }
+
+  public RpcServer(RSCConf lconf, int port) throws IOException, InterruptedException {
+    this(lconf, null, port);
   }
 
   public RpcServer(RSCConf lconf, String address, int port)

--- a/server/src/main/scala/com/cloudera/livy/LivyConf.scala
+++ b/server/src/main/scala/com/cloudera/livy/LivyConf.scala
@@ -109,6 +109,10 @@ object LivyConf {
   // How often Livy polls YARN to refresh YARN app state.
   val YARN_POLL_INTERVAL = Entry("livy.server.yarn.poll-interval", "5s")
 
+  // Address and port configurations for RSC callback server
+  val LAUNCHER_ADDRESS = Entry("livy.launcher_server.address", null)
+  val LAUNCHER_PORT = Entry("livy.launcher_server.port", 0)
+
   val SPARK_MASTER = "spark.master"
   val SPARK_DEPLOY_MODE = "spark.submit.deployMode"
   val SPARK_JARS = "spark.jars"

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
@@ -306,6 +306,13 @@ object InteractiveSession extends Logging {
     }
     builderProperties.put(RSCConf.Entry.SESSION_KIND.key, kind.toString)
 
+    // Set livy callback server address and port configurations to RSCConf if configured.
+    Option(livyConf.get(LivyConf.LAUNCHER_ADDRESS)).foreach(
+      builderProperties.put(RSCConf.Entry.LAUNCHER_ADDRESS.key, _)
+    )
+    builderProperties.put(RSCConf.Entry.LAUNCHER_PORT.key,
+      livyConf.getInt(LivyConf.LAUNCHER_PORT).toString)
+
     require(livyConf.get(LivyConf.LIVY_SPARK_VERSION) != null)
     require(livyConf.get(LivyConf.LIVY_SPARK_SCALA_VERSION) != null)
 


### PR DESCRIPTION
Current RPC server doesn't honor port number settings, it will pick a random port number, which will lead to some issues as described in [LIVY-267](https://issues.cloudera.org/projects/LIVY/issues/LIVY-267?filter=allopenissues). So here propose to fix it:

1. Separate configurations for two RPC server, one is launcher, another is rsc driver's rpc server.
2. Remove `livy.rsc.rpc.server.address` since current it sets null deliberately, so removing it for simplicity.
3. Add `livy.rsc.rpc.server.port` configuration to fix the port number of rsc driver RPC server.

