### PR TITLE
Provide Jetty Http Request/Response Header Size Configuration

### DIFF
--- a/server/src/main/scala/com/cloudera/livy/LivyConf.scala
+++ b/server/src/main/scala/com/cloudera/livy/LivyConf.scala
@@ -58,6 +58,8 @@ object LivyConf {
 
   val SERVER_HOST = Entry("livy.server.host", "0.0.0.0")
   val SERVER_PORT = Entry("livy.server.port", 8998)
+  val HTTP_REQUEST_HEADER_SIZE = Entry("livy.http.request.header.size", 131072)
+  val HTTP_RESPONSE_HEADER_SIZE = Entry("livy.http.response.header.size", 131072)
   val CSRF_PROTECTION = LivyConf.Entry("livy.server.csrf_protection.enabled", false)
 
   val IMPERSONATION_ENABLED = Entry("livy.impersonation.enabled", false)

--- a/server/src/main/scala/com/cloudera/livy/server/WebServer.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/WebServer.scala
@@ -39,12 +39,20 @@ class WebServer(livyConf: LivyConf, var host: String, var port: Int) extends Log
   server.setStopTimeout(1000)
   server.setStopAtShutdown(true)
 
+  val requestHeaderSize = livyConf.getInt(LivyConf.HTTP_REQUEST_HEADER_SIZE)
+  val responseHeaderSize = livyConf.getInt(LivyConf.HTTP_RESPONSE_HEADER_SIZE)
+
   val (connector, protocol) = Option(livyConf.get(WebServer.KeystoreKey)) match {
     case None =>
-      (new ServerConnector(server), "http")
+      val http = new HttpConfiguration()
+      http.setRequestHeaderSize(requestHeaderSize)
+      http.setResponseHeaderSize(responseHeaderSize)
+      (new ServerConnector(server, new HttpConnectionFactory(http)), "http")
 
     case Some(keystore) =>
       val https = new HttpConfiguration()
+      https.setRequestHeaderSize(requestHeaderSize)
+      https.setResponseHeaderSize(responseHeaderSize)
       https.addCustomizer(new SecureRequestCustomizer())
 
       val sslContextFactory = new SslContextFactory()


### PR DESCRIPTION
Kerberos over http requires larger header sizes than the default,
or the HTTP Error 413 Request entity too large will be returned.
This patch increases the default for Livy to 128K and also allows
this to be configurable.