### PR TITLE
Minor. Fix flaky test for interactive session state

### DIFF
--- a/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionSpec.scala
@@ -177,7 +177,9 @@ class InteractiveSessionSpec extends FunSpec
       ))
 
       result should equal (expectedResult)
-      session.state shouldBe a[SessionState.Idle]
+      eventually(timeout(10 seconds), interval(30 millis)) {
+        session.state shouldBe a[SessionState.Idle]
+      }
     }
 
     withSession("should error out the session if the interpreter dies") { session =>


### PR DESCRIPTION
due to the latency of session state update, we may get `Busy` instead of `Idle`, please see [here](https://travis-ci.org/cloudera/livy/jobs/184456364). So here using `eventually` to fix it.