### PR TITLE
LIVY-351. Remove the use of guava api in Livy

### DIFF
--- a/rsc/src/main/java/com/cloudera/livy/rsc/driver/StatementState.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/driver/StatementState.java
@@ -20,7 +20,6 @@ package com.cloudera.livy.rsc.driver;
 import java.util.*;
 
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,7 +79,8 @@ public enum StatementState {
 
   static void validate(StatementState from, StatementState to) {
     LOG.debug("{} -> {}", from, to);
-
-    Preconditions.checkState(isValid(from, to), "Illegal Transition: %s -> %s", from, to);
+    if (!isValid(from, to)) {
+      throw new IllegalStateException("Illegal Transition: " + from + " -> " + to);
+    }
   }
 }


### PR DESCRIPTION
This will lead to ClassNotFound issue when running in client mode. Since Spark doesn't have guava dependency.