### PR TITLE
Expose session id and job id to the httpclient

### DIFF
--- a/api/src/main/java/com/cloudera/livy/JobHandle.java
+++ b/api/src/main/java/com/cloudera/livy/JobHandle.java
@@ -26,6 +26,11 @@ import java.util.concurrent.Future;
 public interface JobHandle<T> extends Future<T> {
 
   /**
+   * @return Return the current job id
+   */
+  long getJobId();	
+	
+  /**
    * Return the current state of the job.
    */
   State getState();

--- a/api/src/main/java/com/cloudera/livy/LivyClient.java
+++ b/api/src/main/java/com/cloudera/livy/LivyClient.java
@@ -27,6 +27,11 @@ import java.util.concurrent.Future;
 public interface LivyClient {
 
   /**
+   * @return The current session id 
+   */
+  int getSessionId();
+	
+  /**
    * Submits a job for asynchronous execution.
    *
    * @param job The job to execute.

--- a/api/src/test/java/com/cloudera/livy/TestClientFactory.java
+++ b/api/src/test/java/com/cloudera/livy/TestClientFactory.java
@@ -80,6 +80,11 @@ public class TestClientFactory implements LivyClientFactory {
     public Future<?> addFile(URI uri) {
       throw new UnsupportedOperationException();
     }
+    
+    @Override
+    public int getSessionId() {
+      throw new UnsupportedOperationException();	
+    }
 
 }
 

--- a/client-common/src/test/java/com/cloudera/livy/client/common/TestAbstractJobHandle.java
+++ b/client-common/src/test/java/com/cloudera/livy/client/common/TestAbstractJobHandle.java
@@ -87,6 +87,11 @@ public class TestAbstractJobHandle {
     public boolean cancel(boolean b) {
       throw new UnsupportedOperationException();
     }
+    
+    @Override
+    public long getJobId() {
+      throw new UnsupportedOperationException();
+    }
 
   }
 

--- a/client-http/src/main/java/com/cloudera/livy/client/http/HttpClient.java
+++ b/client-http/src/main/java/com/cloudera/livy/client/http/HttpClient.java
@@ -186,8 +186,8 @@ class HttpClient implements LivyClient {
     }
   }
 
-  // For testing.
-  int getSessionId() {
+  @Override
+  public int getSessionId() {
     return sessionId;
   }
 

--- a/client-http/src/main/java/com/cloudera/livy/client/http/JobHandleImpl.java
+++ b/client-http/src/main/java/com/cloudera/livy/client/http/JobHandleImpl.java
@@ -272,5 +272,10 @@ class JobHandleImpl<T> extends AbstractJobHandle<T> {
     }
 
   }
+  
+  @Override
+  public long getJobId() {
+    return jobId;
+  }
 
 }

--- a/rsc/src/main/java/com/cloudera/livy/rsc/JobHandleImpl.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/JobHandleImpl.java
@@ -102,5 +102,10 @@ class JobHandleImpl<T> extends AbstractJobHandle<T> {
       changeState(State.FAILED);
     }
   }
+  
+  @Override
+  public long getJobId() {
+    return -1;
+  }
 
 }

--- a/rsc/src/main/java/com/cloudera/livy/rsc/RSCClient.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/RSCClient.java
@@ -406,4 +406,9 @@ public class RSCClient implements LivyClient {
       replState = msg.state;
     }
   }
+
+  @Override
+  public int getSessionId() {
+    return -1;
+  }
 }

--- a/scala-api/src/test/scala/com/cloudera/livy/scalaapi/ScalaJobHandleTest.scala
+++ b/scala-api/src/test/scala/com/cloudera/livy/scalaapi/ScalaJobHandleTest.scala
@@ -188,4 +188,6 @@ private abstract class AbstractJobHandleStub[T] private[livy] extends JobHandle[
   override def cancel(mayInterruptIfRunning: Boolean): Boolean = false
 
   override def isDone: Boolean = true
+
+  override def getJobId: Long = -1
 }


### PR DESCRIPTION
When we use the http client we need to have access to the session id and job id in case of a unexpected shutdown.