### PR TITLE
Livy for Spark2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ language: scala
 
 env:
   - MVN_FLAG='-Pspark-1.6 -DskipTests'
-  - MVN_FLAG='-Pspark-2.0 -DskipTests'
   - MVN_FLAG='-Pspark-1.6 -DskipITs'
+  - MVN_FLAG='-Pspark-2.0 -DskipTests'
   - MVN_FLAG='-Pspark-2.0 -DskipITs'
+  - MVN_FLAG='-Pspark-2.1 -DskipTests'
+  - MVN_FLAG='-Pspark-2.1 -DskipITs'
 
 jdk:
   - oraclejdk7

--- a/pom.xml
+++ b/pom.xml
@@ -682,7 +682,7 @@
             </systemProperties>
             <redirectTestOutputToFile>${test.redirectToFile}</redirectTestOutputToFile>
             <useFile>${test.redirectToFile}</useFile>
-            <argLine>${argLine} -Xmx2g -XX:MaxPermSize=512m</argLine>
+            <argLine>${argLine} -Xmx3g -XX:MaxPermSize=1g</argLine>
             <failIfNoTests>false</failIfNoTests>
           </configuration>
         </plugin>
@@ -711,7 +711,7 @@
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
             <junitxml>.</junitxml>
             <filereports>WDF TestSuite.txt</filereports>
-            <argLine>${argLine} -Xmx2g -XX:MaxPermSize=512m</argLine>
+            <argLine>${argLine} -Xmx3g -XX:MaxPermSize=1g</argLine>
           </configuration>
           <executions>
             <execution>
@@ -1003,6 +1003,18 @@
       </activation>
       <properties>
         <spark.version>2.0.1</spark.version>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>spark-2.1</id>
+      <activation>
+        <property>
+          <name>spark-2.1</name>
+        </property>
+      </activation>
+      <properties>
+        <spark.version>2.1.0</spark.version>
       </properties>
     </profile>
   </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -682,7 +682,7 @@
             </systemProperties>
             <redirectTestOutputToFile>${test.redirectToFile}</redirectTestOutputToFile>
             <useFile>${test.redirectToFile}</useFile>
-            <argLine>${argLine} -Xmx3g -XX:MaxPermSize=1g</argLine>
+            <argLine>${argLine} -Xmx4g -XX:MaxPermSize=1g</argLine>
             <failIfNoTests>false</failIfNoTests>
           </configuration>
         </plugin>
@@ -711,7 +711,7 @@
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
             <junitxml>.</junitxml>
             <filereports>WDF TestSuite.txt</filereports>
-            <argLine>${argLine} -Xmx3g -XX:MaxPermSize=1g</argLine>
+            <argLine>${argLine} -Xmx4g -XX:MaxPermSize=1g</argLine>
           </configuration>
           <executions>
             <execution>

--- a/repl/src/test/scala/com/cloudera/livy/repl/BaseInterpreterSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/BaseInterpreterSpec.scala
@@ -18,6 +18,9 @@
 
 package com.cloudera.livy.repl
 
+import java.io.File
+
+import org.apache.commons.io.FileUtils
 import org.scalatest.{FlatSpec, Matchers}
 
 import com.cloudera.livy.LivyBaseUnitTestSuite
@@ -33,6 +36,7 @@ abstract class BaseInterpreterSpec extends FlatSpec with Matchers with LivyBaseU
       testCode(interpreter)
     } finally {
       interpreter.close()
+      FileUtils.deleteDirectory(new File("metastore_db"))
     }
   }
 }

--- a/repl/src/test/scala/com/cloudera/livy/repl/BaseSessionSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/BaseSessionSpec.scala
@@ -18,6 +18,7 @@
 
 package com.cloudera.livy.repl
 
+import java.io.File
 import java.util.Properties
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -25,6 +26,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
+import org.apache.commons.io.FileUtils
 import org.json4s._
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.concurrent.Eventually._
@@ -63,6 +65,7 @@ abstract class BaseSessionSpec extends FlatSpec with Matchers with LivyBaseUnitT
       testCode(session)
     } finally {
       session.close()
+      FileUtils.deleteDirectory(new File("metastore_db"))
     }
   }
 
@@ -78,6 +81,7 @@ abstract class BaseSessionSpec extends FlatSpec with Matchers with LivyBaseUnitT
       Await.ready(future, 60 seconds)
     } finally {
       session.close()
+      FileUtils.deleteDirectory(new File("metastore_db"))
     }
   }
 

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/JobApiSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/JobApiSpec.scala
@@ -28,6 +28,7 @@ import scala.concurrent.duration._
 import scala.io.Source
 import scala.language.postfixOps
 
+import org.apache.commons.io.FileUtils
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.mock.MockitoSugar.mock
 
@@ -120,6 +121,7 @@ class JobApiSpec extends BaseInteractiveServletSpec {
 
       // Make sure the session's staging directory was cleaned up.
       assert(tempDir.listFiles().length === 0)
+      FileUtils.deleteDirectory(new File("metastore_db"))
     }
 
     it("should support user impersonation") {
@@ -133,6 +135,7 @@ class JobApiSpec extends BaseInteractiveServletSpec {
           user should be (PROXY)
         } finally {
           deleteSession(data.id)
+          FileUtils.deleteDirectory(new File("metastore_db"))
         }
       }
     }
@@ -154,6 +157,7 @@ class JobApiSpec extends BaseInteractiveServletSpec {
         } finally {
           deleteSession(data.id)
           assert(tempDir.listFiles().length === 0)
+          FileUtils.deleteDirectory(new File("metastore_db"))
         }
       }
     }


### PR DESCRIPTION
We hit https://issues.apache.org/jira/browse/SPARK-10872 while running unittests against Spark 2.1. At this point, Spark is not fixing it. In tests, we have to explicitly delete the derby db directory to workaround the issue. Also, need to increase JVM memory footprint with this.