### PR TITLE
LIVY-308. Avoid enabling Hive by default in Spark2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,10 @@ language: scala
 env:
   - MVN_FLAG='-Pspark-1.6 -DskipTests'
   - MVN_FLAG='-Pspark-2.0 -DskipTests'
+  - MVN_FLAG='-Pspark-2.1 -DskipTests'
   - MVN_FLAG='-Pspark-1.6 -DskipITs'
   - MVN_FLAG='-Pspark-2.0 -DskipITs'
+  - MVN_FLAG='-Pspark-2.1 -DskipITs'
 
 jdk:
   - oraclejdk7

--- a/pom.xml
+++ b/pom.xml
@@ -1002,6 +1002,18 @@
         </property>
       </activation>
       <properties>
+        <spark.version>2.0.1</spark.version>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>spark-2.1</id>
+      <activation>
+        <property>
+          <name>spark-2.1</name>
+        </property>
+      </activation>
+      <properties>
         <spark.version>2.1.0</spark.version>
       </properties>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -1002,7 +1002,7 @@
         </property>
       </activation>
       <properties>
-        <spark.version>2.0.1</spark.version>
+        <spark.version>2.1.0</spark.version>
       </properties>
     </profile>
   </profiles>

--- a/repl/src/main/scala/com/cloudera/livy/repl/SparkContextInitializer.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/SparkContextInitializer.scala
@@ -82,7 +82,7 @@ trait SparkContextInitializer extends Logging {
     builder.getClass.getMethod("config", classOf[SparkConf]).invoke(builder, conf)
 
     var spark: Object = null
-    if (conf.get("spark.sql.catalogImplementation", "hive").toLowerCase == "hive") {
+    if (conf.get("spark.sql.catalogImplementation", "in-memory").toLowerCase == "hive") {
       if (sparkClz.getMethod("hiveClassesArePresent").invoke(sparkObj).asInstanceOf[Boolean]) {
         val loader = Option(Thread.currentThread().getContextClassLoader)
           .getOrElse(getClass.getClassLoader)


### PR DESCRIPTION
In the current implementation of Livy Spark2 SparkSession, by default hive support will be enabled if not explicitly disabled, this is a default behavior in spark-shell. But in Livy interpreter we will disable it by default, otherwise it will introduce unit test failure.

This is another solution of issue #283 .