### PR TITLE
LIVY-282. Fix fake_shell unexpectedly exit problem

### DIFF
--- a/repl/src/main/resources/fake_shell.py
+++ b/repl/src/main/resources/fake_shell.py
@@ -97,7 +97,7 @@ class JobContextImpl(object):
         self.hive_ctx = None
         self.streaming_ctx = None
         self.local_tmp_dir_path = local_tmp_dir_path
-        self.spark_session = global_dict['spark']
+        self.spark_session = global_dict.get('spark')
 
     def sc(self):
         return self.sc

--- a/repl/src/main/scala/com/cloudera/livy/repl/ProcessInterpreter.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/ProcessInterpreter.scala
@@ -18,7 +18,7 @@
 
 package com.cloudera.livy.repl
 
-import java.io.{BufferedReader, InputStreamReader, IOException, PrintWriter}
+import java.io.{BufferedReader, IOException, InputStreamReader, PrintWriter}
 import java.util.concurrent.locks.ReentrantLock
 
 import scala.concurrent.Promise
@@ -28,6 +28,7 @@ import org.apache.spark.SparkContext
 import org.json4s.JValue
 
 import com.cloudera.livy.{Logging, Utils}
+import com.cloudera.livy.client.common.ClientConf
 
 private sealed trait Request
 private case class ExecuteRequest(code: String, promise: Promise[JValue]) extends Request
@@ -50,7 +51,11 @@ abstract class ProcessInterpreter(process: Process)
   override def start(): SparkContext = {
     waitUntilReady()
 
-    SparkContext.getOrCreate()
+    if (ClientConf.TEST_MODE) {
+      null.asInstanceOf[SparkContext]
+    } else {
+      SparkContext.getOrCreate()
+    }
   }
 
   override def execute(code: String): Interpreter.ExecuteResponse = {


### PR DESCRIPTION
Due to the bug introduced in LIVY-233, pyspark interpreter will be failed to start in Spark 1.x, in which `SparkSession` is not supported. So here fix this problem.