### PR TITLE
LIVY-279. Bump supported Spark version to 2.1.x

### DIFF
--- a/server/src/main/scala/com/cloudera/livy/utils/LivySparkUtils.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/LivySparkUtils.scala
@@ -32,6 +32,8 @@ object LivySparkUtils extends Logging {
   // For each Spark version we supported, we need to add this mapping relation in case Scala
   // version cannot be detected from "spark-submit --version".
   private val _defaultSparkScalaVersion = SortedMap(
+    // Spark 2.1 + Scala 2.11
+    (2, 1) -> "2.11",
     // Spark 2.0 + Scala 2.11
     (2, 0) -> "2.11",
     // Spark 1.6 + Scala 2.10
@@ -40,7 +42,7 @@ object LivySparkUtils extends Logging {
 
   // Supported Spark version
   private val MIN_VERSION = (1, 6)
-  private val MAX_VERSION = (2, 1)
+  private val MAX_VERSION = (2, 2)
 
   private val sparkVersionRegex = """version (.*)""".r.unanchored
   private val scalaVersionRegex = """Scala version (.*), Java""".r.unanchored

--- a/server/src/test/scala/com/cloudera/livy/utils/LivySparkUtilsSuite.scala
+++ b/server/src/test/scala/com/cloudera/livy/utils/LivySparkUtilsSuite.scala
@@ -58,9 +58,11 @@ class LivySparkUtilsSuite extends FunSuite with Matchers with LivyBaseUnitTestSu
     testSparkVersion("2.0.2")
     testSparkVersion("2.0.0.2.5.1.0-56") // LIVY-229
     testSparkVersion("2.0")
+    testSparkVersion("2.1.0")
+    testSparkVersion("2.1.1")
   }
 
-  test("should not support Spark older than 1.6 or newer than 2.0") {
+  test("should not support Spark older than 1.6") {
     intercept[IllegalArgumentException] { testSparkVersion("1.4.0") }
     intercept[IllegalArgumentException] { testSparkVersion("1.5.0") }
     intercept[IllegalArgumentException] { testSparkVersion("1.5.1") }
@@ -131,5 +133,6 @@ class LivySparkUtilsSuite extends FunSuite with Matchers with LivyBaseUnitTestSu
     sparkScalaVersion(formatSparkVersion("1.6.2"), None, livyConf) shouldBe "2.10"
     sparkScalaVersion(formatSparkVersion("2.0.0"), None, livyConf) shouldBe "2.11"
     sparkScalaVersion(formatSparkVersion("2.0.1"), None, livyConf) shouldBe "2.11"
+    sparkScalaVersion(formatSparkVersion("2.1.0"), None, livyConf) shouldBe "2.11"
   }
 }


### PR DESCRIPTION
Spark 2.1.0 will be released soon, we should also bump the supported version to 2.1.x.