### PR TITLE
LIVY-348. Improve the ACLs in Livy

### DIFF
--- a/client-http/src/test/scala/com/cloudera/livy/client/http/HttpClientSpec.scala
+++ b/client-http/src/test/scala/com/cloudera/livy/client/http/HttpClientSpec.scala
@@ -38,7 +38,7 @@ import org.scalatra.servlet.ScalatraListener
 import com.cloudera.livy._
 import com.cloudera.livy.client.common.{BufferUtils, Serializer}
 import com.cloudera.livy.client.common.HttpMessages._
-import com.cloudera.livy.server.WebServer
+import com.cloudera.livy.server.{AccessManager, WebServer}
 import com.cloudera.livy.server.interactive.{InteractiveSession, InteractiveSessionServlet}
 import com.cloudera.livy.server.recovery.SessionStore
 import com.cloudera.livy.sessions.{InteractiveSessionManager, SessionState, Spark}
@@ -268,7 +268,8 @@ private class HttpClientTestBootstrap extends LifeCycle {
     val conf = new LivyConf()
     val stateStore = mock(classOf[SessionStore])
     val sessionManager = new InteractiveSessionManager(conf, stateStore, Some(Seq.empty))
-    val servlet = new InteractiveSessionServlet(sessionManager, stateStore, conf) {
+    val accessManager = new AccessManager(conf)
+    val servlet = new InteractiveSessionServlet(sessionManager, stateStore, conf, accessManager) {
       override protected def createSession(req: HttpServletRequest): InteractiveSession = {
         val session = mock(classOf[InteractiveSession])
         val id = sessionManager.nextId()

--- a/server/src/main/scala/com/cloudera/livy/LivyConf.scala
+++ b/server/src/main/scala/com/cloudera/livy/LivyConf.scala
@@ -71,7 +71,7 @@ object LivyConf {
 
   val ACCESS_CONTROL_ENABLED = Entry("livy.server.access-control.enabled", false)
   // Allowed users to access Livy, by default any user is allowed to access Livy. If user want to
-  // limit the users who could access Livy, user should configure all the users with comma
+  // limit who could access Livy, user should list all the permitted users with comma
   // separated.
   val ACCESS_CONTROL_ALLOWED_USERS = Entry("livy.server.access-control.allowed-users", "*")
   val ACCESS_CONTROL_MODIFY_USERS = Entry("livy.server.access-control.modify-users", null)

--- a/server/src/main/scala/com/cloudera/livy/server/AccessFilter.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/AccessFilter.scala
@@ -21,9 +21,7 @@ package com.cloudera.livy.server
 import javax.servlet._
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
-import com.cloudera.livy.LivyConf
-
-class AccessFilter(livyConf: LivyConf) extends Filter {
+class AccessFilter(accessManager: AccessManager) extends Filter {
 
   override def init(filterConfig: FilterConfig): Unit = {}
 
@@ -32,11 +30,11 @@ class AccessFilter(livyConf: LivyConf) extends Filter {
                         chain: FilterChain): Unit = {
     val httpRequest = request.asInstanceOf[HttpServletRequest]
     val remoteUser = httpRequest.getRemoteUser
-    if (livyConf.allowedUsers.contains(remoteUser)) {
+    if (accessManager.isUserAllowed(remoteUser)) {
       chain.doFilter(request, response)
     } else {
       val httpServletResponse = response.asInstanceOf[HttpServletResponse]
-      httpServletResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED,
+      httpServletResponse.sendError(HttpServletResponse.SC_FORBIDDEN,
         "User not authorised to use Livy.")
     }
   }

--- a/server/src/main/scala/com/cloudera/livy/server/AccessManager.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/AccessManager.scala
@@ -1,0 +1,124 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.server
+
+import com.cloudera.livy.{LivyConf, Logging}
+
+private[livy] class AccessManager(conf: LivyConf) extends Logging {
+  private val aclsOn = conf.getBoolean(LivyConf.ACCESS_CONTROL_ENABLED)
+
+  private val WILDCARD_ACL = "*"
+
+  private val superUsers = conf.configToSeq(LivyConf.SUPERUSERS)
+  private val modifyUsers = conf.configToSeq(LivyConf.ACCESS_CONTROL_MODIFY_USERS)
+  private val viewUsers = conf.configToSeq(LivyConf.ACCESS_CONTROL_VIEW_USERS)
+  private val allowedUsers = conf.configToSeq(LivyConf.ACCESS_CONTROL_ALLOWED_USERS).toSet
+
+  private val viewAcls = (superUsers ++ modifyUsers ++ viewUsers).toSet
+  private val modifyAcls = (superUsers ++ modifyUsers).toSet
+  private val superAcls = superUsers.toSet
+
+  {
+    // Livy will load AccessFilter if acls is on. In this case if configured users (view users,
+    // modify users, super users) are not in the allowed user list, then AccessFilter check will
+    // be failed, so all these configured users should be included in the allowed users.
+    val notAllowedSuperUsers = superUsers.filter(!isUserAllowed(_))
+    if (notAllowedSuperUsers.nonEmpty && aclsOn) {
+      throw new IllegalArgumentException(
+        s"Users ${notAllowedSuperUsers.mkString(", ")} configured in " +
+        s"${LivyConf.SUPERUSERS.key} are not fully included in " +
+        s"${LivyConf.ACCESS_CONTROL_ALLOWED_USERS.key}, you should added them to the allowed user")
+    }
+
+    val notAllowedViewUsers = viewUsers.filter(!isUserAllowed(_))
+    if (notAllowedViewUsers.nonEmpty && aclsOn) {
+      throw new IllegalArgumentException(
+        s"Users ${notAllowedViewUsers.mkString(", ")} configured in " +
+        s"${LivyConf.ACCESS_CONTROL_VIEW_USERS.key} are not fully included in " +
+        s"${LivyConf.ACCESS_CONTROL_ALLOWED_USERS.key}, you should added them to the allowed user")
+    }
+
+   val notAllowedModifyUsers = modifyUsers.filter(!isUserAllowed(_))
+    if (notAllowedModifyUsers.nonEmpty && aclsOn) {
+      throw new IllegalArgumentException(
+        s"Users ${notAllowedViewUsers.mkString(", ")} configured in " +
+        s"${LivyConf.ACCESS_CONTROL_MODIFY_USERS.key} are not fully included in " +
+        s"${LivyConf.ACCESS_CONTROL_ALLOWED_USERS.key}, you should added them to the allowed user")
+    }
+  }
+
+  info(s"AccessControlManager acls ${if (aclsOn) "enabled" else "disabled"};" +
+    s"users with view permission: ${viewUsers.mkString(", ")};" +
+    s"users with modify permission: ${modifyUsers.mkString(", ")};" +
+    s"users with super permission: ${superUsers.mkString(", ")}")
+
+  /**
+   * Check whether the given user has view access to the REST APIs.
+   */
+  def checkViewPermissions(user: String): Boolean = {
+    debug(s"user=$user aclsOn=$aclsOn viewAcls=${viewAcls.mkString(", ")}")
+    if (!aclsOn || user == null || viewAcls.contains(user) || viewAcls.contains(WILDCARD_ACL)) {
+      true
+    } else {
+      false
+    }
+  }
+
+  /**
+   * Check whether the give user has modification access to the REST APIs.
+   */
+  def checkModifyPermissions(user: String): Boolean = {
+    debug(s"user=$user aclsOn=$aclsOn modifyAcls=${modifyAcls.mkString(", ")}")
+    if (!aclsOn || user == null || modifyAcls.contains(user) || modifyAcls.contains(WILDCARD_ACL)) {
+      true
+    } else {
+      false
+    }
+  }
+
+  /**
+   * Check whether the give user has super access to the REST APIs. This will always be checked
+   * no matter acls is on or off.
+   */
+  def checkSuperUser(user: String): Boolean = {
+    debug(s"user=$user aclsOn=$aclsOn superAcls=${superAcls.mkString(", ")}")
+    if (user == null || superUsers.contains(user) || superUsers.contains(WILDCARD_ACL)) {
+      true
+    } else {
+      false
+    }
+  }
+
+  /**
+   * Check whether the given user has the permission to access REST APIs.
+   */
+  def isUserAllowed(user: String): Boolean = {
+    debug(s"user=$user aclsOn=$aclsOn, allowedUsers=${allowedUsers.mkString(", ")}")
+    if (!aclsOn || allowedUsers.contains(user) || allowedUsers.contains(WILDCARD_ACL)) {
+      true
+    } else {
+      false
+    }
+  }
+
+  /**
+   * Check whether access control is enabled or not.
+   */
+  def isAccessControlOn: Boolean = aclsOn
+}

--- a/server/src/main/scala/com/cloudera/livy/server/AccessManager.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/AccessManager.scala
@@ -34,12 +34,12 @@ private[livy] class AccessManager(conf: LivyConf) extends Logging {
   private val modifyAcls = (superUsers ++ modifyUsers).toSet
   private val superAcls = superUsers.toSet
 
-  {
+  if (aclsOn) {
     // Livy will load AccessFilter if acls is on. In this case if configured users (view users,
     // modify users, super users) are not in the allowed user list, then AccessFilter check will
     // be failed, so all these configured users should be included in the allowed users.
     val notAllowedSuperUsers = superUsers.filter(!isUserAllowed(_))
-    if (notAllowedSuperUsers.nonEmpty && aclsOn) {
+    if (notAllowedSuperUsers.nonEmpty) {
       throw new IllegalArgumentException(
         s"Users ${notAllowedSuperUsers.mkString(", ")} configured in " +
         s"${LivyConf.SUPERUSERS.key} are not fully included in " +
@@ -47,7 +47,7 @@ private[livy] class AccessManager(conf: LivyConf) extends Logging {
     }
 
     val notAllowedViewUsers = viewUsers.filter(!isUserAllowed(_))
-    if (notAllowedViewUsers.nonEmpty && aclsOn) {
+    if (notAllowedViewUsers.nonEmpty) {
       throw new IllegalArgumentException(
         s"Users ${notAllowedViewUsers.mkString(", ")} configured in " +
         s"${LivyConf.ACCESS_CONTROL_VIEW_USERS.key} are not fully included in " +
@@ -55,7 +55,7 @@ private[livy] class AccessManager(conf: LivyConf) extends Logging {
     }
 
    val notAllowedModifyUsers = modifyUsers.filter(!isUserAllowed(_))
-    if (notAllowedModifyUsers.nonEmpty && aclsOn) {
+    if (notAllowedModifyUsers.nonEmpty) {
       throw new IllegalArgumentException(
         s"Users ${notAllowedViewUsers.mkString(", ")} configured in " +
         s"${LivyConf.ACCESS_CONTROL_MODIFY_USERS.key} are not fully included in " +
@@ -110,7 +110,8 @@ private[livy] class AccessManager(conf: LivyConf) extends Logging {
    */
   def isUserAllowed(user: String): Boolean = {
     debug(s"user=$user aclsOn=$aclsOn, allowedUsers=${allowedUsers.mkString(", ")}")
-    if (!aclsOn || allowedUsers.contains(user) || allowedUsers.contains(WILDCARD_ACL)) {
+    if (!aclsOn || user == null || allowedUsers.contains(user) ||
+      allowedUsers.contains(WILDCARD_ACL)) {
       true
     } else {
       false

--- a/server/src/main/scala/com/cloudera/livy/server/batch/BatchSessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/batch/BatchSessionServlet.scala
@@ -21,7 +21,7 @@ package com.cloudera.livy.server.batch
 import javax.servlet.http.HttpServletRequest
 
 import com.cloudera.livy.LivyConf
-import com.cloudera.livy.server.SessionServlet
+import com.cloudera.livy.server.{AccessManager, SessionServlet}
 import com.cloudera.livy.server.recovery.SessionStore
 import com.cloudera.livy.sessions.BatchSessionManager
 import com.cloudera.livy.utils.AppInfo
@@ -36,8 +36,9 @@ case class BatchSessionView(
 class BatchSessionServlet(
     sessionManager: BatchSessionManager,
     sessionStore: SessionStore,
-    livyConf: LivyConf)
-  extends SessionServlet(sessionManager, livyConf)
+    livyConf: LivyConf,
+    accessManager: AccessManager)
+  extends SessionServlet(sessionManager, livyConf, accessManager)
 {
 
   override protected def createSession(req: HttpServletRequest): BatchSession = {
@@ -51,7 +52,7 @@ class BatchSessionServlet(
       session: BatchSession,
       req: HttpServletRequest): Any = {
     val logs =
-      if (hasAccess(session.owner, req)) {
+      if (hasViewAccess(session.owner, req)) {
         val lines = session.logLines()
 
         val size = 10

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/InteractiveSessionServlet.scala
@@ -32,8 +32,7 @@ import org.scalatra.servlet.FileUploadSupport
 import com.cloudera.livy.{ExecuteRequest, JobHandle, LivyConf, Logging}
 import com.cloudera.livy.client.common.HttpMessages
 import com.cloudera.livy.client.common.HttpMessages._
-import com.cloudera.livy.rsc.driver.Statement
-import com.cloudera.livy.server.SessionServlet
+import com.cloudera.livy.server.{AccessManager, SessionServlet}
 import com.cloudera.livy.server.recovery.SessionStore
 import com.cloudera.livy.sessions._
 
@@ -42,8 +41,9 @@ object InteractiveSessionServlet extends Logging
 class InteractiveSessionServlet(
     sessionManager: InteractiveSessionManager,
     sessionStore: SessionStore,
-    livyConf: LivyConf)
-  extends SessionServlet(sessionManager, livyConf)
+    livyConf: LivyConf,
+    accessManager: AccessManager)
+  extends SessionServlet(sessionManager, livyConf, accessManager)
   with SessionHeartbeatNotifier[InteractiveSession, InteractiveRecoveryMetadata]
   with FileUploadSupport
 {
@@ -67,7 +67,7 @@ class InteractiveSessionServlet(
       session: InteractiveSession,
       req: HttpServletRequest): Any = {
     val logs =
-      if (hasAccess(session.owner, req)) {
+      if (hasViewAccess(session.owner, req)) {
         Option(session.logLines())
           .map { lines =>
             val size = 10
@@ -86,21 +86,21 @@ class InteractiveSessionServlet(
   }
 
   post("/:id/stop") {
-    withSession { session =>
+    withModifyAccessSession { session =>
       Await.ready(session.stop(), Duration.Inf)
       NoContent()
     }
   }
 
   post("/:id/interrupt") {
-    withSession { session =>
+    withModifyAccessSession { session =>
       Await.ready(session.interrupt(), Duration.Inf)
       Ok(Map("msg" -> "interrupted"))
     }
   }
 
   get("/:id/statements") {
-    withSession { session =>
+    withViewAccessSession { session =>
       val statements = session.statements
       val from = params.get("from").map(_.toInt).getOrElse(0)
       val size = params.get("size").map(_.toInt).getOrElse(statements.length)
@@ -113,7 +113,7 @@ class InteractiveSessionServlet(
   }
 
   val getStatement = get("/:id/statements/:statementId") {
-    withSession { session =>
+    withViewAccessSession { session =>
       val statementId = params("statementId").toInt
 
       session.getStatement(statementId).getOrElse(NotFound("Statement not found"))
@@ -121,7 +121,7 @@ class InteractiveSessionServlet(
   }
 
   jpost[ExecuteRequest]("/:id/statements") { req =>
-    withSession { session =>
+    withModifyAccessSession { session =>
       val statement = session.executeStatement(req)
 
       Created(statement,
@@ -133,7 +133,7 @@ class InteractiveSessionServlet(
   }
 
   post("/:id/statements/:statementId/cancel") {
-    withSession { session =>
+    withModifyAccessSession { session =>
       val statementId = params("statementId")
       session.cancelStatement(statementId.toInt)
       Ok(Map("msg" -> "canceled"))
@@ -144,14 +144,14 @@ class InteractiveSessionServlet(
   // has access to the session, so even though it returns the same data, it behaves differently
   // from get("/:id").
   post("/:id/connect") {
-    withSession { session =>
+    withModifyAccessSession { session =>
       session.recordActivity()
       Ok(clientSessionView(session, request))
     }
   }
 
   jpost[SerializedJob]("/:id/submit-job") { req =>
-    withSession { session =>
+    withModifyAccessSession { session =>
       try {
       require(req.job != null && req.job.length > 0, "no job provided.")
       val jobId = session.submitJob(req.job)
@@ -165,7 +165,7 @@ class InteractiveSessionServlet(
   }
 
   jpost[SerializedJob]("/:id/run-job") { req =>
-    withSession { session =>
+    withModifyAccessSession { session =>
       require(req.job != null && req.job.length > 0, "no job provided.")
       val jobId = session.runJob(req.job)
       Created(new JobStatus(jobId, JobHandle.State.SENT, null, null))
@@ -173,7 +173,7 @@ class InteractiveSessionServlet(
   }
 
   post("/:id/upload-jar") {
-    withSession { lsession =>
+    withModifyAccessSession { lsession =>
       fileParams.get("jar") match {
         case Some(file) =>
           lsession.addJar(file.getInputStream, file.name)
@@ -184,7 +184,7 @@ class InteractiveSessionServlet(
   }
 
   post("/:id/upload-pyfile") {
-    withSession { lsession =>
+    withModifyAccessSession { lsession =>
       fileParams.get("file") match {
         case Some(file) =>
           lsession.addJar(file.getInputStream, file.name)
@@ -195,7 +195,7 @@ class InteractiveSessionServlet(
   }
 
   post("/:id/upload-file") {
-    withSession { lsession =>
+    withModifyAccessSession { lsession =>
       fileParams.get("file") match {
         case Some(file) =>
           lsession.addFile(file.getInputStream, file.name)
@@ -206,13 +206,13 @@ class InteractiveSessionServlet(
   }
 
   jpost[AddResource]("/:id/add-jar") { req =>
-    withSession { lsession =>
+    withModifyAccessSession { lsession =>
       addJarOrPyFile(req, lsession)
     }
   }
 
   jpost[AddResource]("/:id/add-pyfile") { req =>
-    withSession { lsession =>
+    withModifyAccessSession { lsession =>
       lsession.kind match {
         case PySpark() | PySpark3() => addJarOrPyFile(req, lsession)
         case _ => BadRequest("Only supported for pyspark sessions.")
@@ -221,21 +221,21 @@ class InteractiveSessionServlet(
   }
 
   jpost[AddResource]("/:id/add-file") { req =>
-    withSession { lsession =>
+    withModifyAccessSession { lsession =>
       val uri = new URI(req.uri)
       lsession.addFile(uri)
     }
   }
 
   get("/:id/jobs/:jobid") {
-    withSession { lsession =>
+    withViewAccessSession { lsession =>
       val jobId = params("jobid").toLong
       Ok(lsession.jobStatus(jobId))
     }
   }
 
   post("/:id/jobs/:jobid/cancel") {
-    withSession { lsession =>
+    withModifyAccessSession { lsession =>
       val jobId = params("jobid").toLong
       lsession.cancelJob(jobId)
     }

--- a/server/src/main/scala/com/cloudera/livy/server/interactive/SessionHeartbeat.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/interactive/SessionHeartbeat.scala
@@ -64,8 +64,15 @@ trait SessionHeartbeatNotifier[S <: Session with SessionHeartbeat, R <: Recovery
     }
   }
 
-  abstract override protected def withSession(fn: (S => Any)): Any = {
-    super.withSession { s =>
+  abstract override protected def withViewAccessSession(fn: (S => Any)): Any = {
+    super.withViewAccessSession { s =>
+      s.heartbeat()
+      fn(s)
+    }
+  }
+
+  abstract override protected def withModifyAccessSession(fn: (S) => Any): Any = {
+    super.withModifyAccessSession { s =>
       s.heartbeat()
       fn(s)
     }

--- a/server/src/test/scala/com/cloudera/livy/server/AccessManagerSuite.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/AccessManagerSuite.scala
@@ -94,6 +94,7 @@ class AccessManagerSuite extends FunSuite with Matchers with LivyBaseUnitTestSui
     superUsers.foreach { u => accessManager.isUserAllowed(u) should be (true) }
 
     accessManager.isUserAllowed("anyUser") should be (true)
+    accessManager.isUserAllowed(null) should be (true)
   }
 
   test("configured users are not in the allowed list") {

--- a/server/src/test/scala/com/cloudera/livy/server/AccessManagerSuite.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/AccessManagerSuite.scala
@@ -1,0 +1,120 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.server
+
+import org.scalatest.{FunSuite, Matchers}
+
+import com.cloudera.livy.{LivyBaseUnitTestSuite, LivyConf}
+
+class AccessManagerSuite extends FunSuite with Matchers with LivyBaseUnitTestSuite {
+  import LivyConf._
+
+  private val viewUsers = Seq("user1", "user2", "user3")
+  private val modifyUsers = Seq("user4", "user5")
+  private val superUsers = Seq("user6", "user7")
+
+  test("access permission") {
+    val conf = new LivyConf()
+      .set(ACCESS_CONTROL_ENABLED, true)
+      .set(ACCESS_CONTROL_VIEW_USERS, viewUsers.mkString(","))
+      .set(ACCESS_CONTROL_MODIFY_USERS, modifyUsers.mkString(","))
+      .set(SUPERUSERS, superUsers.mkString(","))
+
+    val accessManager = new AccessManager(conf)
+    accessManager.isAccessControlOn should be (true)
+
+    // check view access
+    viewUsers.foreach { u => accessManager.checkViewPermissions(u) should be (true) }
+    modifyUsers.foreach { u => accessManager.checkViewPermissions(u) should be (true) }
+    superUsers.foreach { u => accessManager.checkViewPermissions(u) should be (true) }
+
+    accessManager.checkViewPermissions(null) should be (true)
+    accessManager.checkViewPermissions("user8") should be (false)
+
+    // check modify access
+    viewUsers.foreach { u => accessManager.checkModifyPermissions(u) should be (false) }
+    modifyUsers.foreach { u => accessManager.checkModifyPermissions(u) should be (true) }
+    superUsers.foreach { u => accessManager.checkModifyPermissions(u) should be (true) }
+
+    accessManager.checkModifyPermissions(null) should be (true)
+    accessManager.checkModifyPermissions("user8") should be (false)
+
+    // check super access
+    viewUsers.foreach { u => accessManager.checkSuperUser(u) should be (false) }
+    modifyUsers.foreach { u => accessManager.checkSuperUser(u) should be (false) }
+    superUsers.foreach { u => accessManager.checkSuperUser(u) should be (true) }
+
+    accessManager.checkSuperUser(null) should be (true)
+    accessManager.checkSuperUser("user8") should be (false)
+  }
+
+  test("wildcard access permission") {
+    val conf = new LivyConf()
+      .set(ACCESS_CONTROL_ENABLED, true)
+      .set(ACCESS_CONTROL_VIEW_USERS, "*")
+      .set(ACCESS_CONTROL_MODIFY_USERS, "*")
+      .set(SUPERUSERS, "*")
+
+    val accessManager = new AccessManager(conf)
+    accessManager.isAccessControlOn should be (true)
+
+    accessManager.checkViewPermissions("anyUser") should be (true)
+    accessManager.checkModifyPermissions("anyUser") should be (true)
+    accessManager.checkSuperUser("anyUser") should be (true)
+  }
+
+  test("default allowed users") {
+    val conf = new LivyConf()
+      .set(ACCESS_CONTROL_ENABLED, true)
+      .set(ACCESS_CONTROL_VIEW_USERS, viewUsers.mkString(","))
+      .set(ACCESS_CONTROL_MODIFY_USERS, modifyUsers.mkString(","))
+      .set(SUPERUSERS, superUsers.mkString(","))
+
+    val accessManager = new AccessManager(conf)
+
+    // check if configured users are allowed
+    viewUsers.foreach { u => accessManager.isUserAllowed(u) should be (true) }
+    modifyUsers.foreach { u => accessManager.isUserAllowed(u) should be (true) }
+    superUsers.foreach { u => accessManager.isUserAllowed(u) should be (true) }
+
+    accessManager.isUserAllowed("anyUser") should be (true)
+  }
+
+  test("configured users are not in the allowed list") {
+    val conf = new LivyConf()
+      .set(ACCESS_CONTROL_ENABLED, true)
+      .set(ACCESS_CONTROL_VIEW_USERS, viewUsers.mkString(","))
+      .set(ACCESS_CONTROL_MODIFY_USERS, modifyUsers.mkString(","))
+      .set(SUPERUSERS, superUsers.mkString(","))
+      .set(ACCESS_CONTROL_ALLOWED_USERS, "user1,user4,user6")
+
+    // AccessManager will throw an exception if acls in on but not all the configured users are
+    // in the allowed list.
+    intercept[IllegalArgumentException](new AccessManager(conf))
+
+    // If acls is off, then allowed user check will not be enabled.
+    conf.set(ACCESS_CONTROL_ENABLED, false)
+    val accessManager = new AccessManager(conf)
+    viewUsers.foreach { u => accessManager.isUserAllowed(u) should be (true) }
+    modifyUsers.foreach { u => accessManager.isUserAllowed(u) should be (true) }
+    superUsers.foreach { u => accessManager.isUserAllowed(u) should be (true) }
+
+    accessManager.isUserAllowed("anyUser") should be (true)
+  }
+}

--- a/server/src/test/scala/com/cloudera/livy/server/BaseSessionServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/BaseSessionServletSpec.scala
@@ -43,18 +43,26 @@ abstract class BaseSessionServletSpec[S <: Session, R <: RecoveryMetadata]
   /** Name of the admin user. */
   protected val ADMIN = "__admin__"
 
+  private val VIEW_USER = "__view__"
+
+  private val MODIFY_USER = "__modify__"
+
   /** Create headers that identify a specific user in tests. */
   protected def makeUserHeaders(user: String): Map[String, String] = {
     defaultHeaders ++ Map(BaseSessionServletSpec.REMOTE_USER_HEADER -> user)
   }
 
   protected val adminHeaders = makeUserHeaders(ADMIN)
+  protected val viewUserHeaders = makeUserHeaders(VIEW_USER)
+  protected val modifyUserHeaders = makeUserHeaders(MODIFY_USER)
 
   /** Create a LivyConf with impersonation enabled and a superuser. */
   protected def createConf(): LivyConf = {
     new LivyConf()
       .set(LivyConf.IMPERSONATION_ENABLED, true)
       .set(LivyConf.SUPERUSERS, ADMIN)
+      .set(LivyConf.ACCESS_CONTROL_VIEW_USERS, VIEW_USER)
+      .set(LivyConf.ACCESS_CONTROL_MODIFY_USERS, MODIFY_USER)
       .set(LivyConf.LOCAL_FS_WHITELIST, sys.props("java.io.tmpdir"))
   }
 

--- a/server/src/test/scala/com/cloudera/livy/server/batch/BatchServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/batch/BatchServletSpec.scala
@@ -30,7 +30,7 @@ import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar.mock
 
 import com.cloudera.livy.Utils
-import com.cloudera.livy.server.BaseSessionServletSpec
+import com.cloudera.livy.server.{AccessManager, BaseSessionServletSpec}
 import com.cloudera.livy.server.recovery.SessionStore
 import com.cloudera.livy.sessions.{BatchSessionManager, SessionState}
 import com.cloudera.livy.utils.AppInfo
@@ -55,10 +55,12 @@ class BatchServletSpec extends BaseSessionServletSpec[BatchSession, BatchRecover
   override def createServlet(): BatchSessionServlet = {
     val livyConf = createConf()
     val sessionStore = mock[SessionStore]
+    val accessManager = new AccessManager(livyConf)
     new BatchSessionServlet(
       new BatchSessionManager(livyConf, sessionStore, Some(Seq.empty)),
       sessionStore,
-      livyConf)
+      livyConf,
+      accessManager)
   }
 
   describe("Batch Servlet") {

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionServletSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/InteractiveSessionServletSpec.scala
@@ -35,6 +35,7 @@ import org.scalatest.mock.MockitoSugar.mock
 import com.cloudera.livy.{ExecuteRequest, LivyConf}
 import com.cloudera.livy.client.common.HttpMessages.SessionInfo
 import com.cloudera.livy.rsc.driver.{Statement, StatementState}
+import com.cloudera.livy.server.AccessManager
 import com.cloudera.livy.server.recovery.SessionStore
 import com.cloudera.livy.sessions._
 import com.cloudera.livy.utils.AppInfo
@@ -45,8 +46,9 @@ class InteractiveSessionServletSpec extends BaseInteractiveServletSpec {
 
   class MockInteractiveSessionServlet(
       sessionManager: InteractiveSessionManager,
-      conf: LivyConf)
-    extends InteractiveSessionServlet(sessionManager, mock[SessionStore], conf) {
+      conf: LivyConf,
+      accessManager: AccessManager)
+    extends InteractiveSessionServlet(sessionManager, mock[SessionStore], conf, accessManager) {
 
     private var statements = IndexedSeq[Statement]()
 
@@ -95,7 +97,8 @@ class InteractiveSessionServletSpec extends BaseInteractiveServletSpec {
   override def createServlet(): InteractiveSessionServlet = {
     val conf = createConf()
     val sessionManager = new InteractiveSessionManager(conf, mock[SessionStore], Some(Seq.empty))
-    new MockInteractiveSessionServlet(sessionManager, conf)
+    val accessManager = new AccessManager(conf)
+    new MockInteractiveSessionServlet(sessionManager, conf, accessManager)
   }
 
   it("should setup and tear down an interactive session") {

--- a/server/src/test/scala/com/cloudera/livy/server/interactive/JobApiSpec.scala
+++ b/server/src/test/scala/com/cloudera/livy/server/interactive/JobApiSpec.scala
@@ -34,7 +34,7 @@ import org.scalatest.mock.MockitoSugar.mock
 import com.cloudera.livy.{Job, JobHandle}
 import com.cloudera.livy.client.common.{BufferUtils, Serializer}
 import com.cloudera.livy.client.common.HttpMessages._
-import com.cloudera.livy.server.RemoteUserOverride
+import com.cloudera.livy.server.{AccessManager, RemoteUserOverride}
 import com.cloudera.livy.server.recovery.SessionStore
 import com.cloudera.livy.sessions.{InteractiveSessionManager, SessionState}
 import com.cloudera.livy.test.jobs.{Echo, GetCurrentUser}
@@ -49,7 +49,9 @@ class JobApiSpec extends BaseInteractiveServletSpec {
     val conf = createConf()
     val sessionStore = mock[SessionStore]
     val sessionManager = new InteractiveSessionManager(conf, sessionStore, Some(Seq.empty))
-    new InteractiveSessionServlet(sessionManager, sessionStore, conf) with RemoteUserOverride
+    val accessManager = new AccessManager(conf)
+    new InteractiveSessionServlet(sessionManager, sessionStore, conf, accessManager)
+      with RemoteUserOverride
   }
 
   def withSessionId(desc: String)(fn: (Int) => Unit): Unit = {


### PR DESCRIPTION
This PR propose to improve current Livy's access control mechanism with fine-grained control:

1. If `livy.server.access-control.enabled` is disabled, which means ACLs is disabled, any user could send any request to Livy.
2. If `livy.server.access-control.enabled` is enabled, then this ACL mechanism divides users into 3 groups:
    1. view accessible users: users could get session, statement data, but cannot POST any queries.
    2. modify accessible users: users could submit new statements, kill sessions.
    3. super users: this is the same as previous, super user could impersonate any user.
   
    In the meanwhile, modify accessible users automatically have the view accessibility, and super user has all the permissions.

Also add new configuration `livy.server.access-control.allowed-users`, this is the same as previous `livy.server.access-control.users`, when ACLs is enabled only users in the allowed list could issue REST queries to Livy server, other users will get 403.

Please review and comment.


