### PR TITLE
LIVY-358. Make JettyServer Http request and response header size configurable

### DIFF
--- a/server/src/main/scala/com/cloudera/livy/LivyConf.scala
+++ b/server/src/main/scala/com/cloudera/livy/LivyConf.scala
@@ -62,12 +62,13 @@ object LivyConf {
 
   val SERVER_HOST = Entry("livy.server.host", "0.0.0.0")
   val SERVER_PORT = Entry("livy.server.port", 8998)
-  val CSRF_PROTECTION = LivyConf.Entry("livy.server.csrf-protection.enabled", false)
 
   val UI_ENABLED = Entry("livy.ui.enabled", true)
 
-  val HTTP_REQUEST_HEADER_SIZE = Entry("livy.http.request.header.size", 131072)
-  val HTTP_RESPONSE_HEADER_SIZE = Entry("livy.http.response.header.size", 131072)
+  val REQUEST_HEADER_SIZE = Entry("livy.server.request-header.size", 131072)
+  val RESPONSE_HEADER_SIZE = Entry("livy.server.response-header.size", 131072)
+
+  val CSRF_PROTECTION = Entry("livy.server.csrf-protection.enabled", false)
 
   val IMPERSONATION_ENABLED = Entry("livy.impersonation.enabled", false)
   val SUPERUSERS = Entry("livy.superusers", null)
@@ -86,14 +87,10 @@ object LivyConf {
 
   val HEARTBEAT_WATCHDOG_INTERVAL = Entry("livy.server.heartbeat-watchdog.interval", "1m")
 
-  val LAUNCH_KERBEROS_PRINCIPAL =
-    LivyConf.Entry("livy.server.launch.kerberos.principal", null)
-  val LAUNCH_KERBEROS_KEYTAB =
-    LivyConf.Entry("livy.server.launch.kerberos.keytab", null)
-  val LAUNCH_KERBEROS_REFRESH_INTERVAL =
-    LivyConf.Entry("livy.server.launch.kerberos.refresh-interval", "1h")
-  val KINIT_FAIL_THRESHOLD =
-    LivyConf.Entry("livy.server.launch.kerberos.kinit-fail-threshold", 5)
+  val LAUNCH_KERBEROS_PRINCIPAL = Entry("livy.server.launch.kerberos.principal", null)
+  val LAUNCH_KERBEROS_KEYTAB = Entry("livy.server.launch.kerberos.keytab", null)
+  val LAUNCH_KERBEROS_REFRESH_INTERVAL = Entry("livy.server.launch.kerberos.refresh-interval", "1h")
+  val KINIT_FAIL_THRESHOLD = Entry("livy.server.launch.kerberos.kinit-fail-threshold", 5)
 
   /**
    * Recovery mode of Livy. Possible values:

--- a/server/src/main/scala/com/cloudera/livy/LivyConf.scala
+++ b/server/src/main/scala/com/cloudera/livy/LivyConf.scala
@@ -66,6 +66,9 @@ object LivyConf {
 
   val UI_ENABLED = Entry("livy.ui.enabled", true)
 
+  val HTTP_REQUEST_HEADER_SIZE = Entry("livy.http.request.header.size", 131072)
+  val HTTP_RESPONSE_HEADER_SIZE = Entry("livy.http.response.header.size", 131072)
+
   val IMPERSONATION_ENABLED = Entry("livy.impersonation.enabled", false)
   val SUPERUSERS = Entry("livy.superusers", null)
 

--- a/server/src/main/scala/com/cloudera/livy/server/WebServer.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/WebServer.scala
@@ -34,12 +34,20 @@ class WebServer(livyConf: LivyConf, var host: String, var port: Int) extends Log
   server.setStopTimeout(1000)
   server.setStopAtShutdown(true)
 
+  val requestHeaderSize = livyConf.getInt(LivyConf.HTTP_REQUEST_HEADER_SIZE)
+  val responseHeaderSize = livyConf.getInt(LivyConf.HTTP_RESPONSE_HEADER_SIZE)
+
   val (connector, protocol) = Option(livyConf.get(LivyConf.SSL_KEYSTORE)) match {
     case None =>
-      (new ServerConnector(server), "http")
+      val http = new HttpConfiguration()
+      http.setRequestHeaderSize(requestHeaderSize)
+      http.setResponseHeaderSize(responseHeaderSize)
+      (new ServerConnector(server, new HttpConnectionFactory(http)), "http")
 
     case Some(keystore) =>
       val https = new HttpConfiguration()
+      https.setRequestHeaderSize(requestHeaderSize)
+      https.setResponseHeaderSize(responseHeaderSize)
       https.addCustomizer(new SecureRequestCustomizer())
 
       val sslContextFactory = new SslContextFactory()

--- a/server/src/main/scala/com/cloudera/livy/server/WebServer.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/WebServer.scala
@@ -34,20 +34,17 @@ class WebServer(livyConf: LivyConf, var host: String, var port: Int) extends Log
   server.setStopTimeout(1000)
   server.setStopAtShutdown(true)
 
-  val requestHeaderSize = livyConf.getInt(LivyConf.HTTP_REQUEST_HEADER_SIZE)
-  val responseHeaderSize = livyConf.getInt(LivyConf.HTTP_RESPONSE_HEADER_SIZE)
-
   val (connector, protocol) = Option(livyConf.get(LivyConf.SSL_KEYSTORE)) match {
     case None =>
       val http = new HttpConfiguration()
-      http.setRequestHeaderSize(requestHeaderSize)
-      http.setResponseHeaderSize(responseHeaderSize)
+      http.setRequestHeaderSize(livyConf.getInt(LivyConf.REQUEST_HEADER_SIZE))
+      http.setResponseHeaderSize(livyConf.getInt(LivyConf.RESPONSE_HEADER_SIZE))
       (new ServerConnector(server, new HttpConnectionFactory(http)), "http")
 
     case Some(keystore) =>
       val https = new HttpConfiguration()
-      https.setRequestHeaderSize(requestHeaderSize)
-      https.setResponseHeaderSize(responseHeaderSize)
+      https.setRequestHeaderSize(livyConf.getInt(LivyConf.REQUEST_HEADER_SIZE))
+      https.setResponseHeaderSize(livyConf.getInt(LivyConf.RESPONSE_HEADER_SIZE))
       https.addCustomizer(new SecureRequestCustomizer())
 
       val sslContextFactory = new SslContextFactory()


### PR DESCRIPTION
This patch is based on #266 , mainly to fix header size too large problem in spnego enabled scenario. 

1. Increase the default header size.
2. Make header size configurable.