### PR TITLE
Minor. [build-issue] Make sure to install setuptools less then version 36.0.0 to avoid module six not found issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ before_install:
   - sudo apt-get -y install python3-pip python-dev
   - sudo apt-get -y install libkrb5-dev
   - sudo apt-get -y remove python-setuptools
-  - pip install --user --upgrade pip setuptools
-  - pip3 install --user --upgrade pip setuptools
+  - pip install --user --upgrade pip "setuptools < 36"
+  - pip3 install --user --upgrade pip "setuptools < 36"
   - pip install --user codecov cloudpickle
   - pip3 install --user cloudpickle
 


### PR DESCRIPTION
The issue is tracked here https://github.com/pypa/setuptools/issues/1042.