### PR TITLE
LIVY-320. Livy python-api client test failing.

### DIFF
--- a/python-api/src/test/python/livy-tests/client_test.py
+++ b/python-api/src/test/python/livy-tests/client_test.py
@@ -25,7 +25,7 @@ from livy.client import HttpClient
 
 session_id = 0
 job_id = 1
-base_uri = 'http://{}:{}'.format(socket.gethostname(), 8998)
+base_uri = 'http://{0}:{1}'.format(socket.gethostname(), 8998)
 client_test = None
 invoked_queued_callback = False
 invoked_running_callback = False


### PR DESCRIPTION
Specified fields for client test. Travis CI looks to be defaulted to python 2.7, so it never came across this issue. 
[LIVY-320](https://issues.cloudera.org/browse/LIVY-320) 
