### PR TITLE
LIVY-329. Fix two SSL issues

### DIFF
--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -3,6 +3,9 @@
 
 # Specify the keystore password.
 # livy.keystore.password =
+#
+# Specify the key password.
+# livy.key-password =
 
 # What host address to start the server on. By default, Livy will bind to all network interfaces.
 # livy.server.host = 0.0.0.0

--- a/server/src/main/scala/com/cloudera/livy/LivyConf.scala
+++ b/server/src/main/scala/com/cloudera/livy/LivyConf.scala
@@ -66,6 +66,10 @@ object LivyConf {
   val ACCESS_CONTROL_ENABLED = Entry("livy.server.access_control.enabled", false)
   val ACCESS_CONTROL_USERS = Entry("livy.server.access_control.users", null)
 
+  val SSL_KEYSTORE = Entry("livy.keystore", null)
+  val SSL_KEYSTORE_PASSWORD = Entry("livy.keystore.password", null)
+  val SSL_KEY_PASSWORD = Entry("livy.key-password", null)
+
   val AUTH_TYPE = Entry("livy.server.auth.type", null)
   val AUTH_KERBEROS_PRINCIPAL = Entry("livy.server.auth.kerberos.principal", null)
   val AUTH_KERBEROS_KEYTAB = Entry("livy.server.auth.kerberos.keytab", null)

--- a/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/LivyServer.scala
@@ -231,7 +231,7 @@ class LivyServer extends Logging {
       }
     })
 
-    _serverUrl = Some(s"http://${server.host}:${server.port}")
+    _serverUrl = Some(s"${server.protocol}://${server.host}:${server.port}")
     sys.props("livy.server.serverUrl") = _serverUrl.get
   }
 

--- a/server/src/main/scala/com/cloudera/livy/server/WebServer.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/WebServer.scala
@@ -28,18 +28,13 @@ import org.eclipse.jetty.util.ssl.SslContextFactory
 
 import com.cloudera.livy.{LivyConf, Logging}
 
-object WebServer {
-  val KeystoreKey = "livy.keystore"
-  val KeystorePasswordKey = "livy.keystore.password"
-}
-
 class WebServer(livyConf: LivyConf, var host: String, var port: Int) extends Logging {
   val server = new Server()
 
   server.setStopTimeout(1000)
   server.setStopAtShutdown(true)
 
-  val (connector, protocol) = Option(livyConf.get(WebServer.KeystoreKey)) match {
+  val (connector, protocol) = Option(livyConf.get(LivyConf.SSL_KEYSTORE)) match {
     case None =>
       (new ServerConnector(server), "http")
 
@@ -49,9 +44,9 @@ class WebServer(livyConf: LivyConf, var host: String, var port: Int) extends Log
 
       val sslContextFactory = new SslContextFactory()
       sslContextFactory.setKeyStorePath(keystore)
-      Option(livyConf.get(WebServer.KeystorePasswordKey))
+      Option(livyConf.get(LivyConf.SSL_KEYSTORE_PASSWORD))
         .foreach(sslContextFactory.setKeyStorePassword)
-      Option(livyConf.get(WebServer.KeystorePasswordKey))
+      Option(livyConf.get(LivyConf.SSL_KEY_PASSWORD))
         .foreach(sslContextFactory.setKeyManagerPassword)
 
       (new ServerConnector(server,


### PR DESCRIPTION
1. Livy server url is exposed as http URL even https is enabled, so we should handle this.
2. Livy server SSL keystore password and key password currently set to same configurations, which should be separated.

Verified locally.