### PR TITLE
LIVY-306. Removed hardcoded minimum timeout value

### DIFF
--- a/server/src/main/scala/com/cloudera/livy/sessions/Session.scala
+++ b/server/src/main/scala/com/cloudera/livy/sessions/Session.scala
@@ -197,7 +197,6 @@ abstract class Session(val id: Int, val owner: String, val livyConf: LivyConf)
     }
   }
 
-  val timeout: Long = TimeUnit.HOURS.toNanos(1)
 
   override def toString(): String = s"${this.getClass.getSimpleName} $id"
 

--- a/server/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
+++ b/server/src/main/scala/com/cloudera/livy/sessions/SessionManager.scala
@@ -133,7 +133,7 @@ class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
   def collectGarbage(): Future[Iterable[Unit]] = {
     def expired(session: Session): Boolean = {
       val currentTime = System.nanoTime()
-      currentTime - session.lastActivity > math.max(sessionTimeout, session.timeout)
+      currentTime - session.lastActivity > sessionTimeout
     }
 
     Future.sequence(all().filter(expired).map(delete))

--- a/server/src/test/scala/com/cloudera/livy/sessions/MockSession.scala
+++ b/server/src/test/scala/com/cloudera/livy/sessions/MockSession.scala
@@ -31,7 +31,5 @@ class MockSession(id: Int, owner: String, conf: LivyConf) extends Session(id, ow
 
   override def state: SessionState = SessionState.Idle()
 
-  override val timeout: Long = 0L
-
   override def recoveryMetadata: RecoveryMetadata = RecoveryMetadata(0)
 }


### PR DESCRIPTION
[LIVY-306](https://issues.cloudera.org/projects/LIVY/issues/LIVY-306)

Currently a session timeout can't be configured below 1h. This is due to a hardcoded value that was missed in the clean up of [LIVY-114](https://issues.cloudera.org/browse/LIVY-114) and [LIVY-127](https://issues.cloudera.org/browse/LIVY-127)

Given the minimum was not intended I have simple removed it and the conf value (default of 1h) will always be used.