### PR TITLE
LIVY-249. Update livy-server script to include status command and return 1 on error

### DIFF
--- a/bin/livy-server
+++ b/bin/livy-server
@@ -108,7 +108,7 @@ start_livy_server() {
     if [ -f "$pid" ]; then
       TARGET_ID="$(cat "$pid")"
       if [[ $(ps -p "$TARGET_ID" -o comm=) =~ "java" ]]; then
-        echo "livy_server running as process $TARGET_ID.  Stop it first."
+        echo "livy-server running as process $TARGET_ID.  Stop it first."
         exit 1
       fi
     fi
@@ -125,6 +125,7 @@ start_livy_server() {
       tail -2 "$log" | sed 's/^/  /'
       echo "full log in $log"
       rm -rf "$pid"
+      exit 1
     fi
   fi
 }
@@ -146,13 +147,26 @@ case $option in
     if [ -f $pid ]; then
       TARGET_ID="$(cat "$pid")"
       if [[ $(ps -p "$TARGET_ID" -o comm=) =~ "java" ]]; then
-        echo "stopping livy_server"
+        echo "stopping livy-server"
         kill "$TARGET_ID" && rm -f "$pid"
       else
-        echo "no livy_server to stop"
+        echo "no livy-server to stop"
       fi
     else
-      echo "no livy_server to stop"
+      echo "no livy-server to stop"
+    fi
+    ;;
+
+  (status)
+    if [ -f "$pid" ]; then
+      TARGET_ID="$(cat "$pid")"
+      if [[ $(ps -p "$TARGET_ID" -o comm=) =~ "java" ]]; then
+        echo "livy-server is running (pid: $TARGET_ID)"
+      else
+        echo "livy-server is not running"
+      fi
+    else
+      echo "livy-server is not running"
     fi
     ;;
 


### PR DESCRIPTION
[LIVY-249](https://issues.cloudera.org/browse/LIVY-249)

Currently if `livy-server` fails to start it will still return `0` (success), this has been fixed. I also added a `livy-server status` command that will return a status output similar to that of `livy-server start` when it's already running or `livy-server stop` when it's already stopped. Lastly I updated all output text to use `livy-server` instead of `livy_server` since that's the actual name of the script.

Tested manually