### PR TITLE
LIVY-322 - subprocess.call() commands in a PySpark snippet can potent…

### DIFF
--- a/repl/src/main/scala/com/cloudera/livy/repl/PythonInterpreter.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/PythonInterpreter.scala
@@ -282,8 +282,8 @@ private class PythonInterpreter(process: Process, gatewayServer: GatewayServer, 
     }
     else {
       throw new Exception(
-         'Livy is unable to find valid JSON in the response from fake_shell. ' +
-         'Please recreate the session.')
+         "Livy is unable to find valid JSON in the response from fake_shell. " +
+         "Please recreate the session.")
     }
   }
 


### PR DESCRIPTION
…ially insert raw text into the sys_stdout in the fake_shell main().  This will then fail to be correctly parsed by PythonInterpreter in the sendRequest, as it will trigger a JsonParseException that is not caught.  Added code to catch the JsonParseException and then retry reads of stdout until a valid line of JSON is reached, or 100 retries have been attempted.