### PR TITLE
LIVY-297. Code should be escaped again in R interpreter

### DIFF
--- a/repl/src/main/scala/com/cloudera/livy/repl/SparkRInterpreter.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/SparkRInterpreter.scala
@@ -30,6 +30,7 @@ import scala.reflect.runtime.universe
 import org.apache.commons.codec.binary.Base64
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.util.{ChildFirstURLClassLoader, MutableURLClassLoader, Utils}
+import org.apache.commons.lang.StringEscapeUtils
 import org.json4s._
 import org.json4s.JsonDSL._
 
@@ -199,7 +200,7 @@ class SparkRInterpreter(process: Process,
   }
 
   private def sendRequest(code: String): String = {
-    stdin.println(s"""try(eval(parse(text="$code")))""")
+    stdin.println(s"""try(eval(parse(text="${StringEscapeUtils.escapeJava(code)}")))""")
     stdin.flush()
 
     stdin.println(PRINT_MARKER)

--- a/repl/src/test/scala/com/cloudera/livy/repl/SparkRInterpreterSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/SparkRInterpreterSpec.scala
@@ -97,4 +97,11 @@ class SparkRInterpreterSpec extends BaseInterpreterSpec {
     ))
   }
 
+  it should "escape the statement" in withInterpreter { interpreter =>
+    val response = interpreter.execute("print(\"a\")")
+    response should equal(Interpreter.ExecuteSuccess(
+      TEXT_PLAIN -> "[1] \"a\""
+    ))
+  }
+
 }


### PR DESCRIPTION
Otherwise the expression cannot be properly unescaped. See issuein LIVY-297.