### PR TITLE
Minor. Ignore empty string in configuration join

### DIFF
--- a/rsc/src/main/java/com/cloudera/livy/rsc/Utils.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/Utils.java
@@ -80,7 +80,7 @@ public class Utils {
   public static String join(Iterable<String> strs, String sep) {
     StringBuilder sb = new StringBuilder();
     for (String s : strs) {
-      if (s != null) {
+      if (s != null && !s.isEmpty()) {
         sb.append(s).append(sep);
       }
     }


### PR DESCRIPTION
This happens in unit test, we usually set `livy.rsc.jars` to empty string, and `livy.repl.jars` to `dummy.jar`. And these two configurations will be converted to `spark.jars=,dummy.jar` when submitting application, in Spark side Spark didn't filter out empty string and will be resolved to a dir path in `addJar`, which will lead to exception. So in the Livy side we should also filter out empty string. 