### PR TITLE
Fix repo url in README to be available without login.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Livy is built using `Apache Maven`_. To check out and build Livy, run:
 
 .. code:: shell
 
-    git clone git@github.com:cloudera/livy.git
+    git clone https://github.com/cloudera/livy.git
     cd livy
     mvn package
 


### PR DESCRIPTION
Change git clone URL in README so that it is available without being logged in to github.