### PR TITLE
LIVY-313. Fixed SparkRInterpreter always returning success.

### DIFF
--- a/repl/src/main/scala/com/cloudera/livy/repl/ProcessInterpreter.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/ProcessInterpreter.scala
@@ -109,7 +109,7 @@ abstract class ProcessInterpreter(process: Process)
 
   private[this] val stderrThread = new Thread("process stderr thread") {
     override def run() = {
-      while(true) {
+      while (true) {
         val lines = Source.fromInputStream(process.getErrorStream).getLines()
 
         for (line <- lines) {

--- a/repl/src/main/scala/com/cloudera/livy/repl/ProcessInterpreter.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/ProcessInterpreter.scala
@@ -109,14 +109,16 @@ abstract class ProcessInterpreter(process: Process)
 
   private[this] val stderrThread = new Thread("process stderr thread") {
     override def run() = {
-      val lines = Source.fromInputStream(process.getErrorStream).getLines()
+      while(true) {
+        val lines = Source.fromInputStream(process.getErrorStream).getLines()
 
-      for (line <- lines) {
-        stderrLock.lock()
-        try {
-          stderrLines :+= line
-        } finally {
-          stderrLock.unlock()
+        for (line <- lines) {
+          stderrLock.lock()
+          try {
+            stderrLines :+= line
+          } finally {
+            stderrLock.unlock()
+          }
         }
       }
     }

--- a/repl/src/main/scala/com/cloudera/livy/repl/ProcessInterpreter.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/ProcessInterpreter.scala
@@ -109,16 +109,14 @@ abstract class ProcessInterpreter(process: Process)
 
   private[this] val stderrThread = new Thread("process stderr thread") {
     override def run() = {
-      while (true) {
-        val lines = Source.fromInputStream(process.getErrorStream).getLines()
+      val lines = Source.fromInputStream(process.getErrorStream).getLines()
 
-        for (line <- lines) {
-          stderrLock.lock()
-          try {
-            stderrLines :+= line
-          } finally {
-            stderrLock.unlock()
-          }
+      for (line <- lines) {
+        stderrLock.lock()
+        try {
+          stderrLines :+= line
+        } finally {
+          stderrLock.unlock()
         }
       }
     }

--- a/repl/src/main/scala/com/cloudera/livy/repl/SparkRInterpreter.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/SparkRInterpreter.scala
@@ -220,7 +220,8 @@ class SparkRInterpreter(process: Process,
 
   private def sendRequest(code: String): RequestResponse = {
     stdin.println(s"""tryCatch(eval(parse(text="${StringEscapeUtils.escapeJava(code)}"))
-                     |,error = function(e) sprintf("%s%s", e, "${LIVY_ERROR_MARKER}"))""".stripMargin)
+                     |,error = function(e) sprintf("%s%s", e, "${LIVY_ERROR_MARKER}"))
+                  """.stripMargin)
     stdin.flush()
 
     stdin.println(PRINT_MARKER)
@@ -250,7 +251,10 @@ class SparkRInterpreter(process: Process,
   }
 
   @tailrec
-  private def readTo(marker: String, errorMarker: String, output: StringBuilder = StringBuilder.newBuilder): RequestResponse = {
+  private def readTo(
+      marker: String,
+      errorMarker: String,
+      output: StringBuilder = StringBuilder.newBuilder): RequestResponse = {
     var char = readChar(output)
 
     // Remove any ANSI color codes which match the pattern "\u001b\\[[0-9;]*[mG]".

--- a/repl/src/test/scala/com/cloudera/livy/repl/SparkRInterpreterSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/SparkRInterpreterSpec.scala
@@ -81,19 +81,18 @@ class SparkRInterpreterSpec extends BaseInterpreterSpec {
 
   it should "report an error if accessing an unknown variable" in withInterpreter { interpreter =>
     val response = interpreter.execute("x")
-    response should equal(Interpreter.ExecuteSuccess(
-      TEXT_PLAIN -> "Error in eval(expr, envir, enclos) : object 'x' not found"
+    response should equal(Interpreter.ExecuteError(
+      "Error",
+      """[1] "Error in eval(expr, envir, enclos): object 'x' not found""""
     ))
   }
 
 
   it should "not hang when executing incomplete statements" in withInterpreter { interpreter =>
     val response = interpreter.execute("x[")
-    response should equal(Interpreter.ExecuteSuccess(
-      TEXT_PLAIN ->
-        """Error in parse(text = "x[") : <text>:2:0: unexpected end of input
-          |1: x[
-          |   ^""".stripMargin
+    response should equal(Interpreter.ExecuteError(
+      "Error",
+        """[1] "Error in parse(text = \"x[\"): <text>:2:0: unexpected end of input\n1: x[\n   ^""""
     ))
   }
 

--- a/repl/src/test/scala/com/cloudera/livy/repl/SparkRSessionSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/SparkRSessionSpec.scala
@@ -130,11 +130,11 @@ class SparkRSessionSpec extends BaseSessionSpec {
 
     val result = parse(statement.output)
     val expectedResult = Extraction.decompose(Map(
-      "status" -> "ok",
+      "status" -> "error",
       "execution_count" -> 0,
-      "data" -> Map(
-        "text/plain" -> "Error in eval(expr, envir, enclos) : object 'x' not found"
-      )
+      "ename" -> "Error",
+      "evalue" -> "[1] \"Error in eval(expr, envir, enclos): object 'x' not found\"",
+      "traceback" -> List()
     ))
 
     result should equal (expectedResult)


### PR DESCRIPTION
- Stopped redirecting stderr to stdout.
- Continue to read ErrorStream (it was only being read once).
- Checking for any errors returned by stderr before returning success.

[LIVY-313](https://issues.cloudera.org/browse/LIVY-313)