### PR TITLE
LIYV-289. Fix NPE in ContextLauncher and expose state of RSCClient

### DIFF
--- a/rsc/src/main/java/com/cloudera/livy/rsc/ContextLauncher.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/ContextLauncher.java
@@ -105,7 +105,9 @@ class ContextLauncher {
         @Override
         public void onFailure(Throwable error) throws Exception {
           // If promise is cancelled or failed, make sure spark-submit is not leaked.
-          child.kill();
+          if (child != null) {
+            child.kill();
+          }
         }
       });
 
@@ -137,10 +139,12 @@ class ContextLauncher {
   private void dispose(boolean forceKill) {
     factory.getServer().unregisterClient(clientId);
     try {
-      if (forceKill) {
-        child.kill();
-      } else {
-        child.detach();
+      if (child != null) {
+        if (forceKill) {
+          child.kill();
+        } else {
+          child.detach();
+        }
       }
     } finally {
       factory.unref();

--- a/rsc/src/main/java/com/cloudera/livy/rsc/RSCClient.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/RSCClient.java
@@ -94,6 +94,10 @@ public class RSCClient implements LivyClient {
     isAlive = true;
   }
 
+  public boolean isAlive() {
+    return isAlive;
+  }
+
   private synchronized void connectToContext(final ContextInfo info) throws Exception {
     this.contextInfo = info;
 


### PR DESCRIPTION
 If `ContextLauncher#startDriver` doesn't start correctly, it will trigger the listener with `child` be empty, this will introduce NPE, so here check whether `child` is null or not. Also expose the state of `RSCClient`.
 
This is originated by @mridulm , please review. \cc @zjffdu .