### PR TITLE
LIVY-349. Fix two SparkR test issue regarding to different versions of R

### DIFF
--- a/repl/src/test/scala/com/cloudera/livy/repl/SparkRInterpreterSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/SparkRInterpreterSpec.scala
@@ -84,10 +84,10 @@ class SparkRInterpreterSpec extends BaseInterpreterSpec {
 
   it should "report an error if accessing an unknown variable" in withInterpreter { interpreter =>
     val response = interpreter.execute("x")
-    response should equal(Interpreter.ExecuteError(
-      "Error",
-      """[1] "Error in eval(expr, envir, enclos): object 'x' not found""""
-    ))
+    assert(response.isInstanceOf[Interpreter.ExecuteError])
+    val errorResponse = response.asInstanceOf[Interpreter.ExecuteError]
+    errorResponse.ename should be ("Error")
+    assert(errorResponse.evalue.contains("object 'x' not found"))
   }
 
 

--- a/repl/src/test/scala/com/cloudera/livy/repl/SparkRSessionSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/SparkRSessionSpec.scala
@@ -132,15 +132,11 @@ class SparkRSessionSpec extends BaseSessionSpec {
     statement.id should equal (0)
 
     val result = parse(statement.output)
-    val expectedResult = Extraction.decompose(Map(
-      "status" -> "error",
-      "execution_count" -> 0,
-      "ename" -> "Error",
-      "evalue" -> "[1] \"Error in eval(expr, envir, enclos): object 'x' not found\"",
-      "traceback" -> List()
-    ))
-
-    result should equal (expectedResult)
+    (result \ "status").extract[String] should be ("error")
+    (result \ "execution_count").extract[Int] should be (0)
+    (result \ "ename").extract[String] should be ("Error")
+    assert((result \ "evalue").extract[String].contains("object 'x' not found"))
+    (result \ "traceback").extract[List[String]] should be (List())
   }
 
 }


### PR DESCRIPTION
This is caused by the difference of error output with different versions of R.