### PR TITLE
LIVY-182. Add SPARK_HOME/conf to classpath when SPARK_CONF_DIR is not…

### DIFF
--- a/bin/livy-server
+++ b/bin/livy-server
@@ -85,6 +85,8 @@ start_livy_server() {
 
   if [ -n "$SPARK_CONF_DIR" ]; then
     LIVY_CLASSPATH="$LIVY_CLASSPATH:$SPARK_CONF_DIR"
+  elif [ -n "$SPARK_HOME" ]; then
+    LIVY_CLASSPATH="$LIVY_CLASSPATH:$SPARK_HOME/conf"
   fi
   if [ -n "$HADOOP_CONF_DIR" ]; then
     LIVY_CLASSPATH="$LIVY_CLASSPATH:$HADOOP_CONF_DIR"


### PR DESCRIPTION
… defined

[LIVY-182](https://issues.cloudera.org/browse/LIVY-182)