### PR TITLE
LIVY-331. Fix flaky test (interactive session should not gc-ed if session timeout check is off)

### DIFF
--- a/server/src/test/scala/com/cloudera/livy/sessions/SessionManagerSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/sessions/SessionManagerSpec.scala
@@ -23,7 +23,7 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.{Failure, Try}
 
-import org.mockito.Mockito.{never, verify, when}
+import org.mockito.Mockito.{doReturn, never, verify, when}
 import org.scalatest.{FunSpec, Matchers}
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.mock.MockitoSugar.mock
@@ -83,7 +83,7 @@ class SessionManagerSpec extends FunSpec with Matchers with LivyBaseUnitTestSuit
     def testSessionGC(session: Session, sm: SessionManager[_, _]): Unit = {
 
       def changeStateAndCheck(s: SessionState)(fn: SessionManager[_, _] => Unit): Unit = {
-        when(session.state).thenReturn(s)
+        doReturn(s).when(session).state
         Await.result(sm.collectGarbage(), Duration.Inf)
         fn(sm)
       }


### PR DESCRIPTION
The fix is inspired by [here](http://stackoverflow.com/questions/11121772/when-i-run-mockito-test-occurs-wrongtypeofreturnvalue-exception).

Tried several times locally without the previous issue, will see if this issue still exist in travis test.