### PR TITLE
LIVY-311. Set classpath in MiniCluster only when it is not in real cluster

### DIFF
--- a/integration-test/src/main/scala/com/cloudera/livy/test/framework/MiniCluster.scala
+++ b/integration-test/src/main/scala/com/cloudera/livy/test/framework/MiniCluster.scala
@@ -238,16 +238,16 @@ class MiniCluster(config: Map[String, String]) extends Cluster with MiniClusterU
     assert(tempDir.mkdir(), "Cannot create temp test dir.")
     sparkConfDir = mkdir("spark-conf")
 
-    val sparkScalaVersion = getSparkScalaVersion()
-    val classPathFile =
-      new File(s"minicluster-dependencies/scala-$sparkScalaVersion/target/classpath")
-    assert(classPathFile.isFile,
-      s"Cannot read MiniCluster classpath file: ${classPathFile.getCanonicalPath}")
-    val sparkClassPath =
-      FileUtils.readFileToString(classPathFile, Charset.defaultCharset())
-
     // When running a real Spark cluster, don't set the classpath.
     val extraCp = if (!isRealSpark()) {
+      val sparkScalaVersion = getSparkScalaVersion()
+      val classPathFile =
+        new File(s"minicluster-dependencies/scala-$sparkScalaVersion/target/classpath")
+      assert(classPathFile.isFile,
+        s"Cannot read MiniCluster classpath file: ${classPathFile.getCanonicalPath}")
+      val sparkClassPath =
+        FileUtils.readFileToString(classPathFile, Charset.defaultCharset())
+
       val dummyJar = Files.createTempFile(Paths.get(tempDir.toURI), "dummy", "jar").toFile
       Map(
         SparkLauncher.DRIVER_EXTRA_CLASSPATH -> sparkClassPath,


### PR DESCRIPTION
I am integrating livy MiniCluster to zeppelin to do integration test. So I am not using real cluster, the following assert will fail for me if it is outside the if block. In this PR, I move it into if block

```
assert(classPathFile.isFile,
        s"Cannot read MiniCluster classpath file: ${classPathFile.getCanonicalPath}")
```