### PR TITLE
LIVY-272. Support Statement progress for interactive session

### DIFF
--- a/repl/scala-2.10/src/main/scala/com/cloudera/livy/repl/SparkInterpreter.scala
+++ b/repl/scala-2.10/src/main/scala/com/cloudera/livy/repl/SparkInterpreter.scala
@@ -33,7 +33,8 @@ import org.apache.spark.repl.SparkIMain
 /**
  * This represents a Spark interpreter. It is not thread safe.
  */
-class SparkInterpreter(conf: SparkConf)
+class SparkInterpreter(conf: SparkConf,
+    override val statementProgressListener: StatementProgressListener)
   extends AbstractSparkInterpreter with SparkContextInitializer {
 
   private var sparkIMain: SparkIMain = _
@@ -103,6 +104,7 @@ class SparkInterpreter(conf: SparkConf)
       createSparkContext(conf)
     }
 
+    sparkContext.addSparkListener(statementProgressListener)
     sparkContext
   }
 

--- a/repl/scala-2.10/src/test/scala/com/cloudera/livy/repl/SparkInterpreterSpec.scala
+++ b/repl/scala-2.10/src/test/scala/com/cloudera/livy/repl/SparkInterpreterSpec.scala
@@ -24,7 +24,7 @@ import com.cloudera.livy.LivyBaseUnitTestSuite
 
 class SparkInterpreterSpec extends FunSpec with Matchers with LivyBaseUnitTestSuite {
   describe("SparkInterpreter") {
-    val interpreter = new SparkInterpreter(null)
+    val interpreter = new SparkInterpreter(null, null)
 
     it("should parse Scala compile error.") {
       // Regression test for LIVY-260.

--- a/repl/scala-2.11/src/main/scala/com/cloudera/livy/repl/SparkInterpreter.scala
+++ b/repl/scala-2.11/src/main/scala/com/cloudera/livy/repl/SparkInterpreter.scala
@@ -33,7 +33,8 @@ import org.apache.spark.repl.SparkILoop
 /**
  * Scala 2.11 version of SparkInterpreter
  */
-class SparkInterpreter(conf: SparkConf)
+class SparkInterpreter(conf: SparkConf,
+    override val statementProgressListener: StatementProgressListener)
   extends AbstractSparkInterpreter with SparkContextInitializer {
 
   protected var sparkContext: SparkContext = _
@@ -89,6 +90,7 @@ class SparkInterpreter(conf: SparkConf)
       createSparkContext(conf)
     }
 
+    sparkContext.addSparkListener(statementProgressListener)
     sparkContext
   }
 

--- a/repl/scala-2.11/src/test/scala/com/cloudera/livy/repl/SparkInterpreterSpec.scala
+++ b/repl/scala-2.11/src/test/scala/com/cloudera/livy/repl/SparkInterpreterSpec.scala
@@ -24,7 +24,7 @@ import com.cloudera.livy.LivyBaseUnitTestSuite
 
 class SparkInterpreterSpec extends FunSpec with Matchers with LivyBaseUnitTestSuite {
   describe("SparkInterpreter") {
-    val interpreter = new SparkInterpreter(null)
+    val interpreter = new SparkInterpreter(null, null)
 
     it("should parse Scala compile error.") {
       // Regression test for LIVY-.

--- a/repl/src/main/scala/com/cloudera/livy/repl/AbstractSparkInterpreter.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/AbstractSparkInterpreter.scala
@@ -50,12 +50,13 @@ abstract class AbstractSparkInterpreter extends Interpreter with Logging {
 
   protected def valueOfTerm(name: String): Option[Any]
 
-  override def execute(code: String): Interpreter.ExecuteResponse = restoreContextClassLoader {
-    require(isStarted())
+  override protected[repl] def execute(code: String): Interpreter.ExecuteResponse =
+    restoreContextClassLoader {
+      require(isStarted())
 
-    executeLines(code.trim.split("\n").toList, Interpreter.ExecuteSuccess(JObject(
-      (TEXT_PLAIN, JString(""))
-    )))
+      executeLines(code.trim.split("\n").toList, Interpreter.ExecuteSuccess(JObject(
+        (TEXT_PLAIN, JString(""))
+      )))
   }
 
   private def executeMagic(magic: String, rest: String): Interpreter.ExecuteResponse = {

--- a/repl/src/main/scala/com/cloudera/livy/repl/Interpreter.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/Interpreter.scala
@@ -37,18 +37,28 @@ trait Interpreter {
 
   def kind: String
 
+  def statementProgressListener: StatementProgressListener
+
   /**
    * Start the Interpreter.
    *
-   * @return A SparkContext, which may be null.
+   * @return A SparkContext
    */
   def start(): SparkContext
 
   /**
-   * Execute the code and return the result as a Future as it may
+   * Execute the code and return the result.
+   */
+  def execute(statementId: Int, code: String): ExecuteResponse = {
+    statementProgressListener.setCurrentStatementId(statementId)
+    execute(code)
+  }
+
+  /**
+   * Execute the code and return the result, it may
    * take some time to execute.
    */
-  def execute(code: String): ExecuteResponse
+  protected[repl] def execute(code: String): ExecuteResponse
 
   /** Shut down the interpreter. */
   def close(): Unit

--- a/repl/src/main/scala/com/cloudera/livy/repl/PythonInterpreter.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/PythonInterpreter.scala
@@ -45,7 +45,7 @@ import com.cloudera.livy.sessions._
 // scalastyle:off println
 object PythonInterpreter extends Logging {
 
-  def apply(conf: SparkConf, kind: Kind): Interpreter = {
+  def apply(conf: SparkConf, kind: Kind, listener: StatementProgressListener): Interpreter = {
     val pythonExec = kind match {
         case PySpark() => sys.env.getOrElse("PYSPARK_PYTHON", "python")
         case PySpark3() => sys.env.getOrElse("PYSPARK3_PYTHON", "python3")
@@ -72,7 +72,7 @@ object PythonInterpreter extends Logging {
     env.put("LIVY_SPARK_MAJOR_VERSION", conf.get("spark.livy.spark_major_version", "1"))
     builder.redirectError(Redirect.PIPE)
     val process = builder.start()
-    new PythonInterpreter(process, gatewayServer, kind.toString)
+    new PythonInterpreter(process, gatewayServer, kind.toString, listener)
   }
 
   private def findPySparkArchives(): Seq[String] = {
@@ -187,8 +187,12 @@ object PythonInterpreter extends Logging {
   }
 }
 
-private class PythonInterpreter(process: Process, gatewayServer: GatewayServer, pyKind: String)
-  extends ProcessInterpreter(process)
+private class PythonInterpreter(
+    process: Process,
+    gatewayServer: GatewayServer,
+    pyKind: String,
+    listener: StatementProgressListener)
+  extends ProcessInterpreter(process, listener)
   with Logging
 {
   implicit val formats = DefaultFormats

--- a/repl/src/main/scala/com/cloudera/livy/repl/Session.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/Session.scala
@@ -116,6 +116,7 @@ class Session(
 
       statement.compareAndTransit(StatementState.Running, StatementState.Available)
       statement.compareAndTransit(StatementState.Cancelling, StatementState.Cancelled)
+      statement.updateProgress(1.0)
     }(interpreterExecutor)
 
     statementId
@@ -187,7 +188,7 @@ class Session(
     }
 
     val resultInJson = try {
-      interpreter.execute(code) match {
+      interpreter.execute(executionCount, code) match {
         case Interpreter.ExecuteSuccess(data) =>
           transitToIdle()
 

--- a/repl/src/main/scala/com/cloudera/livy/repl/SparkRInterpreter.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/SparkRInterpreter.scala
@@ -35,6 +35,7 @@ import org.json4s._
 import org.json4s.JsonDSL._
 
 import com.cloudera.livy.client.common.ClientConf
+import com.cloudera.livy.rsc.RSCConf
 
 // scalastyle:off println
 object SparkRInterpreter {
@@ -64,7 +65,7 @@ object SparkRInterpreter {
     ")"
     ).r.unanchored
 
-  def apply(conf: SparkConf): SparkRInterpreter = {
+  def apply(conf: SparkConf, listener: StatementProgressListener): SparkRInterpreter = {
     val backendTimeout = sys.env.getOrElse("SPARKR_BACKEND_TIMEOUT", "120").toInt
     val mirror = universe.runtimeMirror(getClass.getClassLoader)
     val sparkRBackendClass = mirror.classLoader.loadClass("org.apache.spark.api.r.RBackend")
@@ -117,7 +118,8 @@ object SparkRInterpreter {
       val process = builder.start()
       new SparkRInterpreter(process, backendInstance, backendThread,
         conf.get("spark.livy.spark_major_version", "1"),
-        conf.getBoolean("spark.repl.enableHiveContext", false))
+        conf.getBoolean("spark.repl.enableHiveContext", false),
+        listener)
     } catch {
       case e: Exception =>
         if (backendThread != null) {
@@ -132,15 +134,16 @@ class SparkRInterpreter(process: Process,
     backendInstance: Any,
     backendThread: Thread,
     val sparkMajorVersion: String,
-    hiveEnabled: Boolean)
-  extends ProcessInterpreter(process) {
+    hiveEnabled: Boolean,
+    statementProgressListener: StatementProgressListener)
+  extends ProcessInterpreter(process, statementProgressListener) {
   import SparkRInterpreter._
 
   implicit val formats = DefaultFormats
 
   private[this] var executionCount = 0
   override def kind: String = "sparkr"
-  private[this] val isStarted = new CountDownLatch(1);
+  private[this] val isStarted = new CountDownLatch(1)
 
   final override protected def waitUntilReady(): Unit = {
     // Set the option to catch and ignore errors instead of halting.

--- a/repl/src/main/scala/com/cloudera/livy/repl/StatementProgressListener.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/StatementProgressListener.scala
@@ -21,10 +21,10 @@ package com.cloudera.livy.repl
 import scala.collection.mutable
 
 import com.google.common.annotations.VisibleForTesting
+import org.apache.spark.Success
 import org.apache.spark.scheduler._
 
 import com.cloudera.livy.rsc.RSCConf
-import org.apache.spark.Success
 
 /**
  * [[StatementProgressListener]] is an implementation of SparkListener, used to track the progress

--- a/repl/src/main/scala/com/cloudera/livy/repl/StatementProgressListener.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/StatementProgressListener.scala
@@ -1,0 +1,147 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.repl
+
+import scala.collection.mutable
+
+import com.google.common.annotations.VisibleForTesting
+import org.apache.spark.scheduler._
+
+import com.cloudera.livy.rsc.RSCConf
+
+case class TaskCount(var currFinishedTasks: Int, totalTasks: Int)
+case class JobState(jobId: Int, var isCompleted: Boolean)
+
+/**
+ * [[StatementProgressListener]] is an implementation of SparkListener, used to track the progress
+ * of submitted statement, this class builds a mapping relation between statement, jobs, stages
+ * and tasks, and uses the finished task number to calculate the statement progress.
+ *
+ * By default 100 latest statement progresses will be kept, users could also configure
+ * livy.rsc.retained_statements to change the cached number.
+ *
+ * This statement progress can only reflect the statement in which has Spark jobs, if
+ * the statement submitted doesn't generate any Spark job, the progress will always return 0.0
+ * until completed.
+ */
+class StatementProgressListener(conf: RSCConf) extends SparkListener {
+
+  private val retainedStatements = conf.getInt(RSCConf.Entry.RETAINED_STATEMENT_NUMBER)
+
+  /** Statement id to list of jobs map */
+  @VisibleForTesting
+  private[repl] val statementToJobs = new mutable.LinkedHashMap[Int, Seq[JobState]]()
+  @VisibleForTesting
+  private[repl] val jobIdToStatement = new mutable.HashMap[Int, Int]()
+  /** Job id to list of stage ids map */
+  @VisibleForTesting
+  private[repl] val jobIdToStages = new mutable.HashMap[Int, Seq[Int]]()
+  /** Stage id to number of finished/total tasks map */
+  @VisibleForTesting
+  private[repl] val stageIdToTaskCount = new mutable.HashMap[Int, TaskCount]()
+
+  private var currentStatementId: Int = _
+
+  /**
+   * Set current statement id, onJobStart() will use current statement id to build the mapping
+   * relations.
+   */
+  def setCurrentStatementId(stmtId: Int): Unit = {
+    currentStatementId = stmtId
+  }
+
+  /**
+   * Get the current progress of given statement id.
+   */
+  def progressOfStatement(stmtId: Int): Double = synchronized {
+    var finishedTasks = 0
+    var totalTasks = 0
+
+    for {
+      job <- statementToJobs.getOrElse(stmtId, Seq.empty)
+      stageId <- jobIdToStages.getOrElse(job.jobId, Seq.empty)
+      taskCount <- stageIdToTaskCount.get(stageId)
+    } yield {
+      finishedTasks += taskCount.currFinishedTasks
+      totalTasks += taskCount.totalTasks
+    }
+
+    if (totalTasks == 0) {
+      0.0
+    } else {
+      finishedTasks.toDouble / totalTasks
+    }
+  }
+
+  /**
+   * Get the active job ids of the given statement id.
+   */
+  def activeJobsOfStatement(stmtId: Int): Seq[Int] = synchronized {
+    statementToJobs.getOrElse(stmtId, Seq.empty).filter(!_.isCompleted).map(_.jobId)
+  }
+
+  override def onJobStart(jobStart: SparkListenerJobStart): Unit = synchronized {
+    val jobs = statementToJobs.getOrElseUpdate(currentStatementId, Seq.empty) :+
+      JobState(jobStart.jobId, isCompleted = false)
+    statementToJobs.put(currentStatementId, jobs)
+    jobIdToStatement(jobStart.jobId) = currentStatementId
+
+    statementToJobs.foreach(println)
+
+    jobIdToStages(jobStart.jobId) = jobStart.stageInfos.map(_.stageId)
+    jobStart.stageInfos.foreach { s => stageIdToTaskCount(s.stageId) = TaskCount(0, s.numTasks) }
+  }
+
+  override def onTaskEnd(taskEnd: SparkListenerTaskEnd): Unit = synchronized {
+    stageIdToTaskCount.get(taskEnd.stageId).foreach { t => t.currFinishedTasks += 1 }
+  }
+
+  override def onStageCompleted(stageCompleted: SparkListenerStageCompleted): Unit = synchronized {
+    stageIdToTaskCount.get(stageCompleted.stageInfo.stageId).foreach { t =>
+      t.currFinishedTasks = t.totalTasks
+    }
+  }
+
+  override def onJobEnd(jobEnd: SparkListenerJobEnd): Unit = synchronized {
+    jobIdToStatement.get(jobEnd.jobId).foreach { stmtId =>
+      statementToJobs.get(stmtId).foreach { jobs =>
+        jobs.filter(_.jobId == jobEnd.jobId).foreach(_.isCompleted = true)
+      }
+    }
+
+    // Try to clean the old data when job is finished. This will trigger data cleaning in LRU
+    // policy.
+    cleanOldMetadata()
+  }
+
+  private def cleanOldMetadata(): Unit = {
+    if (statementToJobs.size > retainedStatements) {
+      val toRemove = statementToJobs.size - retainedStatements
+      statementToJobs.take(toRemove).foreach { case (_, jobs) =>
+        jobs.foreach { job =>
+          jobIdToStatement.remove(job.jobId)
+          jobIdToStages.remove(job.jobId).foreach { stages =>
+            stages.foreach(s => stageIdToTaskCount.remove(s))
+          }
+        }
+      }
+      (0 until toRemove).foreach(_ => statementToJobs.remove(statementToJobs.head._1))
+    }
+  }
+}

--- a/repl/src/test/scala/com/cloudera/livy/repl/PythonInterpreterSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/PythonInterpreterSpec.scala
@@ -23,8 +23,8 @@ import org.json4s.{DefaultFormats, JNull, JValue}
 import org.json4s.JsonDSL._
 import org.scalatest._
 
-import com.cloudera.livy.sessions._
 import com.cloudera.livy.rsc.RSCConf
+import com.cloudera.livy.sessions._
 
 abstract class PythonBaseInterpreterSpec extends BaseInterpreterSpec {
 

--- a/repl/src/test/scala/com/cloudera/livy/repl/PythonInterpreterSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/PythonInterpreterSpec.scala
@@ -24,6 +24,7 @@ import org.json4s.JsonDSL._
 import org.scalatest._
 
 import com.cloudera.livy.sessions._
+import com.cloudera.livy.rsc.RSCConf
 
 abstract class PythonBaseInterpreterSpec extends BaseInterpreterSpec {
 
@@ -244,7 +245,8 @@ class Python2InterpreterSpec extends PythonBaseInterpreterSpec {
 
   implicit val formats = DefaultFormats
 
-  override def createInterpreter(): Interpreter = PythonInterpreter(new SparkConf(), PySpark())
+  override def createInterpreter(): Interpreter =
+    PythonInterpreter(new SparkConf(), PySpark(), new StatementProgressListener(new RSCConf()))
 
   // Scalastyle is treating unicode escape as non ascii characters. Turn off the check.
   // scalastyle:off non.ascii.character.disallowed
@@ -271,7 +273,8 @@ class Python3InterpreterSpec extends PythonBaseInterpreterSpec {
     test()
   }
 
-  override def createInterpreter(): Interpreter = PythonInterpreter(new SparkConf(), PySpark3())
+  override def createInterpreter(): Interpreter =
+    PythonInterpreter(new SparkConf(), PySpark3(), new StatementProgressListener(new RSCConf()))
 
   it should "check python version is 3.x" in withInterpreter { interpreter =>
     val response = interpreter.execute("""import sys

--- a/repl/src/test/scala/com/cloudera/livy/repl/PythonSessionSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/PythonSessionSpec.scala
@@ -23,8 +23,8 @@ import org.json4s.Extraction
 import org.json4s.jackson.JsonMethods.parse
 import org.scalatest._
 
-import com.cloudera.livy.sessions._
 import com.cloudera.livy.rsc.RSCConf
+import com.cloudera.livy.sessions._
 
 abstract class PythonSessionSpec extends BaseSessionSpec {
 

--- a/repl/src/test/scala/com/cloudera/livy/repl/PythonSessionSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/PythonSessionSpec.scala
@@ -24,6 +24,7 @@ import org.json4s.jackson.JsonMethods.parse
 import org.scalatest._
 
 import com.cloudera.livy.sessions._
+import com.cloudera.livy.rsc.RSCConf
 
 abstract class PythonSessionSpec extends BaseSessionSpec {
 
@@ -173,7 +174,8 @@ abstract class PythonSessionSpec extends BaseSessionSpec {
 }
 
 class Python2SessionSpec extends PythonSessionSpec {
-  override def createInterpreter(): Interpreter = PythonInterpreter(new SparkConf(), PySpark())
+  override def createInterpreter(): Interpreter =
+    PythonInterpreter(new SparkConf(), PySpark(), new StatementProgressListener(new RSCConf()))
 }
 
 class Python3SessionSpec extends PythonSessionSpec {
@@ -183,7 +185,8 @@ class Python3SessionSpec extends PythonSessionSpec {
     test()
   }
 
-  override def createInterpreter(): Interpreter = PythonInterpreter(new SparkConf(), PySpark3())
+  override def createInterpreter(): Interpreter =
+    PythonInterpreter(new SparkConf(), PySpark3(), new StatementProgressListener(new RSCConf()))
 
   it should "check python version is 3.x" in withSession { session =>
     val statement = execute(session)(

--- a/repl/src/test/scala/com/cloudera/livy/repl/ScalaInterpreterSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/ScalaInterpreterSpec.scala
@@ -22,11 +22,14 @@ import org.apache.spark.SparkConf
 import org.json4s.{DefaultFormats, JValue}
 import org.json4s.JsonDSL._
 
+import com.cloudera.livy.rsc.RSCConf
+
 class ScalaInterpreterSpec extends BaseInterpreterSpec {
 
   implicit val formats = DefaultFormats
 
-  override def createInterpreter(): Interpreter = new SparkInterpreter(new SparkConf())
+  override def createInterpreter(): Interpreter =
+    new SparkInterpreter(new SparkConf(), new StatementProgressListener(new RSCConf()))
 
   it should "execute `1 + 2` == 3" in withInterpreter { interpreter =>
     val response = interpreter.execute("1 + 2")

--- a/repl/src/test/scala/com/cloudera/livy/repl/SparkRInterpreterSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/SparkRInterpreterSpec.scala
@@ -23,6 +23,8 @@ import org.json4s.{DefaultFormats, JValue}
 import org.json4s.JsonDSL._
 import org.scalatest._
 
+import com.cloudera.livy.rsc.RSCConf
+
 class SparkRInterpreterSpec extends BaseInterpreterSpec {
 
   implicit val formats = DefaultFormats
@@ -32,7 +34,8 @@ class SparkRInterpreterSpec extends BaseInterpreterSpec {
     super.withFixture(test)
   }
 
-  override def createInterpreter(): Interpreter = SparkRInterpreter(new SparkConf())
+  override def createInterpreter(): Interpreter =
+    SparkRInterpreter(new SparkConf(), new StatementProgressListener(new RSCConf()))
 
   it should "execute `1 + 2` == 3" in withInterpreter { interpreter =>
     val response = interpreter.execute("1 + 2")

--- a/repl/src/test/scala/com/cloudera/livy/repl/SparkRSessionSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/SparkRSessionSpec.scala
@@ -22,6 +22,8 @@ import org.apache.spark.SparkConf
 import org.json4s.Extraction
 import org.json4s.jackson.JsonMethods.parse
 
+import com.cloudera.livy.rsc.RSCConf
+
 class SparkRSessionSpec extends BaseSessionSpec {
 
   override protected def withFixture(test: NoArgTest) = {
@@ -29,7 +31,8 @@ class SparkRSessionSpec extends BaseSessionSpec {
     super.withFixture(test)
   }
 
-  override def createInterpreter(): Interpreter = SparkRInterpreter(new SparkConf())
+  override def createInterpreter(): Interpreter =
+    SparkRInterpreter(new SparkConf(), new StatementProgressListener(new RSCConf()))
 
   it should "execute `1 + 2` == 3" in withSession { session =>
     val statement = execute(session)("1 + 2")

--- a/repl/src/test/scala/com/cloudera/livy/repl/SparkSessionSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/SparkSessionSpec.scala
@@ -23,8 +23,8 @@ import scala.language.postfixOps
 
 import org.apache.spark.SparkConf
 import org.json4s.Extraction
-import org.json4s.jackson.JsonMethods.parse
 import org.json4s.JsonAST.JValue
+import org.json4s.jackson.JsonMethods.parse
 import org.scalatest.concurrent.Eventually._
 
 import com.cloudera.livy.rsc.RSCConf

--- a/repl/src/test/scala/com/cloudera/livy/repl/SparkSessionSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/SparkSessionSpec.scala
@@ -27,11 +27,13 @@ import org.json4s.jackson.JsonMethods.parse
 import org.json4s.JsonAST.JValue
 import org.scalatest.concurrent.Eventually._
 
+import com.cloudera.livy.rsc.RSCConf
 import com.cloudera.livy.rsc.driver.StatementState
 
 class SparkSessionSpec extends BaseSessionSpec {
 
-  override def createInterpreter(): Interpreter = new SparkInterpreter(new SparkConf())
+  override def createInterpreter(): Interpreter =
+    new SparkInterpreter(new SparkConf(), new StatementProgressListener(new RSCConf()))
 
   it should "execute `1 + 2` == 3" in withSession { session =>
     val statement = execute(session)("1 + 2")

--- a/repl/src/test/scala/com/cloudera/livy/repl/StatementProgressListenerSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/StatementProgressListenerSpec.scala
@@ -1,0 +1,223 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.repl
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.collection.mutable.ArrayBuffer
+import scala.language.reflectiveCalls
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.scheduler._
+import org.scalatest._
+
+import com.cloudera.livy.LivyBaseUnitTestSuite
+import com.cloudera.livy.rsc.RSCConf
+
+class StatementProgressListenerSpec extends FlatSpec
+    with Matchers
+    with BeforeAndAfterAll
+    with BeforeAndAfter
+    with LivyBaseUnitTestSuite {
+  private val rscConf = new RSCConf()
+    .set(RSCConf.Entry.RETAINED_STATEMENT_NUMBER, 2)
+
+  private val testListener = new StatementProgressListener(rscConf) {
+    var onJobStartedCallback: Option[() => Unit] = None
+    var onJobEndCallback: Option[() => Unit] = None
+    var onStageEndCallback: Option[() => Unit] = None
+    var onTaskEndCallback: Option[() => Unit] = None
+
+    override  def onJobStart(jobStart: SparkListenerJobStart): Unit = {
+      super.onJobStart(jobStart)
+      onJobStartedCallback.foreach(f => f())
+    }
+
+    override def onJobEnd(jobEnd: SparkListenerJobEnd): Unit = {
+      super.onJobEnd(jobEnd)
+      onJobEndCallback.foreach(f => f())
+    }
+
+    override def onStageCompleted(stageCompleted: SparkListenerStageCompleted): Unit = {
+      super.onStageCompleted(stageCompleted)
+      onStageEndCallback.foreach(f => f())
+    }
+
+    override def onTaskEnd(taskEnd: SparkListenerTaskEnd): Unit = {
+      super.onTaskEnd(taskEnd)
+      onTaskEndCallback.foreach(f => f())
+    }
+  }
+
+  private val statementId = new AtomicInteger(0)
+
+  private def getStatementId = statementId.getAndIncrement()
+
+  private var sparkInterpreter: SparkInterpreter = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    // Workaround to close SparkContext started by other unit tests.
+    SparkContext.getOrCreate().stop()
+    sparkInterpreter = new SparkInterpreter(new SparkConf(), testListener)
+    sparkInterpreter.start()
+  }
+
+  override def afterAll(): Unit = {
+    sparkInterpreter.close()
+    super.afterAll()
+  }
+
+  after {
+    testListener.onJobStartedCallback = None
+    testListener.onJobEndCallback = None
+    testListener.onStageEndCallback = None
+    testListener.onTaskEndCallback = None
+  }
+
+  it should "correctly calculate progress" in {
+    val executeCode =
+      """
+        |sc.parallelize(1 to 2, 2).map(i => (i, 1)).reduceByKey(_ + _).collect()
+      """.stripMargin
+    val stmtId = getStatementId
+
+    def verifyJobs(): Unit = {
+      testListener.statementToJobs.get(stmtId) should not be (None)
+
+      // One job will be submitted
+      testListener.statementToJobs(stmtId).size should be (1)
+      val jobId = testListener.statementToJobs(stmtId).head.jobId
+      testListener.jobIdToStatement(jobId) should be (stmtId)
+
+      // Two stages will be generated
+      testListener.jobIdToStages(jobId).size should be (2)
+      val stageIds = testListener.jobIdToStages(jobId)
+
+      // 2 tasks per stage will be generated
+      stageIds.foreach { id =>
+        testListener.stageIdToTaskCount(id).currFinishedTasks should be (0)
+        testListener.stageIdToTaskCount(id).totalTasks should be (2)
+      }
+    }
+
+    var taskEndCalls = 0
+    def verifyTasks(): Unit = {
+      taskEndCalls += 1
+      testListener.progressOfStatement(stmtId) should be (taskEndCalls.toDouble / 4)
+    }
+
+    var stageEndCalls = 0
+    def verifyStages(): Unit = {
+      stageEndCalls += 1
+      testListener.progressOfStatement(stmtId) should be (stageEndCalls.toDouble / 2)
+    }
+
+    testListener.onJobStartedCallback = Some(verifyJobs)
+    testListener.onTaskEndCallback = Some(verifyTasks)
+    testListener.onStageEndCallback = Some(verifyStages)
+    sparkInterpreter.execute(stmtId, executeCode)
+
+    testListener.progressOfStatement(stmtId) should be (1.0)
+  }
+
+  it should "not generate Spark jobs for plain Scala code" in {
+    val executeCode = """1 + 1"""
+    val stmtId = getStatementId
+
+    def verifyJobs(): Unit = {
+      fail("No job will be submitted")
+    }
+
+    testListener.onJobStartedCallback = Some(verifyJobs)
+    testListener.progressOfStatement(stmtId) should be (0.0)
+    sparkInterpreter.execute(stmtId, executeCode)
+    testListener.progressOfStatement(stmtId) should be (0.0)
+  }
+
+  it should "handle multiple jobs in one statement" in {
+    val executeCode =
+      """
+        |sc.parallelize(1 to 2, 2).map(i => (i, 1)).reduceByKey(_ + _).collect()
+        |sc.parallelize(1 to 2, 2).map(i => (i, 1)).reduceByKey(_ + _).collect()
+      """.stripMargin
+    val stmtId = getStatementId
+
+    var jobs = 0
+    def verifyJobs(): Unit = {
+      jobs += 1
+
+      testListener.statementToJobs.get(stmtId) should not be (None)
+      // One job will be submitted
+      testListener.statementToJobs(stmtId).size should be (jobs)
+      val jobId = testListener.statementToJobs(stmtId)(jobs - 1).jobId
+      testListener.jobIdToStatement(jobId) should be (stmtId)
+
+      // Two stages will be generated
+      testListener.jobIdToStages(jobId).size should be (2)
+      val stageIds = testListener.jobIdToStages(jobId)
+
+      // 2 tasks per stage will be generated
+      stageIds.foreach { id =>
+        testListener.stageIdToTaskCount(id).currFinishedTasks should be (0)
+        testListener.stageIdToTaskCount(id).totalTasks should be (2)
+      }
+    }
+
+    val taskProgress = ArrayBuffer[Double]()
+    def verifyTasks(): Unit = {
+      taskProgress += testListener.progressOfStatement(stmtId)
+    }
+
+    val stageProgress = ArrayBuffer[Double]()
+    def verifyStages(): Unit = {
+      stageProgress += testListener.progressOfStatement(stmtId)
+    }
+
+    testListener.onJobStartedCallback = Some(verifyJobs)
+    testListener.onTaskEndCallback = Some(verifyTasks)
+    testListener.onStageEndCallback = Some(verifyStages)
+    sparkInterpreter.execute(stmtId, executeCode)
+
+    taskProgress.toArray should be (Array(0.25, 0.5, 0.75, 1, 0.625, 0.75, 0.875, 1.0))
+    stageProgress.toArray should be (Array(0.5, 1.0, 0.75, 1.0))
+
+    testListener.progressOfStatement(stmtId) should be (1.0)
+  }
+
+  it should "remove old statement progress" in {
+    val executeCode =
+      """
+        |sc.parallelize(1 to 2, 2).map(i => (i, 1)).reduceByKey(_ + _).collect()
+      """.stripMargin
+    val stmtId = getStatementId
+
+    def onJobEnd(): Unit = {
+      testListener.statementToJobs(stmtId).size should be (1)
+      testListener.statementToJobs(stmtId).head.isCompleted should be (true)
+
+      testListener.statementToJobs.size should be (2)
+      testListener.statementToJobs.get(0) should be (None)
+      testListener.jobIdToStatement.filter(_._2 == 0) should be (Map.empty)
+    }
+
+    testListener.onJobEndCallback = Some(onJobEnd)
+    sparkInterpreter.execute(stmtId, executeCode)
+  }
+}

--- a/repl/src/test/scala/com/cloudera/livy/repl/StatementProgressListenerSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/StatementProgressListenerSpec.scala
@@ -73,8 +73,6 @@ class StatementProgressListenerSpec extends FlatSpec
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    // Workaround to close SparkContext started by other unit tests.
-    SparkContext.getOrCreate().stop()
     sparkInterpreter = new SparkInterpreter(new SparkConf(), testListener)
     sparkInterpreter.start()
   }

--- a/repl/src/test/scala/com/cloudera/livy/repl/StatementProgressListenerSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/StatementProgressListenerSpec.scala
@@ -21,11 +21,13 @@ package com.cloudera.livy.repl
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.mutable.ArrayBuffer
-import scala.language.reflectiveCalls
+import scala.concurrent.duration._
+import scala.language.{postfixOps, reflectiveCalls}
 
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.SparkConf
 import org.apache.spark.scheduler._
 import org.scalatest._
+import org.scalatest.concurrent.Eventually._
 
 import com.cloudera.livy.LivyBaseUnitTestSuite
 import com.cloudera.livy.rsc.RSCConf
@@ -132,7 +134,9 @@ class StatementProgressListenerSpec extends FlatSpec
     testListener.onStageEndCallback = Some(verifyStages)
     sparkInterpreter.execute(stmtId, executeCode)
 
-    testListener.progressOfStatement(stmtId) should be (1.0)
+    eventually(timeout(30 seconds), interval(100 millis)) {
+      testListener.progressOfStatement(stmtId) should be(1.0)
+    }
   }
 
   it should "not generate Spark jobs for plain Scala code" in {
@@ -196,7 +200,9 @@ class StatementProgressListenerSpec extends FlatSpec
     taskProgress.toArray should be (Array(0.5, 1.0, 0.75, 1.0))
     stageProgress.toArray should be (Array(1.0, 1.0))
 
-    testListener.progressOfStatement(stmtId) should be (1.0)
+    eventually(timeout(30 seconds), interval(100 millis)) {
+      testListener.progressOfStatement(stmtId) should be(1.0)
+    }
   }
 
   it should "remove old statement progress" in {

--- a/rsc/src/main/java/com/cloudera/livy/rsc/RSCConf.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/RSCConf.java
@@ -94,6 +94,10 @@ public class RSCConf extends ClientConf<RSCConf> {
     public Object dflt() { return dflt; }
   }
 
+  public RSCConf() {
+    this(new Properties());
+  }
+
   public RSCConf(Properties config) {
     super(config);
   }

--- a/rsc/src/main/java/com/cloudera/livy/rsc/driver/Statement.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/driver/Statement.java
@@ -48,8 +48,7 @@ public class Statement {
   }
 
   public void updateProgress(double p) {
-    if (this.state.get().equals(StatementState.Cancelled) ||
-      this.state.get().equals(StatementState.Available)) {
+    if (this.state.get().isOneOf(StatementState.Cancelled, StatementState.Available)) {
       this.progress = 1.0;
     } else {
       this.progress = p;

--- a/rsc/src/main/java/com/cloudera/livy/rsc/driver/Statement.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/driver/Statement.java
@@ -26,11 +26,13 @@ public class Statement {
   public final AtomicReference<StatementState> state;
   @JsonRawValue
   public volatile String output;
+  public double progress;
 
   public Statement(Integer id, StatementState state, String output) {
     this.id = id;
     this.state = new AtomicReference<>(state);
     this.output = output;
+    this.progress = 0.0;
   }
 
   public Statement() {
@@ -43,5 +45,14 @@ public class Statement {
       return true;
     }
     return false;
+  }
+
+  public void updateProgress(double p) {
+    if (this.state.get().equals(StatementState.Cancelled) ||
+      this.state.get().equals(StatementState.Available)) {
+      this.progress = 1.0;
+    } else {
+      this.progress = p;
+    }
   }
 }

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionServletSpec.scala
@@ -121,6 +121,7 @@ class InteractiveSessionServletSpec extends BaseInteractiveServletSpec {
 
     jpost[Map[String, Any]]("/0/statements", ExecuteRequest("foo")) { data =>
       data("id") should be (0)
+      data("progress") should be (0.0)
       data("output") shouldBe 1
     }
 

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionSpec.scala
@@ -209,6 +209,22 @@ class InteractiveSessionSpec extends FunSpec
       }
     }
 
+    withSession("should get statement progress along with statement result") { session =>
+      val code =
+        """
+          |from time import sleep
+          |sleep(3)
+        """.stripMargin
+      val statement = session.executeStatement(ExecuteRequest(code))
+      statement.progress should be (0.0)
+
+      eventually(timeout(10 seconds), interval(100 millis)) {
+        val s = session.getStatement(statement.id).get
+        s.state.get() shouldBe StatementState.Available
+        s.progress should be (1.0)
+      }
+    }
+
     withSession("should error out the session if the interpreter dies") { session =>
       session.executeStatement(ExecuteRequest("import os; os._exit(666)"))
       eventually(timeout(30 seconds), interval(100 millis)) {


### PR DESCRIPTION
This proposal adds the support to get the progress of statement by using `SparkListener`. This could potentially Zeppelin like tools to display the progress of submitted statement.