### PR TITLE
Minor. Relief the constraint of recovery folder permission

### DIFF
--- a/server/src/main/scala/com/cloudera/livy/server/recovery/FileSystemStateStore.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/recovery/FileSystemStateStore.scala
@@ -72,10 +72,12 @@ class FileSystemStateStore(
     val fileStatus = fileContext.getFileStatus(absPath("."))
     require(fileStatus.getPermission.getUserAction() == FsAction.ALL,
       s"Livy doesn't have permission to access state store: $fsUri.")
-    require(fileStatus.getPermission.getGroupAction() == FsAction.NONE,
-      s"Group users have permission to access state store: $fsUri. This is insecure.")
-    require(fileStatus.getPermission.getOtherAction() == FsAction.NONE,
-      s"Other users have permission to access state store: $fsUri. This is insecure.")
+    if (fileStatus.getPermission.getGroupAction != FsAction.NONE) {
+      warn(s"Group users have permission to access state store: $fsUri. This is insecure.")
+    }
+    if (fileStatus.getPermission.getOtherAction != FsAction.NONE) {
+      warn(s"Other users have permission to access state store: $fsUri. This is in secure.")
+    }
   }
 
   override def set(key: String, value: Object): Unit = {

--- a/server/src/test/scala/com/cloudera/livy/server/recovery/FileSystemStateStoreSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/recovery/FileSystemStateStoreSpec.scala
@@ -82,9 +82,9 @@ class FileSystemStateStoreSpec extends FunSpec with LivyBaseUnitTestSuite {
       }
       test("600")
       test("400")
-      test("777")
-      test("770")
-      test("707")
+      test("677")
+      test("670")
+      test("607")
     }
 
     it("set should write with an intermediate file") {


### PR DESCRIPTION
Currently if the permission of recovery folder is not 700, LivyServer will be down. This is actually not a fatal issue, and sometimes this folder is created by admin who doesn't know this constraint. So instead of throwing exception when permission is not 0700, printing warning log instead.

CC @tc0312 