### PR TITLE
[LIVY-363] Method toURL in Utils.scala is deprecated

### DIFF
--- a/core/src/main/scala/com/cloudera/livy/Utils.scala
+++ b/core/src/main/scala/com/cloudera/livy/Utils.scala
@@ -30,7 +30,7 @@ import scala.concurrent.duration.Duration
 
 object Utils {
   def getPropertiesFromFile(file: File): Map[String, String] = {
-    loadProperties(file.toURL())
+    loadProperties(file.toURI().toURL())
   }
 
   def loadProperties(url: URL): Map[String, String] = {


### PR DESCRIPTION
[https://issues.cloudera.org/browse/LIVY-363](https://issues.cloudera.org/browse/LIVY-363)
Method toURL in Utils.scala is deprecated. The toURL() method of File does not properly escape characters that aren't valid in a URL.