### PR TITLE
LIVY-280. Livy session leakage issue when app submission timeout

### DIFF
--- a/conf/livy.conf
+++ b/conf/livy.conf
@@ -76,9 +76,17 @@
 
 # If Livy can't find the yarn app within this time, consider it lost.
 # livy.server.yarn.app-lookup-timeout = 30s
+# When the cluster is busy, we may fail to launch yarn app in 30s, then it would cause session
+# leakage, so we need to check session leakage.
+# How long to check livy session leakage
+# livy.server.yarn.app-leakage.check_timeout = 600s
+# how often to check livy session leakage
+# livy.server.yarn.app-leakage.check_interval = 60s
 
 # How often Livy polls YARN to refresh YARN app state.
 # livy.server.yarn.poll-interval = 1s
 #
 # Days to keep Livy server request logs.
 # livy.server.request-log-retain.days = 5
+
+

--- a/conf/livy.conf
+++ b/conf/livy.conf
@@ -75,7 +75,7 @@
 # livy.server.recovery.state-store.url =
 
 # If Livy can't find the yarn app within this time, consider it lost.
-# livy.server.yarn.app-lookup-timeout = 30s
+# livy.server.yarn.app-lookup-timeout = 60s
 # When the cluster is busy, we may fail to launch yarn app in 30s, then it would cause session
 # leakage, so we need to check session leakage.
 # How long to check livy session leakage
@@ -88,5 +88,3 @@
 #
 # Days to keep Livy server request logs.
 # livy.server.request-log-retain.days = 5
-
-

--- a/conf/livy.conf
+++ b/conf/livy.conf
@@ -76,8 +76,8 @@
 
 # If Livy can't find the yarn app within this time, consider it lost.
 # livy.server.yarn.app-lookup-timeout = 60s
-# When the cluster is busy, we may fail to launch yarn app in 30s, then it would cause session
-# leakage, so we need to check session leakage.
+# When the cluster is busy, we may fail to launch yarn app in app-lookup-timeout, then it would
+# cause session leakage, so we need to check session leakage.
 # How long to check livy session leakage
 # livy.server.yarn.app-leakage.check_timeout = 600s
 # how often to check livy session leakage

--- a/server/src/main/scala/com/cloudera/livy/LivyConf.scala
+++ b/server/src/main/scala/com/cloudera/livy/LivyConf.scala
@@ -106,18 +106,23 @@ object LivyConf {
   val RECOVERY_STATE_STORE_URL = Entry("livy.server.recovery.state-store.url", "")
 
   // If Livy can't find the yarn app within this time, consider it lost.
-  val YARN_APP_LOOKUP_TIMEOUT = Entry("livy.server.yarn.app-lookup-timeout", "30s")
+  val YARN_APP_LOOKUP_TIMEOUT = Entry("livy.server.yarn.app-lookup-timeout", "60s")
 
   // How often Livy polls YARN to refresh YARN app state.
   val YARN_POLL_INTERVAL = Entry("livy.server.yarn.poll-interval", "5s")
 
   // Days to keep Livy server request logs.
   val REQUEST_LOG_RETAIN_DAYS = Entry("livy.server.request-log-retain.days", 5)
-
+  
   // REPL related jars separated with comma.
   val REPL_JARS = Entry("livy.repl.jars", null)
   // RSC related jars separated with comma.
   val RSC_JARS = Entry("livy.rsc.jars", null)
+
+  // How long to check livy session leakage
+  val YARN_APP_LEAKAGE_CHECK_TIMEOUT = Entry("livy.server.yarn.app-leakage.check_timeout", "600s")
+  // how often to check livy session leakage
+  val YARN_APP_LEAKAGE_CHECK_INTERVAL = Entry("livy.server.yarn.app-leakage.check_interval", "60s")
 
   val SPARK_MASTER = "spark.master"
   val SPARK_DEPLOY_MODE = "spark.submit.deployMode"

--- a/server/src/main/scala/com/cloudera/livy/LivyConf.scala
+++ b/server/src/main/scala/com/cloudera/livy/LivyConf.scala
@@ -113,7 +113,7 @@ object LivyConf {
 
   // Days to keep Livy server request logs.
   val REQUEST_LOG_RETAIN_DAYS = Entry("livy.server.request-log-retain.days", 5)
-  
+
   // REPL related jars separated with comma.
   val REPL_JARS = Entry("livy.repl.jars", null)
   // RSC related jars separated with comma.

--- a/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
@@ -90,6 +90,7 @@ class LivyServer extends Logging {
 
     // Initialize YarnClient ASAP to save time.
     if (livyConf.isRunningOnYarn()) {
+      SparkYarnApp.init(livyConf)
       Future { SparkYarnApp.yarnClient }
     }
 

--- a/server/src/main/scala/com/cloudera/livy/utils/SparkYarnApp.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/SparkYarnApp.scala
@@ -37,6 +37,14 @@ import com.cloudera.livy.{LivyConf, Logging, Utils}
 import com.cloudera.livy.util.LineBufferedProcess
 
 object SparkYarnApp extends Logging {
+
+  def init(livyConf: LivyConf): Unit = {
+    sessionLeakageCheckInterval = livyConf.getTimeAsMs(LivyConf.YARN_APP_LEAKAGE_CHECK_INTERVAL)
+    sessionLeakageCheckTimeout = livyConf.getTimeAsMs(LivyConf.YARN_APP_LEAKAGE_CHECK_TIMEOUT)
+    leakagedAppGCThread.setDaemon(true)
+    leakagedAppGCThread.start()
+  }
+
   // YarnClient is thread safe. Create once, share it across threads.
   lazy val yarnClient = {
     val c = YarnClient.createYarnClient()
@@ -50,6 +58,47 @@ object SparkYarnApp extends Logging {
 
   private def getYarnPollInterval(livyConf: LivyConf): FiniteDuration =
     livyConf.getTimeAsMs(LivyConf.YARN_POLL_INTERVAL) milliseconds
+
+  private val appType = Set("SPARK").asJava
+
+  private val leakagedAppTags = new java.util.concurrent.ConcurrentHashMap[String, Long]()
+
+  private var sessionLeakageCheckTimeout: Long = _
+
+  private var sessionLeakageCheckInterval: Long = _
+
+  private val leakagedAppGCThread = new Thread() {
+    override def run(): Unit = {
+      while (true) {
+        if (!leakagedAppTags.isEmpty) {
+          // kill the app if found it and remove it if exceeding a threashold
+          val iter = leakagedAppTags.entrySet().iterator()
+          var isRemoved = false
+          val now = System.currentTimeMillis()
+          while(iter.hasNext) {
+            val entry = iter.next()
+            yarnClient.getApplications(appType).asScala
+              .find(_.getApplicationTags.contains(entry.getKey))
+              .foreach(e => {
+                info(s"Kill leakage app ${e.getApplicationId}")
+                yarnClient.killApplication(e.getApplicationId)
+                iter.remove()
+                isRemoved = true
+              })
+            if (!isRemoved) {
+              if ((entry.getValue - now) > sessionLeakageCheckTimeout) {
+                iter.remove()
+                info(s"Remove leakage yarn app tag ${entry.getKey}")
+              }
+            }
+          }
+        }
+        Thread.sleep(sessionLeakageCheckInterval)
+      }
+    }
+  }
+
+
 }
 
 /**
@@ -122,13 +171,16 @@ class SparkYarnApp private[utils] (
 
     // FIXME Should not loop thru all YARN applications but YarnClient doesn't offer an API.
     // Consider calling rmClient in YarnClient directly.
-    val appType = Set("SPARK").asJava
     yarnClient.getApplications(appType).asScala.find(_.getApplicationTags.contains(appTagLowerCase))
     match {
       case Some(app) => app.getApplicationId
       case None =>
         if (deadline.isOverdue) {
-          throw new Exception(s"No YARN application is tagged with $appTagLowerCase.")
+          process.foreach(_.destroy())
+          leakagedAppTags.put(appTag, System.currentTimeMillis())
+          throw new Exception(s"No YARN application is found with tag $appTagLowerCase in " +
+            livyConf.getTimeAsMs(LivyConf.YARN_APP_LOOKUP_TIMEOUT)/1000 + " seconds. " +
+            "Please check your cluster status, it is may be very busy.")
         } else {
           Clock.sleep(pollInterval.toMillis)
           getAppIdFromTag(appTagLowerCase, pollInterval, deadline)

--- a/server/src/main/scala/com/cloudera/livy/utils/SparkYarnApp.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/SparkYarnApp.scala
@@ -80,7 +80,7 @@ object SparkYarnApp extends Logging {
           while(iter.hasNext) {
             val entry = iter.next()
             apps.find(_.getApplicationTags.contains(entry.getKey))
-              .foreach(e => {
+              .foreach({ e =>
                 info(s"Kill leaked app ${e.getApplicationId}")
                 yarnClient.killApplication(e.getApplicationId)
                 iter.remove()


### PR DESCRIPTION
* Add a new daemon thread to kill leaked livy session regularly.  
* Change the default look-up timeout to 60s.