### PR TITLE
LIVY-315. Enable hive in SparkRInterpreter

### DIFF
--- a/repl/src/main/scala/com/cloudera/livy/repl/ProcessInterpreter.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/ProcessInterpreter.scala
@@ -130,6 +130,7 @@ abstract class ProcessInterpreter(process: Process)
       val exitCode = process.waitFor()
       if (exitCode != 0) {
         error(f"Process has died with $exitCode")
+        error(stderrLines.mkString("\n"))
       }
     }
   }


### PR DESCRIPTION
`livy.repl.enableHiveContext` doesn't take effect in SparkRInterpreter. Fix it in this PR.

Tested it manually for both spark 1.6 and spark 2.1