### PR TITLE
LIVY-369. Add a full functionality SSL support for Livy server and client

### DIFF
--- a/client-common/src/main/java/com/cloudera/livy/client/common/SSLOptions.java
+++ b/client-common/src/main/java/com/cloudera/livy/client/common/SSLOptions.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.client.common;
+
+import java.io.File;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import javax.net.ssl.SSLContext;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A class to maintain all the SSL related configurations. This class will be inherited by Livy
+ * Server and Client to create a Server / Client side SSL context.
+ */
+public abstract class SSLOptions {
+  private static final Logger LOG = LoggerFactory.getLogger(SSLOptions.class);
+
+  public final int port;
+  protected final File keyStore;
+  protected final String keyStorePassword;
+  protected final String keyPassword;
+  protected final String keyStoreType;
+
+  protected final boolean needClientAuth;
+  protected final File trustStore;
+  protected final String trustStorePassword;
+  protected final String trustStoreType;
+
+  protected final String protocol;
+  private final Set<String> enabledAlgorithms;
+
+  protected SSLOptions(
+      int port,
+      File keyStore,
+      String keyPassword,
+      String keyStorePassword,
+      String keyStoreType,
+      boolean needClientAuth,
+      File trustStore,
+      String trustStorePassword,
+      String trustStoreType,
+      String protocol,
+      Set<String> enabledAlgorithms
+  ) {
+    this.port = port;
+    this.keyStore = keyStore;
+    this.keyPassword = keyPassword;
+    this.keyStorePassword = keyStorePassword;
+    this.keyStoreType = keyStoreType;
+    this.needClientAuth = needClientAuth;
+    this.trustStore = trustStore;
+    this.trustStorePassword = trustStorePassword;
+    this.trustStoreType = trustStoreType;
+    this.protocol = protocol;
+    this.enabledAlgorithms = enabledAlgorithms;
+  }
+
+  protected Set<String> supportedAlgorithms() throws Exception {
+    if (enabledAlgorithms.isEmpty()) {
+      return Collections.emptySet();
+    } else {
+      SSLContext context;
+      try {
+        context = SSLContext.getInstance(protocol);
+        context.init(null, null, null);
+      } catch (NullPointerException e) {
+        context = SSLContext.getDefault();
+      } catch (NoSuchAlgorithmException e) {
+        context = SSLContext.getDefault();
+      }
+
+      Set<String> providerAlgorithms = new HashSet<>(Arrays.asList(
+        context.getServerSocketFactory().getSupportedCipherSuites()));
+      Set<String> supported = new HashSet<>();
+      for (String algo : enabledAlgorithms) {
+        if (providerAlgorithms.contains(algo)) {
+          supported.add(algo);
+        } else {
+          LOG.debug("Discard SSL algorithm {} since it is not supported by Java", algo);
+        }
+      }
+
+      if (supported.isEmpty()) {
+        throw new IllegalStateException("No supported SSL algorithms found");
+      }
+
+      return supported;
+    }
+  }
+}

--- a/client-http/src/main/java/com/cloudera/livy/client/http/ClientSSLOptions.java
+++ b/client-http/src/main/java/com/cloudera/livy/client/http/ClientSSLOptions.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.client.http;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.security.KeyStore;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import javax.net.ssl.SSLContext;
+
+import org.apache.http.conn.ssl.DefaultHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.http.ssl.SSLContexts;
+import org.apache.http.ssl.TrustStrategy;
+
+import com.cloudera.livy.client.common.SSLOptions;
+
+class ClientSSLOptions extends SSLOptions {
+
+  private ClientSSLOptions(
+    File keyStore,
+    String keyPassword,
+    String keyStorePassword,
+    String keyStoreType,
+    boolean needClientAuth,
+    File trustStore,
+    String trustStorePassword,
+    String trustStoreType,
+    String protocol,
+    Set<String> enabledAlgorithms
+  ) throws Exception {
+    super(-1, keyStore, keyPassword, keyStorePassword, keyStoreType, needClientAuth,
+      trustStore, trustStorePassword, trustStoreType, protocol, enabledAlgorithms);
+  }
+
+  static ClientSSLOptions parse(HttpConf conf) throws Exception {
+    File trustStore = null;
+    if (conf.get(HttpConf.Entry.SSL_TRUSTSTORE) != null) {
+      trustStore = new File(conf.get(HttpConf.Entry.SSL_TRUSTSTORE));
+      if (!trustStore.exists()) {
+        throw new IllegalStateException("Trust store file " + trustStore.getAbsolutePath() +
+        " cannot be found");
+      }
+    }
+
+    String trustStorePassword = conf.get(HttpConf.Entry.SSL_TRUSTSTORE_PASSWORD);
+    if (trustStore != null && trustStorePassword == null) {
+      throw new IllegalStateException("trust store password cannot be null if trust store is " +
+       "provided");
+    }
+
+    String trustStoreType = conf.get(HttpConf.Entry.SSL_TRUSTSTORE_TYPE);
+
+    boolean clientAuth = conf.getBoolean(HttpConf.Entry.SSL_CLIENT_AUTH);
+
+    File keyStore = null;
+    if (conf.get(HttpConf.Entry.SSL_KEYSTORE) != null) {
+      keyStore = new File(conf.get(HttpConf.Entry.SSL_KEYSTORE));
+      if (!keyStore.exists()) {
+        throw new IllegalStateException("Key store file " + keyStore.getAbsolutePath() +
+        " cannot be found");
+      }
+    }
+
+    String keyPassword = conf.get(HttpConf.Entry.SSL_KEY_PASSWORD);
+    String keyStorePassword = conf.get(HttpConf.Entry.SSL_KEYSTORE_PASSWORD);
+    if (keyStore != null && (keyPassword == null || keyStorePassword == null)) {
+      throw new IllegalStateException("Key password or key store password cannot be null if " +
+       "key store is provided.");
+    }
+
+    String keyStoreType = conf.get(HttpConf.Entry.SSL_KEYSTORE_TYPE);
+
+    String protocol = conf.get(HttpConf.Entry.SSL_PROTOCOL);
+
+    String algorithms = conf.get(HttpConf.Entry.SSL_ENABLED_ALGOS);
+    Set<String> enabledAlgorithms;
+    if (algorithms != null) {
+      enabledAlgorithms = new HashSet<>(Arrays.asList(algorithms.split(",")));
+    } else {
+      enabledAlgorithms = Collections.emptySet();
+    }
+
+    return new ClientSSLOptions(keyStore, keyPassword, keyStorePassword, keyStoreType, clientAuth,
+      trustStore, trustStorePassword, trustStoreType, protocol, enabledAlgorithms);
+  }
+
+  SSLConnectionSocketFactory createSslConnectionSocketFactory() throws Exception {
+    KeyStore trustStoreObj = null;
+    if (trustStore != null) {
+      if (trustStoreType != null) {
+        trustStoreObj = KeyStore.getInstance(trustStoreType);
+      } else {
+        trustStoreObj = KeyStore.getInstance(KeyStore.getDefaultType());
+      }
+
+      FileInputStream ins = new FileInputStream(trustStore);
+      try {
+        trustStoreObj.load(ins, trustStorePassword.toCharArray());
+      } finally {
+        ins.close();
+      }
+    }
+
+    KeyStore keyStoreObj = null;
+    if (keyStore != null) {
+      if (keyStoreType != null) {
+        keyStoreObj = KeyStore.getInstance(keyStoreType);
+      } else {
+        keyStoreObj = KeyStore.getInstance(KeyStore.getDefaultType());
+      }
+
+      FileInputStream ins = new FileInputStream(keyStore);
+      try {
+        keyStoreObj.load(ins, keyStorePassword.toCharArray());
+      } finally {
+        ins.close();
+      }
+    }
+
+    SSLContextBuilder builder = SSLContexts.custom();
+    if (trustStoreObj != null) {
+      builder.loadTrustMaterial(trustStoreObj, new TrustStrategy() {
+        @Override
+        public boolean isTrusted(X509Certificate[] x509Certificates, String s)
+            throws CertificateException {
+          return true;
+        }
+      });
+    }
+    if (keyStoreObj != null) {
+      builder.loadKeyMaterial(keyStoreObj, keyPassword.toCharArray());
+    }
+
+    if (protocol != null) {
+      builder.useProtocol(protocol);
+    }
+
+    SSLContext sslContext = builder.build();
+    return new SSLConnectionSocketFactory(
+      sslContext,
+      new String[] { protocol },
+      supportedAlgorithms().toArray(new String[supportedAlgorithms().size()]),
+      new DefaultHostnameVerifier());
+  }
+}

--- a/client-http/src/main/java/com/cloudera/livy/client/http/HttpConf.java
+++ b/client-http/src/main/java/com/cloudera/livy/client/http/HttpConf.java
@@ -43,7 +43,21 @@ class HttpConf extends ClientConf<HttpConf> {
     SPNEGO_ENABLED("spnego.enable", false),
     AUTH_LOGIN_CONFIG("auth.login.config", null),
     KRB5_DEBUG_ENABLED("krb5.debug", false),
-    KRB5_CONF("krb5.conf", null);
+    KRB5_CONF("krb5.conf", null),
+
+    // SSL related configurations
+    SSL_TRUSTSTORE("ssl.truststore", null),
+    SSL_TRUSTSTORE_PASSWORD("ssl.truststore-password", null),
+    SSL_TRUSTSTORE_TYPE("ssl.truststore-type", null),
+
+    SSL_CLIENT_AUTH("ssl.client-auth", false),
+    SSL_KEYSTORE("ssl.keystore", null),
+    SSL_KEY_PASSWORD("ssl.key-password", null),
+    SSL_KEYSTORE_PASSWORD("ssl.keystore-password", null),
+    SSL_KEYSTORE_TYPE("ssl.keystore-type", null),
+
+    SSL_PROTOCOL("ssl.protocol", null),
+    SSL_ENABLED_ALGOS("ssl.enabled-algorithms", null);
 
     private final String key;
     private final Object dflt;

--- a/client-http/src/main/java/com/cloudera/livy/client/http/LivyConnection.java
+++ b/client-http/src/main/java/com/cloudera/livy/client/http/LivyConnection.java
@@ -68,7 +68,7 @@ class LivyConnection {
   private final CloseableHttpClient client;
   private final ObjectMapper mapper;
 
-  LivyConnection(URI uri, final HttpConf config) {
+  LivyConnection(URI uri, final HttpConf config) throws Exception {
     HttpClientContext ctx = HttpClientContext.create();
     int port = uri.getPort() > 0 ? uri.getPort() : 8998;
 
@@ -131,6 +131,8 @@ class LivyConnection {
     CredentialsProvider credsProvider = new BasicCredentialsProvider();
     credsProvider.setCredentials(AuthScope.ANY, credentials);
 
+    String scheme = uri.getScheme();
+
     HttpClientBuilder builder = HttpClientBuilder.create()
       .disableAutomaticRetries()
       .evictExpiredConnections()
@@ -141,6 +143,11 @@ class LivyConnection {
       .setMaxConnTotal(1)
       .setDefaultCredentialsProvider(credsProvider)
       .setUserAgent("livy-client-http");
+
+    if (scheme.equals("https")) {
+      ClientSSLOptions clientSSLOptions = ClientSSLOptions.parse(config);
+      builder.setSSLSocketFactory(clientSSLOptions.createSslConnectionSocketFactory());
+    }
 
     if (config.isSpnegoEnabled()) {
       Registry<AuthSchemeProvider> authSchemeProviderRegistry =

--- a/conf/livy-client.conf.template
+++ b/conf/livy-client.conf.template
@@ -26,6 +26,36 @@
 # Maximum interval between successive polls
 # livy.client.http.job.max-poll-interval = 5s
 
+# Truststore for SSL server authentication.
+# livy.client.http.ssl.truststore =
+
+# Specify the truststore password.
+# livy.client.http.ssl.truststore-password =
+
+# Specify the truststore type.
+# livy.client.http.ssl.truststore-type =
+
+# Whether to enable SSL client authentication.
+# livy.client.http.ssl.client-auth = false
+
+# Use this keystore for the SSL client authentication.
+# livy.client.http.ssl.keystore =
+
+# Specify the keystore password.
+# livy.client.http.ssl.keystore-password =
+#
+# Specify the key password.
+# livy.client.http.ssl.key-password =
+
+# Specify the keystore type.
+# livy.client.http.ssl.keystore-type =
+
+# Specify the protocol of SSL.
+# livy.client.http.ssl.protocol =
+#
+# Specify SSL enabled algorithms.
+# livy.client.http.ssl.enabled-algorithms =
+
 #
 # Configurations for Livy RSCClient
 #

--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -1,11 +1,32 @@
 # Use this keystore for the SSL certificate and key.
-# livy.keystore =
+# livy.server.ssl.keystore =
 
 # Specify the keystore password.
-# livy.keystore.password =
+# livy.server.ssl.keystore-password =
 #
 # Specify the key password.
-# livy.key-password =
+# livy.server.ssl.key-password =
+
+# Specify the keystore type.
+# livy.server.ssl.keystore-type =
+
+# Whether to enable SSL client authentication.
+# livy.serverl.ssl.client-auth = false
+
+# Truststore for SSL client authentication.
+# livy.server.ssl.truststore =
+
+# Specify the truststore password.
+# livy.server.ssl.truststore-password =
+
+# Specify the truststore type.
+# livy.server.ssl.truststore-type =
+
+# Specify the protocol of SSL.
+# livy.server.ssl.protocol =
+#
+# Specify SSL enabled algorithms.
+# livy.server.ssl.enabled-algorithms =
 
 # What host address to start the server on. By default, Livy will bind to all network interfaces.
 # livy.server.host = 0.0.0.0

--- a/server/src/main/scala/com/cloudera/livy/LivyConf.scala
+++ b/server/src/main/scala/com/cloudera/livy/LivyConf.scala
@@ -76,9 +76,19 @@ object LivyConf {
   val ACCESS_CONTROL_ENABLED = Entry("livy.server.access-control.enabled", false)
   val ACCESS_CONTROL_USERS = Entry("livy.server.access-control.users", null)
 
-  val SSL_KEYSTORE = Entry("livy.keystore", null)
-  val SSL_KEYSTORE_PASSWORD = Entry("livy.keystore.password", null)
-  val SSL_KEY_PASSWORD = Entry("livy.key-password", null)
+  // Livy Server SSL related configurations.
+  val SSL_PORT = Entry("livy.server.https.port", 8998)
+  val SSL_KEYSTORE = Entry("livy.server.ssl.keystore", null)
+  val SSL_KEYSTORE_PASSWORD = Entry("livy.server.ssl.keystore-password", null)
+  val SSL_KEY_PASSWORD = Entry("livy.server.ssl.key-password", null)
+  val SSL_KEYSTORE_TYPE = Entry("livy.server.ssl.keystore-type", null)
+  val SSL_PROTOCOL = Entry("livy.server.ssl.protocol", null)
+  val SSL_ENABLED_ALGOS = Entry("livy.server.ssl.enabled-algorithms", null)
+
+  val SSL_CLIENT_AUTH = Entry("livy.server.ssl.client-auth", false)
+  val SSL_TRUSTSTORE = Entry("livy.server.ssl.truststore", null)
+  val SSL_TRUSTSTORE_PASSWORD = Entry("livy.server.ssl.truststore-password", null)
+  val SSL_TRUSTSTORE_TYPE = Entry("livy.server.ssl.truststore-type", null)
 
   val AUTH_TYPE = Entry("livy.server.auth.type", null)
   val AUTH_KERBEROS_PRINCIPAL = Entry("livy.server.auth.kerberos.principal", null)
@@ -192,7 +202,10 @@ object LivyConf {
     YARN_APP_LEAKAGE_CHECK_TIMEOUT.key ->
       DepConf("livy.server.yarn.app-leakage.check_timeout", "0.4"),
     YARN_APP_LEAKAGE_CHECK_INTERVAL.key ->
-      DepConf("livy.server.yarn.app-leakage.check_interval", "0.4")
+      DepConf("livy.server.yarn.app-leakage.check_interval", "0.4"),
+    SSL_KEYSTORE.key -> DepConf("livy.keystore", "0.4"),
+    SSL_KEY_PASSWORD.key -> DepConf("livy.key-password", "0.4"),
+    SSL_KEYSTORE_PASSWORD.key -> DepConf("livy.keystore.password", "0.4")
   )
 
   private val deprecatedConfigs: Map[String, DeprecatedConf] = {

--- a/server/src/main/scala/com/cloudera/livy/server/ServerSSLOptions.scala
+++ b/server/src/main/scala/com/cloudera/livy/server/ServerSSLOptions.scala
@@ -1,0 +1,116 @@
+/*
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.livy.server
+
+import java.io.File
+
+import scala.collection.JavaConverters._
+
+import org.eclipse.jetty.util.ssl.SslContextFactory
+
+import com.cloudera.livy.LivyConf
+import com.cloudera.livy.client.common.SSLOptions
+
+private[livy] class ServerSSLOptions private(
+  port: Int,
+  keyStore: File,
+  keyPassword: String,
+  keyStorePassword: String,
+  keyStoreType: String,
+  needClientAuth: Boolean,
+  trustStore: File,
+  trustStorePassword: String,
+  trustStoreType: String,
+  protocol: String,
+  enabledAlgorithms: Set[String])
+extends SSLOptions(
+  port,
+  keyStore,
+  keyPassword,
+  keyStorePassword,
+  keyStoreType,
+  needClientAuth,
+  trustStore,
+  trustStorePassword,
+  trustStoreType,
+  protocol,
+  enabledAlgorithms.asJava
+) {
+
+  def createJettySslContextFactory(): SslContextFactory = {
+    val sslContextFactory = new SslContextFactory()
+
+    sslContextFactory.setKeyStorePath(keyStore.getAbsolutePath)
+    sslContextFactory.setKeyManagerPassword(keyPassword)
+    sslContextFactory.setKeyStorePassword(keyStorePassword)
+    Option(keyStoreType).foreach(sslContextFactory.setKeyStoreType)
+
+    if (needClientAuth) {
+      Option(trustStore).foreach(file => sslContextFactory.setTrustStorePath(file.getAbsolutePath))
+      Option(trustStorePassword).foreach(sslContextFactory.setTrustStorePassword)
+      Option(trustStoreType).foreach(sslContextFactory.setTrustStoreType)
+    }
+
+    Option(protocol).foreach(sslContextFactory.setProtocol)
+    if (!supportedAlgorithms().isEmpty) {
+      sslContextFactory.setIncludeCipherSuites(supportedAlgorithms().asScala.toSeq: _*)
+    }
+
+    sslContextFactory
+  }
+}
+
+private[livy] object ServerSSLOptions {
+  def parse(conf: LivyConf): ServerSSLOptions = {
+    val port = conf.getInt(LivyConf.SSL_PORT)
+
+    val keyStore = new File(conf.get(LivyConf.SSL_KEYSTORE))
+    require(keyStore.exists(), "Cannot find key store file")
+
+    val keyPassword = conf.get(LivyConf.SSL_KEY_PASSWORD)
+    val keyStorePassword = conf.get(LivyConf.SSL_KEYSTORE_PASSWORD)
+    require(keyPassword != null)
+    require(keyStorePassword != null)
+
+    val keyStoreType = conf.get(LivyConf.SSL_KEYSTORE_TYPE)
+
+    val protocol = conf.get(LivyConf.SSL_PROTOCOL)
+    val algos = Option(conf.get(LivyConf.SSL_ENABLED_ALGOS)).map { s =>
+      s.split(",").map(_.trim).filter(_.nonEmpty).toSet
+    }.getOrElse(Set.empty)
+
+    val clientAuth = conf.getBoolean(LivyConf.SSL_CLIENT_AUTH)
+    val trustStore = Option(conf.get(LivyConf.SSL_TRUSTSTORE)).map { t =>
+      val f = new File(t)
+      require(f.exists(), "Cannot find trust store file")
+      f
+    }.getOrElse(null.asInstanceOf[File])
+
+    val trustStorePassword = conf.get(LivyConf.SSL_TRUSTSTORE_PASSWORD)
+    if (trustStore != null) {
+      require(trustStorePassword != null,
+        "Trust store password cannot be null if trust store is provided")
+    }
+
+    val trustStoreType = conf.get(LivyConf.SSL_TRUSTSTORE_TYPE)
+
+    new ServerSSLOptions(port, keyStore, keyPassword, keyStorePassword, keyStoreType,
+      clientAuth, trustStore, trustStorePassword, trustStoreType, protocol, algos)
+  }
+}


### PR DESCRIPTION
Current LivyServer already supports SSL, but the functionality is not fully implemented, it cannot support client side authentication, also cannot specify advanced configurations. Also SSL support for Livy http client is missing.

So here propose to add a full functionality SSL support for Livy server and client.