### PR TITLE
LIVY-295. Make livy.rsc.jars a Livy conf

### DIFF
--- a/conf/livy.conf
+++ b/conf/livy.conf
@@ -25,7 +25,7 @@
 # Comma-separated list of Livy RSC jars. By default Livy will upload jars from its installation
 # directory every time a session is started. By caching these files in HDFS, for example, startup
 # time of sessions on YARN can be reduced.
-# livy.jars =
+# livy.rsc.jars =
 
 # Comma-separated list of Livy REPL jars. By default Livy will upload jars from its installation
 # directory every time a session is started. By caching these files in HDFS, for example, startup

--- a/server/src/main/scala/com/cloudera/livy/LivyConf.scala
+++ b/server/src/main/scala/com/cloudera/livy/LivyConf.scala
@@ -114,6 +114,11 @@ object LivyConf {
   // Days to keep Livy server request logs.
   val REQUEST_LOG_RETAIN_DAYS = Entry("livy.server.request-log-retain.days", 5)
 
+  // REPL related jars separated with comma.
+  val REPL_JARS = Entry("livy.repl.jars", null)
+  // RSC related jars separated with comma.
+  val RSC_JARS = Entry("livy.rsc.jars", null)
+
   val SPARK_MASTER = "spark.master"
   val SPARK_DEPLOY_MODE = "spark.submit.deployMode"
   val SPARK_JARS = "spark.jars"

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
@@ -60,7 +60,6 @@ case class InteractiveRecoveryMetadata(
   extends RecoveryMetadata
 
 object InteractiveSession extends Logging {
-  private[interactive] val LIVY_REPL_JARS = "livy.repl.jars"
   private[interactive] val SPARK_YARN_IS_PYTHON = "spark.yarn.isPython"
 
   val RECOVERY_SESSION_TYPE = "interactive"
@@ -159,7 +158,7 @@ object InteractiveSession extends Logging {
     builderProperties ++= conf
 
     def livyJars(livyConf: LivyConf, scalaVersion: String): List[String] = {
-      Option(livyConf.get(LIVY_REPL_JARS)).map { jars =>
+      Option(livyConf.get(LivyConf.REPL_JARS)).map { jars =>
         val regex = """[\w-]+_(\d\.\d\d).*\.jar""".r
         jars.split(",").filter { name => new Path(name).getName match {
             // Filter out unmatched scala jars
@@ -310,6 +309,10 @@ object InteractiveSession extends Logging {
       case _ =>
     }
     builderProperties.put(RSCConf.Entry.SESSION_KIND.key, kind.toString)
+
+    // Set Livy.rsc.jars from livy conf to rsc conf, RSC conf will take precedence if both are set.
+    Option(livyConf.get(LivyConf.RSC_JARS)).foreach(
+      builderProperties.getOrElseUpdate(RSCConf.Entry.LIVY_JARS.key(), _))
 
     require(livyConf.get(LivyConf.LIVY_SPARK_VERSION) != null)
     require(livyConf.get(LivyConf.LIVY_SPARK_SCALA_VERSION) != null)

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/BaseInteractiveServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/BaseInteractiveServletSpec.scala
@@ -50,7 +50,7 @@ abstract class BaseInteractiveServletSpec
     }
     super.createConf()
       .set(LivyConf.SESSION_STAGING_DIR, tempDir.toURI().toString())
-      .set(InteractiveSession.LIVY_REPL_JARS, "dummy.jar")
+      .set(LivyConf.REPL_JARS, "dummy.jar")
       .set(LivyConf.LIVY_SPARK_VERSION, "1.6.0")
       .set(LivyConf.LIVY_SPARK_SCALA_VERSION, "2.10.5")
   }


### PR DESCRIPTION
The issue is coming from [here](https://groups.google.com/a/cloudera.org/forum/#!topic/livy-dev/KTbBOZ3W3tQ).

Currently `livy.rsc.jars` is a RSC configuration, which means user should specify this configuration each time when creating a session, this is semantically incorrect and inconvenient, also equivalent to `livy.repl.jars`, we should change this to Livy configuration.

Besides current doc uses `livy.jars` as a configuration name, no code honors this configuration name, this should also be updated.