### PR TITLE
LIVY-302 - Fail to parse Spark version when including "-SNAPSHOT"

### DIFF
--- a/server/src/main/scala/com/cloudera/livy/utils/LivySparkUtils.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/LivySparkUtils.scala
@@ -145,11 +145,11 @@ object LivySparkUtils extends Logging {
    * @return Two element tuple, one is major version and the other is minor version
    */
   def formatSparkVersion(version: String): (Int, Int) = {
-    val versionPattern = """(\d)+\.(\d)+(?:[\.-]\d*)*""".r
-    version match {
-      case versionPattern(major, minor) =>
-        (major.toInt, minor.toInt)
-      case _ =>
+    val versionPattern = """^(\d+)\.(\d+)(\..*)?$""".r
+    versionPattern.findFirstMatchIn(version) match {
+      case Some(m) =>
+        (m.group(1).toInt, m.group(2).toInt)
+      case None =>
         throw new IllegalArgumentException(s"Fail to parse Spark version from $version")
     }
   }

--- a/server/src/test/scala/com/cloudera/livy/utils/LivySparkUtilsSuite.scala
+++ b/server/src/test/scala/com/cloudera/livy/utils/LivySparkUtilsSuite.scala
@@ -69,6 +69,7 @@ class LivySparkUtilsSuite extends FunSuite with Matchers with LivyBaseUnitTestSu
     intercept[IllegalArgumentException] { testSparkVersion("1.5.0") }
     intercept[IllegalArgumentException] { testSparkVersion("1.5.1") }
     intercept[IllegalArgumentException] { testSparkVersion("1.5.2") }
+    intercept[IllegalArgumentException] { testSparkVersion("1.5.0-cdh5.6.1") }
   }
 
   test("should fail on bad version") {

--- a/server/src/test/scala/com/cloudera/livy/utils/LivySparkUtilsSuite.scala
+++ b/server/src/test/scala/com/cloudera/livy/utils/LivySparkUtilsSuite.scala
@@ -50,7 +50,7 @@ class LivySparkUtilsSuite extends FunSuite with Matchers with LivyBaseUnitTestSu
     testSparkVersion("1.6.1-SNAPSHOT")
     testSparkVersion("1.6.2")
     testSparkVersion("1.6")
-    testSparkVersion("1.6.3.2.5.0-12")    
+    testSparkVersion("1.6.3.2.5.0-12")
   }
 
   test("should support Spark 2.0.x") {

--- a/server/src/test/scala/com/cloudera/livy/utils/LivySparkUtilsSuite.scala
+++ b/server/src/test/scala/com/cloudera/livy/utils/LivySparkUtilsSuite.scala
@@ -47,15 +47,17 @@ class LivySparkUtilsSuite extends FunSuite with Matchers with LivyBaseUnitTestSu
   test("should support Spark 1.6") {
     testSparkVersion("1.6.0")
     testSparkVersion("1.6.1")
+    testSparkVersion("1.6.1-SNAPSHOT")
     testSparkVersion("1.6.2")
     testSparkVersion("1.6")
-    testSparkVersion("1.6.3.2.5.0-12")
+    testSparkVersion("1.6.3.2.5.0-12")    
   }
 
   test("should support Spark 2.0.x") {
     testSparkVersion("2.0.0")
     testSparkVersion("2.0.1")
     testSparkVersion("2.0.2")
+    testSparkVersion("2.0.3-SNAPSHOT")
     testSparkVersion("2.0.0.2.5.1.0-56") // LIVY-229
     testSparkVersion("2.0")
     testSparkVersion("2.1.0")


### PR DESCRIPTION
add spark version check case : spark version is 2.0.3-SNAPSHOT