### PR TITLE
MINOR. A small REST API typo in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -580,7 +580,7 @@ DELETE /sessions/{sessionId}
 Kills the `Session`_ job.
 
 
-GET /sessions/{sessionId}/logs
+GET /sessions/{sessionId}/log
 ------------------------------
 
 Gets the log lines from this session.


### PR DESCRIPTION
README incorrectly said `logs` instead of `log` for the `sessions` REST API call, it is correct for the `batches` call below.