### PR TITLE
LIVY-293: Redirect Spark Log to REST Response Log field instead of redirecting to livi-server.out log file

### DIFF
--- a/rsc/src/main/java/com/cloudera/livy/rsc/DriverProcessInfo.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/DriverProcessInfo.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cloudera.livy.rsc;
 
 import io.netty.util.concurrent.Promise;

--- a/rsc/src/main/java/com/cloudera/livy/rsc/DriverProcessInfo.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/DriverProcessInfo.java
@@ -1,0 +1,26 @@
+package com.cloudera.livy.rsc;
+
+import io.netty.util.concurrent.Promise;
+
+/**
+ * Information about driver process and @{@link ContextInfo}
+ */
+public class DriverProcessInfo {
+
+  private Promise<ContextInfo> contextInfo;
+  private transient Process driverProcess;
+
+
+  public DriverProcessInfo(Promise<ContextInfo> contextInfo, Process driverProcess) {
+    this.contextInfo = contextInfo;
+    this.driverProcess = driverProcess;
+  }
+
+  public Promise<ContextInfo> getContextInfo() {
+    return contextInfo;
+  }
+
+  public Process getDriverProcess() {
+    return driverProcess;
+  }
+}

--- a/rsc/src/main/java/com/cloudera/livy/rsc/RSCClient.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/RSCClient.java
@@ -60,12 +60,14 @@ public class RSCClient implements LivyClient {
   private final Promise<URI> serverUriPromise;
 
   private ContextInfo contextInfo;
+  private transient Process driverProcess;
   private volatile boolean isAlive;
   private volatile String replState;
 
-  RSCClient(RSCConf conf, Promise<ContextInfo> ctx) throws IOException {
+  RSCClient(RSCConf conf, Promise<ContextInfo> ctx, Process driverProcess) throws IOException {
     this.conf = conf;
     this.contextInfoPromise = ctx;
+    this.driverProcess = driverProcess;
     this.jobs = new ConcurrentHashMap<>();
     this.protocol = new ClientProtocol();
     this.driverRpc = ImmediateEventExecutor.INSTANCE.newPromise();
@@ -96,6 +98,10 @@ public class RSCClient implements LivyClient {
 
   public boolean isAlive() {
     return isAlive;
+  }
+
+  public Process getDriverProcess() {
+    return driverProcess;
   }
 
   private synchronized void connectToContext(final ContextInfo info) throws Exception {

--- a/rsc/src/main/java/com/cloudera/livy/rsc/RSCClientFactory.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/RSCClientFactory.java
@@ -57,14 +57,17 @@ public final class RSCClientFactory implements LivyClientFactory {
     boolean needsServer = false;
     try {
       Promise<ContextInfo> info;
+      Process driverProcess = null;
       if (uri.getUserInfo() != null && uri.getHost() != null && uri.getPort() > 0) {
         info = createContextInfo(uri);
       } else {
         needsServer = true;
         ref(lconf);
-        info = ContextLauncher.create(this, lconf);
+        DriverProcessInfo processInfo = ContextLauncher.create(this, lconf);
+        info = processInfo.getContextInfo();
+        driverProcess = processInfo.getDriverProcess();
       }
-      return new RSCClient(lconf, info);
+      return new RSCClient(lconf, info, driverProcess);
     } catch (Exception e) {
       if (needsServer) {
         unref();

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
@@ -377,7 +377,8 @@ class InteractiveSession(
 
   private val app = mockApp.orElse {
     if (livyConf.isRunningOnYarn()) {
-      val driverProcess = client.map(client => Some(new LineBufferedProcess(client.getDriverProcess))).getOrElse(None)
+      val driverProcess = client.map(client => Some(new LineBufferedProcess(
+        client.getDriverProcess))).getOrElse(None)
       // When Livy is running with YARN, SparkYarnApp can provide better YARN integration.
       // (e.g. Reflect YARN application state to session state).
       Option(SparkApp.create(appTag, appId, driverProcess, livyConf, Some(this)))

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
@@ -44,6 +44,7 @@ import com.cloudera.livy.server.recovery.SessionStore
 import com.cloudera.livy.sessions._
 import com.cloudera.livy.sessions.Session._
 import com.cloudera.livy.sessions.SessionState.Dead
+import com.cloudera.livy.util.LineBufferedProcess
 import com.cloudera.livy.utils.{AppInfo, LivySparkUtils, SparkApp, SparkAppListener}
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -376,9 +377,10 @@ class InteractiveSession(
 
   private val app = mockApp.orElse {
     if (livyConf.isRunningOnYarn()) {
+      val driverProcess = client.map(client => Some(new LineBufferedProcess(client.getDriverProcess))).getOrElse(None)
       // When Livy is running with YARN, SparkYarnApp can provide better YARN integration.
       // (e.g. Reflect YARN application state to session state).
-      Option(SparkApp.create(appTag, appId, None, livyConf, Some(this)))
+      Option(SparkApp.create(appTag, appId, driverProcess, livyConf, Some(this)))
     } else {
       // When Livy is running with other cluster manager, SparkApp doesn't provide any
       // additional benefit over controlling RSCDriver using RSCClient. Don't use it.

--- a/server/src/main/scala/com/cloudera/livy/utils/SparkYarnApp.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/SparkYarnApp.scala
@@ -78,7 +78,7 @@ class SparkYarnApp private[utils] (
   private var yarnDiagnostics: IndexedSeq[String] = IndexedSeq.empty[String]
 
   override def log(): IndexedSeq[String] =
-    process.map(_.inputLines).getOrElse(ArrayBuffer.empty[String]) ++ yarnDiagnostics
+    process.map(_.inputLines).getOrElse(ArrayBuffer.empty[String]) ++ yarnDiagnostics ++ process.map(_.errorLines).getOrElse(ArrayBuffer.empty[String])
 
   override def kill(): Unit = synchronized {
     if (isRunning) {

--- a/server/src/main/scala/com/cloudera/livy/utils/SparkYarnApp.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/SparkYarnApp.scala
@@ -78,7 +78,8 @@ class SparkYarnApp private[utils] (
   private var yarnDiagnostics: IndexedSeq[String] = IndexedSeq.empty[String]
 
   override def log(): IndexedSeq[String] =
-    process.map(_.inputLines).getOrElse(ArrayBuffer.empty[String]) ++ yarnDiagnostics ++ process.map(_.errorLines).getOrElse(ArrayBuffer.empty[String])
+    process.map(_.inputLines).getOrElse(ArrayBuffer.empty[String]) ++ yarnDiagnostics ++
+      process.map(_.errorLines).getOrElse(ArrayBuffer.empty[String])
 
   override def kill(): Unit = synchronized {
     if (isRunning) {


### PR DESCRIPTION
Passing driverProcess to SparkApp for interactive sessions. This will help getting /log work for interactive.

