### PR TITLE
LIVY-240. Improve the session gc mechanism

### DIFF
--- a/conf/livy.conf
+++ b/conf/livy.conf
@@ -21,6 +21,9 @@
 
 # Time in milliseconds on how long Livy will wait before timing out an idle session.
 # livy.server.session.timeout = 1h
+#
+# How long a finished session state should be kept in LivyServer for query.
+# livy.server.session.state-retain.sec = 600s
 
 # If livy should impersonate the requesting users when creating a new session.
 # livy.impersonation.enabled = true

--- a/conf/livy.conf
+++ b/conf/livy.conf
@@ -16,6 +16,9 @@
 # What spark deploy mode Livy sessions should use.
 # livy.spark.deployMode =
 
+# Enabled to check whether timeout Livy sessions should be stopped.
+# livy.server.session.timeout-check = true
+
 # Time in milliseconds on how long Livy will wait before timing out an idle session.
 # livy.server.session.timeout = 1h
 

--- a/core/src/main/scala/com/cloudera/livy/sessions/SessionState.scala
+++ b/core/src/main/scala/com/cloudera/livy/sessions/SessionState.scala
@@ -23,6 +23,11 @@ sealed trait SessionState {
   def isActive: Boolean
 }
 
+sealed trait FinishedSessionState extends SessionState {
+  /** When session is finished. */
+  def time: Long
+}
+
 object SessionState {
 
   def apply(s: String): SessionState = {
@@ -83,19 +88,19 @@ object SessionState {
     override def toString: String = "shutting_down"
   }
 
-  case class Error(time: Long = System.nanoTime()) extends SessionState {
+  case class Error(time: Long = System.nanoTime()) extends FinishedSessionState {
     override def isActive: Boolean = true
 
     override def toString: String = "error"
   }
 
-  case class Dead(time: Long = System.nanoTime()) extends SessionState {
+  case class Dead(time: Long = System.nanoTime()) extends FinishedSessionState {
     override def isActive: Boolean = false
 
     override def toString: String = "dead"
   }
 
-  case class Success(time: Long = System.nanoTime()) extends SessionState {
+  case class Success(time: Long = System.nanoTime()) extends FinishedSessionState {
     override def isActive: Boolean = false
 
     override def toString: String = "success"

--- a/server/src/main/scala/com/cloudera/livy/LivyConf.scala
+++ b/server/src/main/scala/com/cloudera/livy/LivyConf.scala
@@ -124,6 +124,12 @@ object LivyConf {
   // how often to check livy session leakage
   val YARN_APP_LEAKAGE_CHECK_INTERVAL = Entry("livy.server.yarn.app-leakage.check_interval", "60s")
 
+  // Whether session timeout should be checked, by default it will be checked, which means inactive
+  // session will be stopped after "livy.server.session.timeout"
+  val SESSION_TIMEOUT_CHECK = Entry("livy.server.session.timeout-check", true)
+  // How long will an inactive session be gc-ed.
+  val SESSION_TIMEOUT = Entry("livy.server.session.timeout", "1h")
+
   val SPARK_MASTER = "spark.master"
   val SPARK_DEPLOY_MODE = "spark.submit.deployMode"
   val SPARK_JARS = "spark.jars"

--- a/server/src/main/scala/com/cloudera/livy/LivyConf.scala
+++ b/server/src/main/scala/com/cloudera/livy/LivyConf.scala
@@ -129,6 +129,8 @@ object LivyConf {
   val SESSION_TIMEOUT_CHECK = Entry("livy.server.session.timeout-check", true)
   // How long will an inactive session be gc-ed.
   val SESSION_TIMEOUT = Entry("livy.server.session.timeout", "1h")
+  // How long a finished session state will be kept in memory
+  val SESSION_STATE_RETAIN_TIME = Entry("livy.server.session.state-retain.sec", "600s")
 
   val SPARK_MASTER = "spark.master"
   val SPARK_DEPLOY_MODE = "spark.submit.deployMode"

--- a/server/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
+++ b/server/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
@@ -135,7 +135,10 @@ class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
       val currentTime = System.nanoTime()
       currentTime - session.lastActivity > sessionTimeout
       session.state match {
-        case SessionState.Success(_) | SessionState.Dead(_) | SessionState.Error(_) => true
+        case SessionState.Success(_) | SessionState.Dead(_) | SessionState.Error(_) =>
+          // don't gc finished session in integration test, because we need to check the session
+          // state after it is finished.
+          !sys.env.getOrElse("LIVY_INTEGRATION_TEST", "false").toBoolean
         case _ =>
           if (!sessionTimeoutCheck) {
             false

--- a/server/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
+++ b/server/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
@@ -136,7 +136,7 @@ class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
       currentTime - session.lastActivity > sessionTimeout
       session.state match {
         case SessionState.Success(_) | SessionState.Dead(_) | SessionState.Error(_) => true
-        case _  =>
+        case _ =>
           if (!sessionTimeoutCheck) {
             false
           } else if (session.isInstanceOf[BatchSession]) {

--- a/server/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
+++ b/server/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
@@ -147,7 +147,7 @@ class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
             false
           } else {
             val currentTime = System.nanoTime()
-            currentTime - session.lastActivity > math.max(sessionTimeout, session.timeout)
+            currentTime - session.lastActivity > sessionTimeout
           }
       }
     }

--- a/server/src/test/scala/com/cloudera/livy/sessions/SessionManagerSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/sessions/SessionManagerSpec.scala
@@ -97,7 +97,7 @@ class SessionManagerSpec extends FunSpec with Matchers with LivyBaseUnitTestSuit
       }
 
       // Stopped session should be gc-ed immediate without checking timeout
-      for (s <-Seq(SessionState.Error(),
+      for (s <- Seq(SessionState.Error(),
         SessionState.Success(),
         SessionState.Dead())) {
         changeStateAndCheck(s) { sm => sm.get(session.id) should be (None) }

--- a/server/src/test/scala/com/cloudera/livy/sessions/SessionManagerSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/sessions/SessionManagerSpec.scala
@@ -30,14 +30,17 @@ import org.scalatest.mock.MockitoSugar.mock
 
 import com.cloudera.livy.{LivyBaseUnitTestSuite, LivyConf}
 import com.cloudera.livy.server.batch.{BatchRecoveryMetadata, BatchSession}
+import com.cloudera.livy.server.interactive.InteractiveSession
 import com.cloudera.livy.server.recovery.SessionStore
 import com.cloudera.livy.sessions.Session.RecoveryMetadata
 
 class SessionManagerSpec extends FunSpec with Matchers with LivyBaseUnitTestSuite {
+  implicit def executor: ExecutionContext = ExecutionContext.global
+
   describe("SessionManager") {
     it("should garbage collect old sessions") {
       val livyConf = new LivyConf()
-      livyConf.set(SessionManager.SESSION_TIMEOUT, "100ms")
+      livyConf.set(LivyConf.SESSION_TIMEOUT, "100ms")
       val manager = new SessionManager[MockSession, RecoveryMetadata](
         livyConf,
         { _ => assert(false).asInstanceOf[MockSession] },
@@ -49,6 +52,55 @@ class SessionManagerSpec extends FunSpec with Matchers with LivyBaseUnitTestSuit
       eventually(timeout(5 seconds), interval(100 millis)) {
         Await.result(manager.collectGarbage(), Duration.Inf)
         manager.get(session.id) should be(None)
+      }
+    }
+
+    it("batch session should not be gc-ed until application is finished") {
+      val sessionId = 24
+      val session = mock[BatchSession]
+      when(session.id).thenReturn(sessionId)
+      when(session.stop()).thenReturn(Future {})
+      when(session.lastActivity).thenReturn(System.nanoTime())
+
+      val sm = new BatchSessionManager(new LivyConf(), mock[SessionStore], Some(Seq(session)))
+      testSessionGC(session, sm)
+    }
+
+    it("interactive session should not gc-ed if session timeout check is off") {
+      val sessionId = 24
+      val session = mock[InteractiveSession]
+      when(session.id).thenReturn(sessionId)
+      when(session.stop()).thenReturn(Future {})
+      when(session.lastActivity).thenReturn(System.nanoTime())
+
+      val conf = new LivyConf().set(LivyConf.SESSION_TIMEOUT_CHECK, false)
+      val sm = new InteractiveSessionManager(conf, mock[SessionStore], Some(Seq(session)))
+      testSessionGC(session, sm)
+    }
+
+    def testSessionGC(session: Session, sm: SessionManager[_, _]): Unit = {
+
+      def changeStateAndCheck(s: SessionState)(fn: SessionManager[_, _] => Unit): Unit = {
+        when(session.state).thenReturn(s)
+        Await.result(sm.collectGarbage(), Duration.Inf)
+        fn(sm)
+      }
+
+      // Batch session should not be gc-ed when alive
+      for (s <- Seq(SessionState.Running(),
+        SessionState.Idle(),
+        SessionState.Recovering(),
+        SessionState.NotStarted(),
+        SessionState.Busy(),
+        SessionState.ShuttingDown())) {
+        changeStateAndCheck(s) { sm => sm.get(session.id) should be (Some(session)) }
+      }
+
+      // Stopped session should be gc-ed immediate without checking timeout
+      for (s <-Seq(SessionState.Error(),
+        SessionState.Success(),
+        SessionState.Dead())) {
+        changeStateAndCheck(s) { sm => sm.get(session.id) should be (None) }
       }
     }
   }


### PR DESCRIPTION
Current session gc mechanism has some issues:

1. Stopped session still needs to wait to timeout to gc-ed.
2. Batch session will be gc-ed unexpectedly in run-time when timing out, which makes long running application impossible.
3. Sometimes user doesn't want to stop idle sessions.

So here with this patch:

1. Never check the activity of batch session, which means batch session will only be gc-ed after stop.
2. Add a configuration to turn off activity check for interactive session, which meets some usage scenarios.
3. Add a configuration to control how long a finished session state will be kept in memory before cleaned out.

CC @tc0312 