### PR TITLE
LIVY-298 - hive-site.xml added in spark.jars. not spark.files

### DIFF
--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSession.scala
@@ -288,7 +288,7 @@ object InteractiveSession extends Logging {
         case (Some(file), false) =>
           debug("Enable HiveContext because hive-site.xml is found under classpath, "
             + file.getAbsolutePath)
-          mergeConfList(List(file.getAbsolutePath), LivyConf.SPARK_FILES)
+          mergeConfList(List(file.getAbsolutePath), LivyConf.SPARK_JARS)
           mergeConfList(datanucleusJars(livyConf, sparkMajorVersion), LivyConf.SPARK_JARS)
         case (None, false) =>
           warn("Enable HiveContext but no hive-site.xml found under" +


### PR DESCRIPTION
in currently livy,
when hive-site.xml in livy classpath, livy added hive-site.xml in SPARK_FILES.
ex) spark.files /home/livy/livy-server/conf/hive-site.xml
execute code,
executor find hive-site.xml in same classpath. (/home/livy/livy-server/conf/hive-site.xml)
but cluster node do not has "/home/livy/livy-server/conf/hive-site.xml)

so hive-site.xml is added in spark.jars. not spark.files