### PR TITLE
Minor. Remove backslash textwrap.dedent heredoc breaks python interpreter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -324,7 +324,7 @@ Pi. This is from the `Spark Examples`_:
 .. code:: python
 
     data = {
-      'code': textwrap.dedent("""\
+      'code': textwrap.dedent("""
         val NUM_SAMPLES = 100000;
         val count = sc.parallelize(1 to NUM_SAMPLES).map { i =>
           val x = Math.random();
@@ -415,7 +415,7 @@ The Pi example from before then can be run as:
 .. code:: python
 
     data = {
-      'code': textwrap.dedent("""\
+      'code': textwrap.dedent("""
         n <- 100000
         piFunc <- function(elem) {
           rands <- runif(n = 2, min = -1, max = 1)

--- a/README.rst
+++ b/README.rst
@@ -338,6 +338,10 @@ Pi. This is from the `Spark Examples`_:
     r = requests.post(statements_url, data=json.dumps(data), headers=headers)
     pprint.pprint(r.json())
 
+    statement_url = host + r.headers['location']
+    r = requests.get(statement_url, headers=headers)
+    pprint.pprint(r.json())
+
     {u'id': 1,
      u'output': {u'data': {u'text/plain': u'Pi is roughly 3.14004\nNUM_SAMPLES: Int = 100000\ncount: Int = 78501'},
                  u'execution_count': 1,


### PR DESCRIPTION
The original code does not run at all (tested in ipython 2.7.3).  The fixed code works great. Overall the README.md for livy is of quite high quality: I am looking forward to working with this project.