### PR TITLE
LIVY-292. Fix Python Job API issue and add Java/python Job API example

### DIFF
--- a/examples/src/main/java/com/cloudera/livy/examples/PiApp.java
+++ b/examples/src/main/java/com/cloudera/livy/examples/PiApp.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.examples;
+
+import java.io.File;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.api.java.function.Function2;
+
+import com.cloudera.livy.*;
+
+class PiJob implements
+    Job<Double>,
+    Function<Integer, Integer>,
+    Function2<Integer, Integer, Integer> {
+
+  private final int slices;
+  private final int samples;
+
+  public PiJob(int slices) {
+    this.slices = slices;
+    this.samples = (int) Math.min(100000L * slices, Integer.MAX_VALUE);
+  }
+
+  @Override
+  public Double call(JobContext ctx) throws Exception {
+    List<Integer> sampleList = new ArrayList<>();
+    for (int i = 0; i < samples; i++) {
+      sampleList.add(i);
+    }
+
+    return 4.0d * ctx.sc().parallelize(sampleList, slices).map(this).reduce(this) / samples;
+  }
+
+  @Override
+  public Integer call(Integer v1) {
+    double x = Math.random() * 2 - 1;
+    double y = Math.random() * 2 - 1;
+    return (x * x + y * y < 1) ? 1 : 0;
+  }
+
+  @Override
+  public Integer call(Integer v1, Integer v2) {
+    return v1 + v2;
+  }
+}
+
+/**
+ * Example execution:
+ * java -cp /pathTo/spark-core_2.10-*version*.jar:/pathTo/livy-api-*version*.jar:
+ * /pathTo/livy-client-http-*version*.jar:/pathTo/livy-examples-*version*.jar
+ * com.cloudera.livy.examples.PiApp http://livy-host:8998 2
+ */
+public class PiApp {
+  public static void main(String[] args) throws Exception {
+    if (args.length != 2) {
+      System.err.println("Usage: PiJob <livy url> <slices>");
+      System.exit(-1);
+    }
+
+    LivyClient client = new LivyClientBuilder()
+      .setURI(new URI(args[0]))
+      .build();
+
+    try {
+      System.out.println("Uploading livy-example jar to the SparkContext...");
+      for (String s : System.getProperty("java.class.path").split(File.pathSeparator)) {
+        if (new File(s).getName().startsWith("livy-examples")) {
+          client.uploadJar(new File(s)).get();
+          break;
+        }
+      }
+
+      final int slices = Integer.parseInt(args[1]);
+      double pi = client.submit(new PiJob(slices)).get();
+
+      System.out.println("Pi is roughly " + pi);
+    } finally {
+      client.stop(true);
+    }
+  }
+}
+

--- a/examples/src/main/python/pi_app.py
+++ b/examples/src/main/python/pi_app.py
@@ -1,0 +1,48 @@
+from __future__ import print_function
+#
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import sys
+from random import random
+from operator import add
+
+from livy.client import HttpClient
+
+if __name__ == "__main__":
+    """
+        Usage: PiJob [livy url] [slices]
+    """
+    slices = int(sys.argv[2])
+    samples = 100000 * slices
+
+    client = HttpClient(sys.argv[1])
+
+    def f(_):
+        x = random() * 2 - 1
+        y = random() * 2 - 1
+        return 1 if x ** 2 + y ** 2 <= 1 else 0
+
+    def pi_job(context):
+        count = context.sc.parallelize(range(1, samples + 1), slices).map(f).reduce(add)
+        return 4.0 * count / samples
+
+    pi = client.submit(pi_job).result()
+
+    print("Pi is roughly %f" % pi)
+    client.stop(True)
+

--- a/examples/src/main/python/pi_app.py
+++ b/examples/src/main/python/pi_app.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 #
 # Licensed to Cloudera, Inc. under one
 # or more contributor license agreements.  See the NOTICE file
@@ -17,6 +16,8 @@ from __future__ import print_function
 # limitations under the License.
 #
 
+from __future__ import print_function
+
 import sys
 from random import random
 from operator import add
@@ -25,8 +26,18 @@ from livy.client import HttpClient
 
 if __name__ == "__main__":
     """
-        Usage: PiJob [livy url] [slices]
+        Usage: pi_app [livy url] [slices]
+
+        To run this Python script you need to install livy-python-api-*version*.tar.gz with
+        easy_install first.
+
+        python /pathTo/pi_app.py http://<livy-server>:8998 2
     """
+
+    if len(sys.argv) != 3:
+        print("Usage: pi_app <livy url> <slices>", file=sys.stderr)
+        exit(-1)
+
     slices = int(sys.argv[2])
     samples = 100000 * slices
 

--- a/repl/src/main/scala/com/cloudera/livy/repl/BypassPySparkJob.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/BypassPySparkJob.scala
@@ -23,10 +23,14 @@ import com.cloudera.livy.{Job, JobContext}
 
 class BypassPySparkJob(
     serializedJob: Array[Byte],
-    pysparkJobProcessor: PySparkJobProcessor) extends Job[Array[Byte]] {
+    replDriver: ReplDriver) extends Job[Array[Byte]] {
 
   override def call(jc: JobContext): Array[Byte] = {
-    val resultByteArray = pysparkJobProcessor.processBypassJob(serializedJob)
+    val interpreter = replDriver.interpreter
+    require(interpreter != null && interpreter.isInstanceOf[PythonInterpreter])
+    val pi = interpreter.asInstanceOf[PythonInterpreter]
+
+    val resultByteArray = pi.pysparkJobProcessor.processBypassJob(serializedJob)
     val resultString = new String(resultByteArray, StandardCharsets.UTF_8)
     if (resultString.startsWith("Client job error:")) {
       throw new PythonJobException(resultString)

--- a/repl/src/main/scala/com/cloudera/livy/repl/PythonInterpreter.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/PythonInterpreter.scala
@@ -195,7 +195,8 @@ private class PythonInterpreter(process: Process, gatewayServer: GatewayServer, 
 
   override def kind: String = pyKind
 
-  private val pysparkJobProcessor = PythonInterpreter.initiatePy4jCallbackGateway(gatewayServer)
+  private[repl] val pysparkJobProcessor =
+    PythonInterpreter.initiatePy4jCallbackGateway(gatewayServer)
 
   override def close(): Unit = {
     try {
@@ -255,11 +256,6 @@ private class PythonInterpreter(process: Process, gatewayServer: GatewayServer, 
     Option(stdout.readLine()).map { case line =>
       parse(line)
     }
-  }
-
-  def createWrapper(driver: ReplDriver, msg: BaseProtocol.BypassJobRequest): BypassJobWrapper = {
-    new BypassJobWrapper(driver, msg.id,
-      new BypassPySparkJob(msg.serializedJob, pysparkJobProcessor))
   }
 
   def addFile(path: String): Unit = {

--- a/repl/src/main/scala/com/cloudera/livy/repl/ReplDriver.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/ReplDriver.scala
@@ -94,13 +94,15 @@ class ReplDriver(conf: SparkConf, livyConf: RSCConf)
   }
 
   override protected def createWrapper(msg: BaseProtocol.BypassJobRequest): BypassJobWrapper = {
-    interpreter match {
-      case pi: PythonInterpreter => pi.createWrapper(this, msg)
+    kind match {
+      case PySpark() | PySpark3() => new BypassJobWrapper(this, msg.id,
+        new BypassPySparkJob(msg.serializedJob, this))
       case _ => super.createWrapper(msg)
     }
   }
 
   override protected def addFile(path: String): Unit = {
+    require(interpreter != null)
     interpreter match {
       case pi: PythonInterpreter => pi.addFile(path)
       case _ => super.addFile(path)
@@ -108,6 +110,7 @@ class ReplDriver(conf: SparkConf, livyConf: RSCConf)
   }
 
   override protected def addJarOrPyFile(path: String): Unit = {
+    require(interpreter != null)
     interpreter match {
       case pi: PythonInterpreter => pi.addPyFile(this, conf, path)
       case _ => super.addJarOrPyFile(path)


### PR DESCRIPTION
Add two Java / Python Job API examples to Livy to demonstrate how to use.

Also Fix an issue of Python Job API where interpreter is not created when Job request is received in RSCDriver, this will lead to kryo deserialization error.