### PR TITLE
LIVY-245. Add support shared variables across Jobs

### DIFF
--- a/api/src/main/java/com/cloudera/livy/JobContext.java
+++ b/api/src/main/java/com/cloudera/livy/JobContext.java
@@ -18,9 +18,7 @@
 package com.cloudera.livy;
 
 import java.io.File;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.NoSuchElementException;
 
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SQLContext;
@@ -46,6 +44,15 @@ public interface JobContext {
 
   /** Returns the JavaStreamingContext which has already been created. */
   JavaStreamingContext streamingctx();
+
+  /** Get shared object */
+  <E> E getSharedObject(String name) throws NoSuchElementException;
+
+  /** Set shared object, it will replace the old one if already existed */
+  <E> void setSharedObject(String name, E object);
+
+  /** Remove shared object from cache */
+  <E> E removeSharedObject(String name);
 
   /**
    * Creates the SparkStreaming context.

--- a/integration-test/src/test/scala/com/cloudera/livy/test/JobApiIT.scala
+++ b/integration-test/src/test/scala/com/cloudera/livy/test/JobApiIT.scala
@@ -158,6 +158,12 @@ class JobApiIT extends BaseIntegrationTestSuite with BeforeAndAfterAll with Logg
     assert(result === "hello")
   }
 
+  test("share variables across jobs") {
+    assume(client2 != null, "Client not active.")
+    waitFor(client2.submit(new SharedVariableCounter("x"))) shouldBe 0
+    waitFor(client2.submit(new SharedVariableCounter("x"))) shouldBe 1
+  }
+
   scalaTest("run scala jobs") {
     assume(client2 != null, "Client not active.")
 
@@ -173,6 +179,11 @@ class JobApiIT extends BaseIntegrationTestSuite with BeforeAndAfterAll with Logg
     jobs.foreach { job =>
       val result = waitFor(client2.submit(job))
       assert(result === job.value)
+    }
+
+    (0 until 2).foreach { i =>
+      val result = waitFor(client.submit(new ScalaSharedVariableCounter("test")))
+      assert(i === result)
     }
   }
 

--- a/integration-test/src/test/scala/com/cloudera/livy/test/JobApiIT.scala
+++ b/integration-test/src/test/scala/com/cloudera/livy/test/JobApiIT.scala
@@ -182,7 +182,7 @@ class JobApiIT extends BaseIntegrationTestSuite with BeforeAndAfterAll with Logg
     }
 
     (0 until 2).foreach { i =>
-      val result = waitFor(client.submit(new ScalaSharedVariableCounter("test")))
+      val result = waitFor(client2.submit(new ScalaSharedVariableCounter("test")))
       assert(i === result)
     }
   }

--- a/repl/src/main/scala/com/cloudera/livy/repl/Session.scala
+++ b/repl/src/main/scala/com/cloudera/livy/repl/Session.scala
@@ -68,7 +68,7 @@ class Session(
   private var _state: SessionState = SessionState.NotStarted()
 
   // Number of statements kept in driver's memory
-  private val numRetainedStatements = livyConf.getInt(RSCConf.Entry.RETAINED_STATEMENT_NUMBER)
+  private val numRetainedStatements = livyConf.getInt(RSCConf.Entry.RETAINED_STATEMENTS)
 
   private val _statements = new JLinkedHashMap[Int, Statement] {
     protected override def removeEldestEntry(eldest: Entry[Int, Statement]): Boolean = {

--- a/repl/src/test/scala/com/cloudera/livy/repl/SessionSpec.scala
+++ b/repl/src/test/scala/com/cloudera/livy/repl/SessionSpec.scala
@@ -99,7 +99,7 @@ class SessionSpec extends FunSpec with Eventually with LivyBaseUnitTestSuite {
         override def answer(invocationOnMock: InvocationOnMock): String = "spark"
       })
 
-      rscConf.set(RSCConf.Entry.RETAINED_STATEMENT_NUMBER, 2)
+      rscConf.set(RSCConf.Entry.RETAINED_STATEMENTS, 2)
       val session = new Session(rscConf, interpreter)
       session.start()
 

--- a/rsc/src/main/java/com/cloudera/livy/rsc/RSCConf.java
+++ b/rsc/src/main/java/com/cloudera/livy/rsc/RSCConf.java
@@ -75,7 +75,8 @@ public class RSCConf extends ClientConf<RSCConf> {
     JOB_CANCEL_TRIGGER_INTERVAL("job-cancel.trigger-interval", "100ms"),
     JOB_CANCEL_TIMEOUT("job-cancel.timeout", "30s"),
 
-    RETAINED_STATEMENT_NUMBER("retained-statements", 100);
+    RETAINED_STATEMENTS("retained-statements", 100),
+    RETAINED_SHARE_VARIABLES("retained.share-variables", 100);
 
     private final String key;
     private final Object dflt;
@@ -155,7 +156,7 @@ public class RSCConf extends ClientConf<RSCConf> {
       put(RSCConf.Entry.TEST_STUCK_START_DRIVER.key, DepConf.TEST_STUCK_START_DRIVER);
       put(RSCConf.Entry.JOB_CANCEL_TRIGGER_INTERVAL.key, DepConf.JOB_CANCEL_TRIGGER_INTERVAL);
       put(RSCConf.Entry.JOB_CANCEL_TIMEOUT.key, DepConf.JOB_CANCEL_TIMEOUT);
-      put(RSCConf.Entry.RETAINED_STATEMENT_NUMBER.key, DepConf.RETAINED_STATEMENT_NUMBER);
+      put(RSCConf.Entry.RETAINED_STATEMENTS.key, DepConf.RETAINED_STATEMENTS);
   }});
 
   // Maps deprecated key to DeprecatedConf with the same key.
@@ -181,7 +182,7 @@ public class RSCConf extends ClientConf<RSCConf> {
     TEST_STUCK_START_DRIVER("test.do_not_use.stuck_start_driver", "0.4"),
     JOB_CANCEL_TRIGGER_INTERVAL("job_cancel.trigger_interval", "0.4"),
     JOB_CANCEL_TIMEOUT("job_cancel.timeout", "0.4"),
-    RETAINED_STATEMENT_NUMBER("retained_statements", "0.4");
+    RETAINED_STATEMENTS("retained_statements", "0.4");
 
     private final String key;
     private final String version;

--- a/scala-api/src/main/scala/com/cloudera/livy/scalaapi/ScalaJobContext.scala
+++ b/scala-api/src/main/scala/com/cloudera/livy/scalaapi/ScalaJobContext.scala
@@ -48,6 +48,15 @@ class ScalaJobContext private[livy] (context: JobContext) {
 
   def sparkSession[E]: E = context.sparkSession()
 
+  /** Set shared object, it will replace the old one if already existed */
+  def setSharedVariable[E](name: String, obj: E): Unit = context.setSharedObject(name, obj)
+
+  /** Get shared object */
+  def getSharedVariable[E](name: String): E = context.getSharedObject(name)
+
+  /** Remove shared object from cache */
+  def removeSharedVariable[E](name: String): E = context.removeSharedObject(name)
+
   /**
    * Creates the SparkStreaming context.
    *

--- a/test-lib/src/main/java/com/cloudera/livy/test/jobs/SharedVariableCounter.java
+++ b/test-lib/src/main/java/com/cloudera/livy/test/jobs/SharedVariableCounter.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.test.jobs;
+
+import java.util.NoSuchElementException;
+
+import com.cloudera.livy.Job;
+import com.cloudera.livy.JobContext;
+
+public class SharedVariableCounter implements Job<Integer> {
+
+  private final String name;
+
+  public SharedVariableCounter(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public Integer call(JobContext jc) {
+    Integer value = -1;
+
+    try {
+      value = jc.getSharedObject(name);
+    } catch (NoSuchElementException e) {
+      jc.setSharedObject(name, value);
+    }
+
+    Integer newValue = value + 1;
+    jc.setSharedObject(name, newValue);
+
+    return newValue;
+  }
+}

--- a/test-lib/src/main/scala/com/cloudera/livy/test/jobs/ScalaSharedVariableCounter.scala
+++ b/test-lib/src/main/scala/com/cloudera/livy/test/jobs/ScalaSharedVariableCounter.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.test.jobs
+
+import com.cloudera.livy.{Job, JobContext}
+
+class ScalaSharedVariableCounter(name: String) extends Job[Int] {
+
+  override def call(jc: JobContext): Int = {
+    val value = try {
+      jc.getSharedObject(name)
+    } catch {
+      case e: NoSuchElementException =>
+        jc.setSharedObject(name, -1)
+        -1
+    }
+
+    val newValue = value + 1
+    jc.setSharedObject(name, newValue)
+
+    newValue
+  }
+}


### PR DESCRIPTION
Currently we cannot share variables across different Jobs in Livy, so here propose to add a cache layer in RSC to store shared objects. This cache followed LRU, the least not used will be removed when exceeding limits.

This work is based on @alex-the-man 's work  #248 