### PR TITLE
LIVY-300. Fixed a race condition in rsc's RPC channel.

### DIFF
--- a/rsc/src/test/java/com/cloudera/livy/rsc/rpc/TestRpc.java
+++ b/rsc/src/test/java/com/cloudera/livy/rsc/rpc/TestRpc.java
@@ -190,6 +190,9 @@ public class TestRpc {
     EmbeddedChannel client = (EmbeddedChannel) clientRpc.getChannel();
     EmbeddedChannel server = (EmbeddedChannel) serverRpc.getChannel();
 
+    server.runPendingTasks();
+    client.runPendingTasks();
+
     int count = 0;
     while (!client.outboundMessages().isEmpty()) {
       server.writeInbound(client.readOutbound());


### PR DESCRIPTION
In `Rpc.call()`, RPC function call messages are enqueued to the send buffer of the Channel on `Channel.write()` call because it's called outside of the netty Channel IO event loop.
RPC replies are handled by `RpcDispatcher.channelRead0`. It calls `RpcDispatcher.writeMessage()` which calls `Channel.write()` to send RPC reply messages to the Channel. `RpcDispatcher.channelRead0` is executed in the event loop which means `Channel.write()` writes messages directly to the socket and bypassing the send buffer.
When one side of the RPC channel is making a RPC call but at the same time received another RPC call from the other side. Then this race condition might happen:
- Send call header
- Send reply header
- Send reply payload
- Send call payload
This means RPC reply messages might preempt the on going RPC call and messages will be sent out of order.

To fix this, we have to prevent`RpcDispatcher.channelRead0` from being called while `Rpc.call()` is sending messages. One of the solution is changing Rpc.call()` to write messages in the event loop.